### PR TITLE
Fixing step 4.3's typo

### DIFF
--- a/content/rancher/v2.x/en/installation/ha-server-install/_index.md
+++ b/content/rancher/v2.x/en/installation/ha-server-install/_index.md
@@ -213,7 +213,7 @@ RKE is a fast, versatile Kubernetes installer that you can use to install Kubern
 
     ```
     # MacOS
-    $ ./rke_darwin-amd64 ---version
+    $ ./rke_darwin-amd64 --version
     # Linux
     $ ./rke_linux-amd64 --version
     ```


### PR DESCRIPTION
Fixing the typo in the command to check if RKE is running using "./rke_darwin-amd64 ---version" does not run because of the typo.