### PR TITLE
Update kubernetes versions for v0.1.9

### DIFF
--- a/content/rke/v0.1.x/en/config-options/_index.md
+++ b/content/rke/v0.1.x/en/config-options/_index.md
@@ -54,14 +54,16 @@ ignore_docker_version: true
 
 ### Kubernetes Version
 
-You can select which version of Kubernetes to install for your cluster. These options are the Kubernetes versions made available in Rancher v2.x. The current default Kubernetes version used by RKE is `v1.10.3-rancher2-1`. If a version is defined in `kubernetes_version` and is not found in this list, the default is used.
+You can select which version of Kubernetes to install for your cluster. These options are the Kubernetes versions made available in Rancher v2.x. The current default Kubernetes version used by RKE is `v1.11.1-rancher1-1`. If a version is defined in `kubernetes_version` and is not found in this list, the default is used.
 
  Kubernetes version|
  -----------------|
+ v1.11.1-rancher1-1|
+ v1.10.5-rancher1-2|
  v1.10.3-rancher2-1|
  v1.10.1-rancher2-1|
  v1.10.0-rancher1-1|
- v1.9.7-rancher2-1|
+ v1.9.7-rancher2-2|
  v1.9.5-rancher1-1|
  v1.8.11-rancher2-1|
  v1.8.10-rancher1-1|
@@ -74,7 +76,7 @@ There are two ways to select a Kubernetes version:
 - Using the configuration option `kubernetes_version`
 
 ```yaml
-kubernetes_version: "v1.10.3-rancher2-1"
+kubernetes_version: "v1.11.1-rancher1-1"
 ```
 
 In case both are defined, the system images configuration will take precedence over `kubernetes_version`.


### PR DESCRIPTION
Used https://github.com/rancher/rke/blob/v0.1.9/vendor/github.com/rancher/types/apis/management.cattle.io/v3/k8s_defaults.go as a reference.