### PR TITLE
Adding Amazon AWS QS Destroy Links to workload quickstart

### DIFF
--- a/content/rancher/v2.x/en/quick-start-guide/workload/quickstart-deploy-workload-ingress/_index.md
+++ b/content/rancher/v2.x/en/quick-start-guide/workload/quickstart-deploy-workload-ingress/_index.md
@@ -75,5 +75,6 @@ Congratulations! You have successfully deployed a workload exposed via an ingres
 
 When you're done using your sandbox, destroy the Rancher Server and your cluster. See one of the following:
 
+- [Amazon AWS: Destroying the Environment]({{< baseurl >}}/rancher/v2.x/en/quick-start-guide/deployment/amazon-aws-qs/#destroying-the-environment)
 - [DigitalOcean: Destroying the Environment]({{< baseurl >}}/rancher/v2.x/en/quick-start-guide/deployment/digital-ocean-qs/#destroying-the-environment)
 - [Vagrant: Destroying the Environment]({{< baseurl >}}/rancher/v2.x/en/quick-start-guide/deployment/quickstart-vagrant/#destroying-the-environment)

--- a/content/rancher/v2.x/en/quick-start-guide/workload/quickstart-deploy-workload-nodeport/_index.md
+++ b/content/rancher/v2.x/en/quick-start-guide/workload/quickstart-deploy-workload-nodeport/_index.md
@@ -149,5 +149,6 @@ Congratulations! You have successfully deployed a workload exposed via a NodePor
 
 When you're done using your sandbox, destroy the Rancher Server and your cluster. See one of the following:
 
+- [Amazon AWS: Destroying the Environment]({{< baseurl >}}/rancher/v2.x/en/quick-start-guide/deployment/amazon-aws-qs/#destroying-the-environment)
 - [DigitalOcean: Destroying the Environment]({{< baseurl >}}/rancher/v2.x/en/quick-start-guide/deployment/digital-ocean-qs/#destroying-the-environment)
 - [Vagrant: Destroying the Environment]({{< baseurl >}}/rancher/v2.x/en/quick-start-guide/deployment/quickstart-vagrant/#destroying-the-environment)


### PR DESCRIPTION
@chrisurwin @superseb For uniformity, we should add the Amazon AWS QS Destroy link to the bottom of the workload quickstart pages.