### PR TITLE
Fixed 404 links

### DIFF
--- a/content/rancher/v2.x/en/backups/backups/single-node-backups/_index.md
+++ b/content/rancher/v2.x/en/backups/backups/single-node-backups/_index.md
@@ -43,4 +43,4 @@ docker run  --volumes-from rancher-data-<RANCHER_VERSION> \
 docker start <RANCHER_CONTAINER_ID>
     ```
 
-**Result:** A backup of your Rancher Server is created. If you ever need to restore your backup, see [Restoring Backups: Single Node Installs]({{< baseurl >}}/rancher/v2.x/en/upgrades/restorations/single-node-restoration).
+**Result:** A backup of your Rancher Server is created. If you ever need to restore your backup, see [Restoring Backups: Single Node Installs]({{< baseurl >}}/rancher/v2.x/en/backups/restorations/single-node-restoration).

--- a/content/rancher/v2.x/en/upgrades/rollbacks/ha-server-rollbacks/_index.md
+++ b/content/rancher/v2.x/en/upgrades/rollbacks/ha-server-rollbacks/_index.md
@@ -8,7 +8,7 @@ aliases:
 
 If you upgrade Rancher and the upgrade does not complete successfully, you may need to rollback your Rancher Server to its last healthy state.
 
-To restore Rancher follow the procedure detailed here: [Restoring Backups — High Availability Installs](/rancher/v2.x/en/backups/restorations/ha-restoration)
+To restore Rancher follow the procedure detailed here: [Restoring Backups — High Availability Installs]({{< baseurl >}}/rancher/v2.x/en/backups/restorations/ha-restoration)
 
 Restoring a snapshot of the Rancher Server cluster will revert Rancher to the version and state at the time of the snapshot.
 


### PR DESCRIPTION
Here are the following 404 links found in the docs:

https://rancher.com/docs/rancher/v2.x/en/upgrades/rollbacks/ha-server-rollbacks/
https://rancher.com/rancher/v2.x/en/backups/restorations/ha-restoration

https://rancher.com/docs/rancher/v2.x/en/backups/backups/single-node-backups/
https://rancher.com/docs/rancher/v2.x/en/upgrades/restorations/single-node-restoration