### PR TITLE
Removing 2.1 draft flags and comments

### DIFF
--- a/content/rancher/v2.x/en/admin-settings/authentication/_index.md
+++ b/content/rancher/v2.x/en/admin-settings/authentication/_index.md
@@ -25,8 +25,7 @@ The Rancher authentication proxy integrates with the following external authenti
 | [OpenLDAP]({{< baseurl >}}/rancher/v2.x/en/admin-settings/authentication/openldap/)             | v2.0.5           |
 | [Microsoft AD FS]({{< baseurl >}}rancher/v2.x/en/admin-settings/authentication/microsoft-adfs/) | v2.0.7           |
 | [PingIdentity]({{< baseurl >}}/rancher/v2.x/en/admin-settings/authentication/ping-federate/)    | v2.0.7           |  
-
-<!-- | [Keycloak]({{< baseurl >}}/rancher/v2.x/en/admin-settings/authentication/keycloak/)                   | v2.1.0 -->     
+| [Keycloak]({{< baseurl >}}/rancher/v2.x/en/admin-settings/authentication/keycloak/)             | v2.1.0           |
 
 <br/>
 However, Rancher also provides local authentication.

--- a/content/rancher/v2.x/en/admin-settings/authentication/keycloak/_index.md
+++ b/content/rancher/v2.x/en/admin-settings/authentication/keycloak/_index.md
@@ -1,9 +1,8 @@
 ---
 title: Configuring KeyCloak (SAML)
 weight: 1200
-draft: true
 ---
-_Available as of v2.0.1_
+_Available as of v2.1.0_
 
 If your organization uses KeyCloak Identity Provider (IdP) for user authentication, you can configure Rancher to allow your users to log in using their IdP credentials.
 

--- a/content/rancher/v2.x/en/installation/air-gap-installation/config-rancher-for-private-reg/_index.md
+++ b/content/rancher/v2.x/en/installation/air-gap-installation/config-rancher-for-private-reg/_index.md
@@ -1,7 +1,6 @@
 ---
 title: 3—Configuring Rancher for the Private Registry
 weight: 75
-draft: true
 ---
 
 Rancher needs to be configured to use the private registry as source for the needed images.

--- a/content/rancher/v2.x/en/installation/air-gap-installation/install-rancher/_index.md
+++ b/content/rancher/v2.x/en/installation/air-gap-installation/install-rancher/_index.md
@@ -1,7 +1,10 @@
 ---
 title: 2—Installing Rancher
 weight: 50
+<<<<<<< HEAD
 draft: true
+=======
+>>>>>>> removing draft flag for air gap
 ---
 
 After your private registry is setup for your Rancher installation, complete that installation. Follow one of the procedures below based on the configuration in which you want to run Rancher.

--- a/content/rancher/v2.x/en/installation/air-gap-installation/install-rancher/_index.md
+++ b/content/rancher/v2.x/en/installation/air-gap-installation/install-rancher/_index.md
@@ -1,10 +1,6 @@
 ---
 title: 2—Installing Rancher
 weight: 50
-<<<<<<< HEAD
-draft: true
-=======
->>>>>>> removing draft flag for air gap
 ---
 
 After your private registry is setup for your Rancher installation, complete that installation. Follow one of the procedures below based on the configuration in which you want to run Rancher.

--- a/content/rancher/v2.x/en/installation/air-gap-installation/prepare-private-reg/_index.md
+++ b/content/rancher/v2.x/en/installation/air-gap-installation/prepare-private-reg/_index.md
@@ -1,7 +1,6 @@
 ---
 title: 1—Preparing the Private Registry
 weight: 25
-draft: true
 ---
 
 For the first part of your air gap install, you'll prepare your private registry for Rancher installation by downloading the Rancher release files, and then pushing them to your private registry.

--- a/content/rancher/v2.x/en/k8s-in-rancher/projects-and-namespaces/resource-quotas/_index.md
+++ b/content/rancher/v2.x/en/k8s-in-rancher/projects-and-namespaces/resource-quotas/_index.md
@@ -1,7 +1,6 @@
 ---
 title: Resource Quotas
 weight: 5000
-draft: true
 ---
 
 _Available as of v2.1.0_


### PR DESCRIPTION
Windows and node cleaning flags are accounted for in their own PRs. This one covers keycloak, air gap, and resource quotas