### PR TITLE
Add note to cacerts.pem filename when adding secret

### DIFF
--- a/content/rancher/v2.x/en/installation/ha/helm-rancher/tls-secrets/_index.md
+++ b/content/rancher/v2.x/en/installation/ha/helm-rancher/tls-secrets/_index.md
@@ -11,8 +11,8 @@ Use `kubectl` with the `tls` secret type to create the secrets.
 
 ```
 kubectl -n cattle-system create secret tls tls-rancher-ingress \
-  --cert=./tls.crt \
-  --key=./tls.key
+  --cert=tls.crt \
+  --key=tls.key
 ```
 
 ### Private CA Signed - Additional Steps
@@ -20,6 +20,8 @@ kubectl -n cattle-system create secret tls tls-rancher-ingress \
 If you are using a private CA, Rancher will need to have a copy of the CA cert to include when generating agent configs.
 
 Copy the CA cert into a file named `cacerts.pem` and use `kubectl` to create the `tls-ca` secret in the `cattle-system` namespace.
+
+>**Important:** Make sure the file is called `cacerts.pem` as Rancher uses that filename to configure the CA cert.
 
 ```
 kubectl -n cattle-system create secret generic tls-ca \


### PR DESCRIPTION
* Added a note to show users it's important the file is called `cacerts.pem`
* Changed the file location for secret to be consistent (either `./` all or not)