### PR TITLE
Fix a typo in kube-proxy options

### DIFF
--- a/content/rke/v0.1.x/en/config-options/services/_index.md
+++ b/content/rke/v0.1.x/en/config-options/services/_index.md
@@ -97,4 +97,4 @@ Currently, RKE doesn't support any specific options for the `scheduler` service.
 ## Kubernetes Network Proxy
 The [Kubernetes network proxy](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/) service runs on all nodes and manages endpoints created by Kubernetes for TCP/UDP ports.
 
-Currently, RKE doesn't support any specific options for the `kube-proxy` service.
+Currently, RKE doesn't support any specific options for the `kubeproxy` service.


### PR DESCRIPTION
The cluster.yaml config doesn't accept `kube-proxy`, it only accepts `kubeproxy` like this:

```
services:
  kubeproxy:
    extra_args: []
```