### PR TITLE
Add new chart options in 2.1.0

### DIFF
--- a/content/rancher/v2.x/en/installation/ha/helm-rancher/chart-options/_index.md
+++ b/content/rancher/v2.x/en/installation/ha/helm-rancher/chart-options/_index.md
@@ -19,7 +19,13 @@ weight: 276
 
 | Option | Default Value | Description |
 | --- | --- | --- |
+| `additionalTrustedCAs` | false | `bool` - See [Additional Trusted CAs](#additional-trusted-cas) |
+| `auditLog.destination` | "sidecar" | `string` - Stream to sidecar container console or hostPath volume - "sidecar, hostPath" |
+| `auditLog.hostPath` | "/var/log/rancher/audit" | `string` - log file destination on host |
 | `auditLog.level` | 0 | `int` - set the [API Audit Log]({{< baseurl >}}/rancher/v2.x/en/installation/api-auditing) level. 0 is off. [0-3] |
+| `auditLog.maxAge` | 1 | `int` - maximum number of days to retain old audit log files |
+| `auditLog.maxBackups` | 1 | `int` - maximum number of audit log files to retain |
+| `auditLog.maxSize` | 100 | `int` - maximum size in megabytes of the audit log file before it gets rotated |
 | `debug` | false | `bool` - set debug flag on rancher server |
 | `imagePullSecrets` | [] | `list` - list of names of Secret resource containing private registry credentials |
 | `proxy` | "" | `string` - string - HTTP[S] proxy server for Rancher |
@@ -27,19 +33,23 @@ weight: 276
 | `resources` | {} | `map` - rancher pod resource requests & limits |
 | `rancherImage` | "rancher/rancher" | `string` - rancher image source |
 | `rancherImageTag` | same as chart version | `string` - rancher/rancher image tag |
-| `tls` | "ingress" | `string` - Where to terminate SSL. - "ingress, external" |
+| `tls` | "ingress" | `string` - **DEPRECATED**: Changing this option is not recommended. See [External TLS Termination](#external-tls-termination) for details. - "ingress, external" |
 
 <br/>
 
 ### API Audit Log
 
-Enabling the [API Audit Log](https://rancher.com/docs/rancher/v2.x/en/installation/api-auditing/) will create a sidecar container in the Rancher pod. This container (`rancher-audit-log`) will stream the log to `stdout`.
+Enabling the [API Audit Log](https://rancher.com/docs/rancher/v2.x/en/installation/api-auditing/).
 
 You can collect this log as you would any container log. Enable the [Logging service under Rancher Tools](https://rancher.com/docs/rancher/v2.x/en/tools/logging/) for the `System` Project on the Rancher server cluster.
 
-```
+```plain
 --set auditLog.level=1
 ```
+
+By default enabling Audit Logging will create a sidecar container in the Rancher pod. This container (`rancher-audit-log`) will stream the log to `stdout`.  You can collect this log as you would any container log. Enable the [Logging service under Rancher Tools](https://rancher.com/docs/rancher/v2.x/en/tools/logging/) for the Rancher server cluster or System Project.
+
+Set the `auditLog.destination` to `hostPath` to forward logs to volume shared with the host system instead of streaming to a sidecar container. When setting the destination to `hostPath` you may want to adjust the other auditLog parameters for log rotation.
 
 ### HTTP Proxy
 
@@ -47,9 +57,23 @@ Rancher requires internet access for some functionality (helm charts). Use `prox
 
 Add your IP exceptions to the `noProxy` list. Make sure you add the Service cluster IP range (default: 10.43.0.1/16) and any worker cluster `controlplane` nodes. Rancher supports CIDR notation ranges in this list.
 
-```
+```plain
 --set proxy="http://<username>:<password>@<proxy_url>:<proxy_port>/"
 --set noProxy="127.0.0.1,localhost,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
+```
+
+### Additional Trusted CAs
+
+If you have private registries, catalogs or a proxy that intercepts certificates, you may need to add additional trusted CAs to Rancher.
+
+```plain
+--set additionalTrustedCAs=true
+```
+
+Once the Rancher deployment is created, copy your CA certs in pem format into a file named `ca-additional.pem` and use `kubectl` to create the `tls-ca-additional` secret in the `cattle-system` namespace.
+
+```plain
+kubectl -n cattle-system create secret generic tls-ca-additional --from-file=ca-additional.pem
 ```
 
 ### Private Registry and Air Gap Installs
@@ -58,21 +82,56 @@ See [Installing Rancher - Air Gap]({{< baseurl >}}/rancher/v2.x/en/installation/
 
 ### External TLS Termination
 
-If you wish to terminate the SSL/TLS on a load-balancer external to the Rancher cluster (ingress), use the `--tls=external` option and point your load balancer at port http 80 on all of the rancher cluster nodes.
+Due to security concerns and configuration variability, terminating TLS exclusively on an external load balancer is being deprecated. This option will be removed in future versions of the Helm chart.
 
-> **Note:** If you are using a Private CA signed cert, add `--set privateCA=true` and see [Adding TLS Secrets - Private CA Signed - Additional Steps]({{< baseurl >}}/rancher/v2.x/en/installation/ha/helm-rancher/tls-secrets/#private-ca-signed---additional-steps) to add the CA cert for Rancher.
+We recommend configuring your load balancer as a Layer 4 balancer, forwarding plain 80/tcp and 443/tcp to the Rancher Management cluster nodes. The Ingress Controller on the cluster will redirect http traffic on port 80 to https on port 443.
 
-Your load balancer must support long lived websocket connections and will need to insert proxy headers so Rancher can route links correctly.
+You may configure your load balancer as a Layer 7 balancer with a SSL/TLS certificate, but you will need to configure the load balancer to forward to the https endpoints on the Rancher Management Cluster nodes.
 
-> **Note:** The `tls=external` option will expose the Rancher interface on http port 80.  Clients that are allowed to connect directly to the Rancher cluster will not be encrypted. We recommend that you restrict direct access at the network level to just your load balancer.
+#### Conversion
 
-#### Required headers
+##### Certificates
 
-* `Host`
-* `X-Forwarded-Proto`
-* `X-Forwarded-Port`
-* `X-Forwarded-For`
+Make sure you have a copy of the following:
 
-#### Health checks
+* Server Certificate
+* Server Certificate Private Key
+* Any Chain Certificates
+* Private CA Root Certificate (if Private CA)
 
-Rancher will respond `200` to health checks on the `/healthz` endpoint.
+The certificate doesn't need to be the same one used by the external load balancer, but it can be.  If you creating a new certificate and used a Private CA to sign the certificate installed on the external load balancer, use the same CA to sign the new certificate.
+
+##### Gather Chart Options
+
+The Helm chart options for setting up TLS with provided certificates can be found in the [Install Rancher - Certificates from Files (Kubernetes Secrets)]({{< baseurl >}}/rancher/v2.x/en/installation/ha/helm-rancher/#certificates-from-files-kubernetes-secret) section.
+
+In general you will need to swap out:
+
+```plain
+--set tls=external
+```
+
+With:
+
+```plain
+  --set ingress.tls.source=secret
+```
+
+> **Note:** if your certificates are signed by a private CA don't forget to add the `--set privateCA=true` option.
+
+##### Upgrade
+
+Once you have selected the `helm --set` options for your SSL configuration, follow the [Rancher Upgrade]({{< baseurl >}}/rancher/v2.x/en/upgrades/upgrades/ha-server-upgrade-helm) instructions replacing the deprecated chart options with the new configuration.
+
+Example with privateCA option:
+
+```plain
+helm upgrade rancher rancher-stable/rancher \
+  --set hostname=rancher.my.org \
+  --set ingress.tls.source=secret \
+  --set privateCA=true
+```
+
+##### Populate Certificate Secrets
+
+The Ingress controller will wait until you have populated the certificate secrets before serving the Rancher application. See [Adding TLS Secrets]({{< baseurl >}}/rancher/v2.x/en/installation/ha/helm-rancher/tls-secrets/) for details.


### PR DESCRIPTION
* Add in options to publish Audit Log to a volume
* Add in options to add additional trusted CA certificates
* Revert but deprecate tls=external

@superseb pointed out that some users may have set the `tls=external` option. Did not think of the upgrade ramifications. Removing it may break upgrades. So revert, but document that its deprecated and you should migrate your install to a "supported" TLS option.

#870 

rancher/server-chart#30

