### PR TITLE
update configure Load Balancer

### DIFF
--- a/content/rancher/v2.x/en/installation/ha-server-install/_index.md
+++ b/content/rancher/v2.x/en/installation/ha-server-install/_index.md
@@ -119,9 +119,9 @@ After installing NGINX, you need to update the NGINX config file, `nginx.conf`, 
     worker_processes 4;
     worker_rlimit_nofile 40000;
     
-    # only one needed, depending of your distribution:
-    load_module /usr/lib/nginx/modules/ngx_stream_module.so;
-    load_module /usr/lib/nginx/modules/ngx_stream_module.so;
+    # uncomment depending on your distribution:
+    #load_module /usr/lib/nginx/modules/ngx_stream_module.so;
+    #load_module /usr/lib/nginx/modules/ngx_stream_module.so;
 
     events {
         worker_connections 8192;
@@ -157,7 +157,11 @@ After installing NGINX, you need to update the NGINX config file, `nginx.conf`, 
     ```
 
 >**Note:**
-> You may encounter this error : `nginx: [emerg] unknown directive "stream" in /etc/nginx/nginx.conf`. This tells you nginx can't load the needed stream module `ngx_stream_module.so`. To solve this issue, verify the `/usr/lib(64)/nginx/modules` directoty is not empty. If it is empty, you need to install the `nginx modules` package.
+> On Fedora, and maybe other distro, you may encounter this error : `nginx: [emerg] unknown directive "stream" in /etc/nginx/nginx.conf`. This tells you nginx can't load the needed stream module `ngx_stream_module.so`. To solve this issue:
+
+1- verify the `/usr/lib(64)/nginx/modules` directory is not empty. If it is empty, you need to install the Fedora package `nginx-all-modules`.
+
+2- Uncomment the line at the top of `ngnix.conf` to let Nginx load the module.
 
 ### Option - Run NGINX as Docker container
 

--- a/content/rancher/v2.x/en/installation/ha-server-install/_index.md
+++ b/content/rancher/v2.x/en/installation/ha-server-install/_index.md
@@ -118,6 +118,10 @@ After installing NGINX, you need to update the NGINX config file, `nginx.conf`, 
     ```
     worker_processes 4;
     worker_rlimit_nofile 40000;
+    
+    # only one needed, depending of your distribution:
+    load_module /usr/lib/nginx/modules/ngx_stream_module.so;
+    load_module /usr/lib/nginx/modules/ngx_stream_module.so;
 
     events {
         worker_connections 8192;
@@ -151,6 +155,9 @@ After installing NGINX, you need to update the NGINX config file, `nginx.conf`, 
     ```
     # nginx -s reload
     ```
+
+>**Note:**
+> You may encounter this error : `nginx: [emerg] unknown directive "stream" in /etc/nginx/nginx.conf`. This tells you nginx can't load the needed stream module `ngx_stream_module.so`. To solve this issue, verify the `/usr/lib(64)/nginx/modules` directoty is not empty. If it is empty, you need to install the `nginx modules` package.
 
 ### Option - Run NGINX as Docker container
 

--- a/content/rancher/v2.x/en/installation/ha-server-install/_index.md
+++ b/content/rancher/v2.x/en/installation/ha-server-install/_index.md
@@ -120,7 +120,7 @@ After installing NGINX, you need to update the NGINX config file, `nginx.conf`, 
     worker_rlimit_nofile 40000;
     
     # uncomment depending on your distribution:
-    #load_module /usr/lib/nginx/modules/ngx_stream_module.so;
+    #load_module /usr/lib64/nginx/modules/ngx_stream_module.so;
     #load_module /usr/lib/nginx/modules/ngx_stream_module.so;
 
     events {


### PR DESCRIPTION
The provided `nginx.conf` will not work as it in all distro.
1- you must tell nginx at the top of the config file to load the stream module
2- you must have the nginx module package installed.
For example, on fedora 28, this is a separate package from nginx.