### PR TITLE
[DOC] 1.x ZFS instructions - Add zfsonlinux link

### DIFF
--- a/content/os/v1.x/en/installation/storage/using-zfs/_index.md
+++ b/content/os/v1.x/en/installation/storage/using-zfs/_index.md
@@ -5,7 +5,7 @@ weight: 162
 
 #### Installing the ZFS service
 
-The `zfs` service will install the kernel-headers for your kernel (if you build your own kernel, you'll need to replicate this service), and then download the [ZFS on Linux]() source, and build and install it. Then it will build a `zfs-tools` image that will be used to give you access to the zfs tools.
+The `zfs` service will install the kernel-headers for your kernel (if you build your own kernel, you'll need to replicate this service), and then download the [ZFS on Linux](https://zfsonlinux.org/) source, and build and install it. Then it will build a `zfs-tools` image that will be used to give you access to the zfs tools.
 
 The only restriction is that you must mount your zpool into `/mnt`, as this is the only shared mount directory that will be accessible throughout the system-docker managed containers (including the console).
 


### PR DESCRIPTION
This PR adds a missing Markdown link to the zfsonlinux project.
