### PR TITLE
Correct typo in VirtualBox name

### DIFF
--- a/content/os/v1.x/en/_index.md
+++ b/content/os/v1.x/en/_index.md
@@ -20,7 +20,7 @@ Docker is an open-source platform designed for developers, system admins, and De
 Platform | RAM requirement
 ---- | ----
 Baremetal | 1280MB
-VirtubalBox | 1280MB
+VirtualBox | 1280MB
 VMWare | 1280MB (rancheros.iso) <br> 2048MB (rancheros-vmware.iso)
 GCE |  1280MB
 AWS |  1.7GB


### PR DESCRIPTION
Just found this little typo when browsing RancherOS docs and decided to fix it right away :)