### PR TITLE
Remove code block quotes

### DIFF
--- a/content/rke/v0.1.x/en/installation/managing-clusters/_index.md
+++ b/content/rke/v0.1.x/en/installation/managing-clusters/_index.md
@@ -28,10 +28,8 @@ This command does the following to each node in the `cluster.yml`:
 
 - Remove the Kubernetes services deployed on it
 - Clean each host from the directories left by the services:
-  ```
   - /etc/kubernetes/ssl
   - /var/lib/etcd
   - /etc/cni
   - /opt/cni
   - /var/run/calico
-  ```


### PR DESCRIPTION
The built page shows quotes of the code block.
https://rancher.com/docs/rke/v0.1.x/en/installation/managing-clusters/