### PR TITLE
Fix wording of 'backups and rollbacks' subtitle

### DIFF
--- a/content/rancher/v2.x/en/installation/_index.md
+++ b/content/rancher/v2.x/en/installation/_index.md
@@ -30,7 +30,7 @@ This section also includes help content for Rancher configuration and maintenanc
 
 -  [Backups and Rollbacks]({{< baseurl >}}/rancher/v2.x/en/backups/)
 
- 	This page lists the ports you must open to operate Rancher.
+ 	This section is devoted to protecting your Rancher Server data in a disaster scenario.
 
 -  [Port Requirements]({{< baseurl >}}/rancher/v2.x/en/installation/references/)
 


### PR DESCRIPTION
The existing subtitle does not correlate with the section, looks like it was copied from elsewhere and not updated