### PR TITLE
Fix "Creating an API Key" url

### DIFF
--- a/content/rancher/v2.x/en/concepts/cli-configuration/_index.md
+++ b/content/rancher/v2.x/en/concepts/cli-configuration/_index.md
@@ -14,7 +14,7 @@ The binary can be downloaded directly from the UI. The link can be found in the 
 After you download the Rancher CLI, you need to make a few configurations. Rancher CLI requires:
 
 - Your [Rancher Server URL]({{< baseurl >}}/rancher/v2.x/en/tasks/global-configuration/server-url), which is used to connect to Rancher Server.
-- An API Bearer Token, which is used to authenticate with Rancher. For more information about obtaining a Bearer Token, see [Creating an API Key]({{< baseurl >}}/rancher/v2.x/en/tasks/user-settings/api-keys).
+- An API Bearer Token, which is used to authenticate with Rancher. For more information about obtaining a Bearer Token, see [Creating an API Key]({{< baseurl >}}/rancher/v2.x/en/tasks/user-settings/api-keys/).
 
 ### CLI Authentication
 

--- a/content/rancher/v2.x/en/concepts/cli-configuration/_index.md
+++ b/content/rancher/v2.x/en/concepts/cli-configuration/_index.md
@@ -14,7 +14,7 @@ The binary can be downloaded directly from the UI. The link can be found in the 
 After you download the Rancher CLI, you need to make a few configurations. Rancher CLI requires:
 
 - Your [Rancher Server URL]({{< baseurl >}}/rancher/v2.x/en/tasks/global-configuration/server-url), which is used to connect to Rancher Server.
-- An API Bearer Token, which is used to authenticate with Rancher. For more information about obtaining a Bearer Token, see [Creating an API Key]({{< baseurl >}}/rancher/v2.x/en/tasks/user-settings/api-keys/_index.md).
+- An API Bearer Token, which is used to authenticate with Rancher. For more information about obtaining a Bearer Token, see [Creating an API Key]({{< baseurl >}}/rancher/v2.x/en/tasks/user-settings/api-keys).
 
 ### CLI Authentication
 


### PR DESCRIPTION
The current URL gives `404 Not Found` due to pointing to a markdown file `_index.md` which should be removed.