### PR TITLE
Address gitlab version requirements for pipeline

### DIFF
--- a/content/rancher/v2.x/en/tools/pipelines/configurations/_index.md
+++ b/content/rancher/v2.x/en/tools/pipelines/configurations/_index.md
@@ -72,8 +72,8 @@ Select your provider's tab below and follow the directions.
 1. Enable the repository for which you want to run a pipeline. Then click **Done**.  
 
 >**Note:** 
-1. Pipeline uses Gitlab [v4 API](https://docs.gitlab.com/ee/api/v3_to_v4.html) and the supported Gitlab version is 9.0+.  
-2. If you use GitLab 10.7+ and your Rancher setup is in a local network, enable the **Allow requests to the local network from hooks and services** option in GitLab admin settings.
+> 1. Pipeline uses Gitlab [v4 API](https://docs.gitlab.com/ee/api/v3_to_v4.html) and the supported Gitlab version is 9.0+.  
+> 2. If you use GitLab 10.7+ and your Rancher setup is in a local network, enable the **Allow requests to the local network from hooks and services** option in GitLab admin settings.
 {{% /tab %}}
 {{% /tabs %}}
 

--- a/content/rancher/v2.x/en/tools/pipelines/configurations/_index.md
+++ b/content/rancher/v2.x/en/tools/pipelines/configurations/_index.md
@@ -71,7 +71,9 @@ Select your provider's tab below and follow the directions.
 
 1. Enable the repository for which you want to run a pipeline. Then click **Done**.  
 
->**Note:** If you use GitLab and your Rancher setup is in a local network, enable the **Allow requests to the local network from hooks and services** option in GitLab admin settings.
+>**Note:** 
+1. Pipeline uses Gitlab [v4 API](https://docs.gitlab.com/ee/api/v3_to_v4.html) and the supported Gitlab version is 9.0+.  
+2. If you use GitLab 10.7+ and your Rancher setup is in a local network, enable the **Allow requests to the local network from hooks and services** option in GitLab admin settings.
 {{% /tab %}}
 {{% /tabs %}}
 


### PR DESCRIPTION
1. Related issue: https://github.com/rancher/rancher/issues/16209
2. The `Allow requests to the local network from hooks and services` option is available since 10.7: https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/17905 