### PR TITLE
Use name 'Projects/Namespaces' instead of 'Projects'

### DIFF
--- a/content/rancher/v2.x/en/quick-start-guide/workload/quickstart-deploy-workload-ingress/_index.md
+++ b/content/rancher/v2.x/en/quick-start-guide/workload/quickstart-deploy-workload-ingress/_index.md
@@ -15,7 +15,7 @@ For this workload, you'll be deploying the application Rancher Hello-World.
 
 1.  From the **Clusters** page, open the cluster that you just created.
 
-2.  From the main menu of the **Dashboard**, select **Projects**.
+2.  From the main menu of the **Dashboard**, select **Projects/Namespaces**.
 
 3.  Open the **Project: Default** project.
 

--- a/content/rancher/v2.x/en/quick-start-guide/workload/quickstart-deploy-workload-nodeport/_index.md
+++ b/content/rancher/v2.x/en/quick-start-guide/workload/quickstart-deploy-workload-nodeport/_index.md
@@ -15,7 +15,7 @@ For this workload, you'll be deploying the application Rancher Hello-World.
 
 1.  From the **Clusters** page, open the cluster that you just created.
 
-2.  From the main menu of the **Dashboard**, select **Projects**.
+2.  From the main menu of the **Dashboard**, select **Projects/Namespaces**.
 
 3.  Open the **Project: Default** project.
 


### PR DESCRIPTION
The Quickstart guide says "From the main menu of the Dashboard, select Projects.", but there is no tab named "Projects". I believe it was renamed to be 'Projects/Namespaces'.