### PR TITLE
`kube_config_rancher-cluster.yml` file location

### DIFF
--- a/content/rancher/v2.x/en/installation/ha-server-install-external-lb/_index.md
+++ b/content/rancher/v2.x/en/installation/ha-server-install-external-lb/_index.md
@@ -326,7 +326,7 @@ With all configuration in place, use RKE to launch Rancher. You can complete thi
 
 ## 11. Back Up Auto-Generated Config File
 
-During installation, RKE automatically generates a config file named `kube_config_rancher-cluster.yml` in the same directory as the RKE binary. Copy this file and back it up to a safe location. You'll use this file later when upgrading Rancher Server.
+During installation, RKE automatically generates a config file named `kube_config_rancher-cluster.yml` in the same directory as the `rancher-cluster.yml` file. Copy this file and back it up to a safe location. You'll use this file later when upgrading Rancher Server.
 
 ## 12. Remove Default Certificates
 


### PR DESCRIPTION
rke binary is in `/root/bin` folder:
`$ ls -al /root/bin
-rwxr-xr-x.  1 root root  31M Jun 26 20:09 rke*
`
configuration file `rancher-cluster.yml` is in `/root/rancher-cluster` directory
`ls -al /root/rancher-cluster
-rw-r--r--.  1 root root 5.7K Jun 27 08:53 rancher-cluster.yml
`

When running `rke up --config rancher-cluster/rancher-cluster.yml`, the resulting configuration file is not in rke location, but in same directory than `rancher-cluster.yml` :
` ls -al /root/rancher-cluster
-rw-r-----.  1 root root 5.3K Jun 27 11:55 kube_config_rancher-cluster.yml
-rw-r--r--.  1 root root 5.7K Jun 27 08:53 rancher-cluster.yml
`