### PR TITLE
undraft kubectl access and catalog

### DIFF
--- a/content/rancher/v2.x/en/tasks/clusters/using-kubectl-to-access-a-cluster/_index.md
+++ b/content/rancher/v2.x/en/tasks/clusters/using-kubectl-to-access-a-cluster/_index.md
@@ -1,7 +1,6 @@
 ---
 title: Using kubectl to Access a Cluster
 weight: 3450
-draft: true
 ---
 Coming Soon
 

--- a/content/rancher/v2.x/en/tasks/global-configuration/catalog/_index.md
+++ b/content/rancher/v2.x/en/tasks/global-configuration/catalog/_index.md
@@ -1,7 +1,6 @@
 ---
 title: Catalog
 weight: 3026
-draft: true
 ---
 
 ## Creating Custom Catalogs


### PR DESCRIPTION
@MBishop17 last PR to merge for when we want to unstage catalog, CLI, kubectl access

review these sections one more time after all PRs have been merged:

```
rancher/v2.x/en/concepts/global-configuration/_index.md - CLI section
rancher/v2.x/en/concepts/clusters/_index.md - kubeconfig usage
rancher/v2.x/en/tasks/clusters/using-kubectl-to-access-a-cluster/_index.md
ancher/v2.x/en/tasks/projects/_index.md - we should break this into more sections like how clusters is. 
rancher/v2.x/en/tasks/global-configuration/catalog/_index.md
```