### PR TITLE
Remove Persisting State part in boot-from-iso

### DIFF
--- a/content/os/v1.x/en/installation/running-rancheros/workstation/boot-from-iso/_index.md
+++ b/content/os/v1.x/en/installation/running-rancheros/workstation/boot-from-iso/_index.md
@@ -10,18 +10,3 @@ You must boot with at least **1280MB** of memory. If you boot with the ISO, you 
 ### Install to Disk
 
 After you boot RancherOS from ISO, you can follow the instructions [here]({{< baseurl >}}/os/v1.x/en/installation/running-rancheros/server/install-to-disk/) to install RancherOS to a hard disk.
-
-### Persisting State
-
-If you are running from the ISO, RancherOS will be running from memory. All downloaded Docker images, for example, will be stored in a ramdisk and will be lost after the server is rebooted. You can
-create a file system with the label `RANCHER_STATE` to instruct RancherOS to use that partition to store state. Suppose you have a disk partition on the server called `/dev/sda`, the following command formats that partition and labels it `RANCHER_STATE`
-
-```
-$ sudo mkfs.ext4 -L RANCHER_STATE /dev/sda
-# Reboot afterwards in order for the changes to start being saved.
-$ sudo reboot
-```
-
-After you reboot, the server RancherOS will use `/dev/sda` as the state partition.
-
-> **Note:** If you are installing RancherOS to disk, you do not need to run this command.


### PR DESCRIPTION
If users don't add extra kernel parameters or modify os-config, this part can't be unsupported now.
I would recommend to remove it to avoid user confusion.

https://forums.rancher.com/t/iso-persisting/4534