### PR TITLE
Fixing "creating a cluster" url

### DIFF
--- a/content/rancher/v2.x/en/installation/single-node-install-external-lb/_index.md
+++ b/content/rancher/v2.x/en/installation/single-node-install-external-lb/_index.md
@@ -198,7 +198,7 @@ By default, Rancher automatically generates self-signed certificates for itself 
 You have a couple of options:
 
 - Create a backup of your Rancher Server in case of a disaster scenario: [Single Node Backup and Restoration]({{< baseurl >}}/rancher/v2.x/en/installation/backups-and-restoration/single-node-backup-and-restoration/).
-- Create a Kubernettes cluster: [Creating a Cluster]({{ <baseurl> }}/rancher/v2.x/en/tasks/clusters/creating-a-cluster/).
+- Create a Kubernettes cluster: [Creating a Cluster]({{< baseurl >}}/rancher/v2.x/en/tasks/clusters/creating-a-cluster/).
 
 <br/>
 


### PR DESCRIPTION
Hello,

This PR fixes "Creating a cluster" url which in the following [page](https://rancher.com/docs/rancher/v2.x/en/installation/single-node-install-external-lb/).
I am not sure how this parsing to html issue be solved, but I have noticed that all `{{< baseurl >}}` tags are written with a space before and after the `baseurl` keyword

The current link is rendered as the following

```
https://rancher.com/docs/rancher/v2.x/en/installation/single-node-install-external-lb/%7B%7B%20%3Cbaseurl%3E%20%7D%7D/rancher/v2.x/en/tasks/clusters/creating-a-cluster/
```

However the correct url should be as the following

```
https://rancher.com/docs/rancher/v2.x/en/tasks/clusters/creating-a-cluster/
```

If there is another way that should solve this issue let me know so I can update the code with it.

Thanks