### PR TITLE
Update _Index.md

### DIFF
--- a/content/rancher/v2.x/en/installation/troubleshooting-ha/job-complete-status/_index.md
+++ b/content/rancher/v2.x/en/installation/troubleshooting-ha/job-complete-status/_index.md
@@ -20,8 +20,9 @@ Usually something is printed along the lines of `error: error converting YAML to
 <b>Things to check</b>
 <ul>
 <ul>
-<li>Is each of the base64 encoded certificate string placed directly after the key, for example: `tls.crt: LS01...`, there should be no newline/space before, in between or after.</li>
+<li>Is each of the base64 encoded certificate string placed directly after the key, for example: <code>tls.crt: LS01...</code>, there should be no newline/space before, in between or after.</li>
 <li>Is the YAML properly formatted, each indentation should be 2 spaces as shown in the template files.</li>
+<li>Verify the integrity of your certificate by running this command <code>cat MyCertificate | base64 -d</code> on Linux, <code>cat MyCertificate | base64 -D</code> on Mac OS . If any error exists, the command output will tell you.
 </ul>
 </ul>
 

--- a/content/rancher/v2.x/en/installation/troubleshooting-ha/job-complete-status/_index.md
+++ b/content/rancher/v2.x/en/installation/troubleshooting-ha/job-complete-status/_index.md
@@ -20,9 +20,9 @@ Usually something is printed along the lines of `error: error converting YAML to
 <b>Things to check</b>
 <ul>
 <ul>
-<li>Is each of the base64 encoded certificate string placed directly after the key, for example: <code>tls.crt: LS01...</code>, there should be no newline/space before, in between or after.</li>
+<li>Is each of the base64 encoded certificate string placed directly after the key, for example: `tls.crt: LS01...`, there should be no newline/space before, in between or after.</li>
 <li>Is the YAML properly formatted, each indentation should be 2 spaces as shown in the template files.</li>
-<li>Verify the integrity of your certificate by running this command <code>cat MyCertificate | base64 -d</code> on Linux, <code>cat MyCertificate | base64 -D</code> on Mac OS . If any error exists, the command output will tell you.
+<li>Verify the integrity of your certificate by running this command `cat MyCertificate | base64 -d` on Linux, `cat MyCertificate | base64 -D` on Mac OS . If any error exists, the command output will tell you.
 </ul>
 </ul>
 


### PR DESCRIPTION
1. Code inside a list must be inside <code>  code </code>
2. The command line `cat MyCert | base64 -d` let you quickly verify the certificate integrity.