### PR TITLE
redirection is broken in What's next

### DIFF
--- a/content/rancher/v2.x/en/installation/ha-server-install-external-lb/_index.md
+++ b/content/rancher/v2.x/en/installation/ha-server-install-external-lb/_index.md
@@ -349,7 +349,7 @@ By default, Rancher automatically generates self-signed certificates for itself 
 You have a couple of options:
 
 - Create a backup of your Rancher Server in case of a disaster scenario: [High Availablility Back Up and Restoration]({{< baseurl >}}/rancher/v2.x/en/installation/backups-and-restoration/ha-backup-and-restoration).
-- Create a Kubernettes cluster: [Creating a Cluster]({{ <baseurl> }}/rancher/v2.x/en/tasks/clusters/creating-a-cluster/).
+- Create a Kubernettes cluster: [Creating a Cluster]({{ < baseurl > }}/rancher/v2.x/en/tasks/clusters/creating-a-cluster/).
 
 <br/>
 


### PR DESCRIPTION
we need a space around `baseurl` 
{{ < baseurl > }}  and not {{ <baseurl> }}. The last is not taken into account.