### PR TITLE
QA feedback ha install

### DIFF
--- a/content/rancher/v2.x/en/installation/ha/helm-rancher/_index.md
+++ b/content/rancher/v2.x/en/installation/ha/helm-rancher/_index.md
@@ -13,7 +13,7 @@ Use `helm repo add` to add the Rancher chart repository.
 helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
 ```
 
-For additional chart details and source see the [server-chart](https://github.com/rancher/server-chart) repo on GitHub.
+For additional chart details, view the [source of these Rancher server charts](https://github.com/rancher/server-chart).
 
 ### Install cert-manager
 

--- a/content/rancher/v2.x/en/installation/ha/helm-rancher/_index.md
+++ b/content/rancher/v2.x/en/installation/ha/helm-rancher/_index.md
@@ -13,6 +13,8 @@ Use `helm repo add` to add the Rancher chart repository.
 helm repo add rancher-stable https://releases.rancher.com/server-charts/stable
 ```
 
+For additional chart details and source see the [server-chart](https://github.com/rancher/server-chart) repo on GitHub.
+
 ### Install cert-manager
 
 > **Note:** cert-manager is only required for Rancher generated and LetsEncrypt issued certificates.  You may skip this step if you are bringing your own certificates and using the `ingress.tls.source=secret` option.

--- a/content/rancher/v2.x/en/installation/ha/kubernetes-rke/_index.md
+++ b/content/rancher/v2.x/en/installation/ha/kubernetes-rke/_index.md
@@ -9,7 +9,7 @@ Use RKE to install Kubernetes with a high-availability etcd configuration.
 
 Using the sample below create the `rancher-cluster.yml` file. Replace the IP Addresses in the `nodes` list with the IP address or DNS names of the 3 Nodes you created.
 
-> **Note:** If you node has public and internal addresses, its recommended to set `internal_address:` so Kubernetes will use it for intra-cluster communication.  Some services like AWS EC2 require setting `internal_address:` if you want to use self-referencing security groups or firewalls.
+> **Note:** If your node has public and internal addresses, it is recommended to set the `internal_address:` so Kubernetes will use it for intra-cluster communication.  Some services like AWS EC2 require setting the `internal_address:` if you want to use self-referencing security groups or firewalls.
 
 ```yaml
 nodes:

--- a/content/rancher/v2.x/en/installation/ha/kubernetes-rke/_index.md
+++ b/content/rancher/v2.x/en/installation/ha/kubernetes-rke/_index.md
@@ -9,15 +9,20 @@ Use RKE to install Kubernetes with a high-availability etcd configuration.
 
 Using the sample below create the `rancher-cluster.yml` file. Replace the IP Addresses in the `nodes` list with the IP address or DNS names of the 3 Nodes you created.
 
+> **Note:** If you node has public and internal addresses, its recommended to set `internal_address:` so Kubernetes will use it for intra-cluster communication.  Some services like AWS EC2 require setting `internal_address:` if you want to use self-referencing security groups or firewalls.
+
 ```yaml
 nodes:
 - address: 165.227.114.63
+  internal_address: 172.16.22.12
   user: ubuntu
   role: [controlplane,worker,etcd]
 - address: 165.227.116.167
+  internal_address: 172.16.32.37
   user: ubuntu
   role: [controlplane,worker,etcd]
 - address: 165.227.127.226
+  internal_address: 172.16.42.73
   user: ubuntu
   role: [controlplane,worker,etcd]
 ```


### PR DESCRIPTION
* Add link to chart source in install docs.
* Need internal_address on ec2 instances with self-referencing Security Groups, its a good general practice anyways.