### PR TITLE
Fixes a mistake on the installation overview page

### DIFF
--- a/content/rancher/v2.x/en/installation/_index.md
+++ b/content/rancher/v2.x/en/installation/_index.md
@@ -30,7 +30,7 @@ This section also includes help content for Rancher configuration and maintenanc
 
 -  [Backups and Rollbacks]({{< baseurl >}}/rancher/v2.x/en/backups/)
 
- 	This page lists the ports you must open to operate Rancher.
+ 	How to create and restore from backups.
 
 -  [Port Requirements]({{< baseurl >}}/rancher/v2.x/en/installation/references/)
 


### PR DESCRIPTION
`Backups and Rollbacks` mistakenly had the same description as `Port Requirements`:
`This page lists the ports you must open to operate Rancher.`