### PR TITLE
Improve HA install steps

### DIFF
--- a/content/rancher/v2.x/en/faq/technical/_index.md
+++ b/content/rancher/v2.x/en/faq/technical/_index.md
@@ -123,3 +123,21 @@ When the node is removed from the cluster, and the node is cleaned, you can read
 ### How can I add additional arguments/binds/environment variables to Kubernetes components in a Rancher Launched Kubernetes cluster?
 
 You can add additional arguments/binds/environment variables via the [Config File]({{< baseurl >}}/rancher/v2.x/en/cluster-provisioning/rke-clusters/options/#config-file) option in Cluster Options. For more information, see the [Extra Args, Extra Binds, and Extra Environment Variables]({{< baseurl >}}/rke/v0.1.x/en/config-options/services/services-extras/) in the RKE documentation or browse the [Example Cluster.ymls]({{< baseurl >}}/rke/v0.1.x/en/example-yamls/).
+
+### How do I check `Common Name` and `Subject Alternative Names` in my server certificate?
+
+Although technically an entry in `Subject Alternative Names` is required, having the hostname in both `Common Name` and as entry in `Subject Alternative Names` gives you maximum compatibility with older browser/applications.
+
+Check `Common Name`:
+
+```
+openssl x509 -noout -subject -in cert.pem
+subject= /CN=rancher.my.org
+```
+
+Check `Subject Alternative Names`:
+
+```
+openssl x509 -noout -in cert.pem -text | grep DNS
+                DNS:rancher.my.org
+```

--- a/content/rancher/v2.x/en/installation/ha/_index.md
+++ b/content/rancher/v2.x/en/installation/ha/_index.md
@@ -11,13 +11,13 @@ This procedure walks you through setting up a 3-node cluster with RKE and instal
 
 ## Recommended Architecture
 
-* DNS for Rancher should resolve to a layer 4 load balancer
+* DNS for Rancher should resolve to a Layer 4 load balancer (TCP)
 * The Load Balancer should forward port TCP/80 and TCP/443 to all 3 nodes in the Kubernetes cluster.
 * The Ingress controller will redirect HTTP to HTTPS and terminate SSL/TLS on port TCP/443.
 * The Ingress controller will forward traffic to port TCP/80 on the pod in the Rancher deployment.
 
-<sup>HA Rancher install with layer 4 load balancer, depicting SSL termination at ingress controllers</sup>
 ![Rancher HA]({{< baseurl >}}/img/rancher/ha/rancher2ha.svg)
+<sup>HA Rancher install with Layer 4 load balancer (TCP), depicting SSL termination at ingress controllers</sup>
 
 ## Required Tools
 

--- a/content/rancher/v2.x/en/installation/ha/helm-rancher/_index.md
+++ b/content/rancher/v2.x/en/installation/ha/helm-rancher/_index.md
@@ -11,17 +11,31 @@ Rancher installation is managed using the Helm package manager for Kubernetes.  
 
 Use `helm repo add` command to add the Helm chart repository that contains charts to install Rancher. For more information about the repository choices and which is best for your use case, see [Choosing a Version of Rancher]({{< baseurl >}}/rancher/v2.x/en/installation/server-tags/#helm-chart-repositories).
 
-Replace `<CHART_REPO>` with the Helm chart repository that you want to use (i.e. `latest` or `stable`).
+Replace both occurences of `<CHART_REPO>` with the Helm chart repository that you want to use (i.e. `latest` or `stable`).
 
 ```
 helm repo add rancher-<CHART_REPO> https://releases.rancher.com/server-charts/<CHART_REPO>
 ```
 
-### Install cert-manager
+### Choose your SSL Configuration
 
-> **Note:** cert-manager is only required for Rancher generated and LetsEncrypt issued certificates.  You may skip this step if you are bringing your own certificates or using the `ingress.tls.source=secret` option.
+Rancher Server is designed to be secure by default and requires SSL/TLS configuration.
 
-Rancher relies on [cert-manager](https://github.com/kubernetes/charts/tree/master/stable/cert-manager) from the official Kubernetes Helm chart repository to issue self-signed or LetsEncrypt certificates.
+There are three recommended options for the source of the certificate.
+
+> **Note:** If you want terminate SSL/TLS externally, see [TLS termination on an External Load Balancer]({{< baseurl >}}/rancher/v2.x/en/installation/ha/helm-rancher/chart-options/#external-tls-termination).
+
+| Configuration | Chart option | Description | Requires cert-manager |
+|-----|-----|-----|-----|
+| [Rancher Generated Certificates](#rancher-generated-certificates) | `ingress.tls.source=rancher` | Use certificates issued by Rancher's generated CA (self signed)<br/>This is the **default** | [yes](#optional-install-cert-manager) |
+| [Let’s Encrypt](#let-s-encrypt) | `ingress.tls.source=letsEncrypt` | Use [Let's Encrypt](https://letsencrypt.org/) to issue a certificate | [yes](#optional-install-cert-manager) |
+| [Certificates from Files](#certificates-from-files) | `ingress.tls.source=secret` | Use your own certificate files by creating Kubernetes Secret(s) | no |
+
+### Optional: Install cert-manager
+
+> **Note:** cert-manager is only required for certificates issued by Rancher's generated CA (`ingress.tls.source=rancher`) and Let's Encrypt issued certificates (`ingress.tls.source=letsEncrypt`). You should skip this step if you are using your own certificate files (option `ingress.tls.source=secret`) or if you use [TLS termination on an External Load Balancer]({{< baseurl >}}/rancher/v2.x/en/installation/ha/helm-rancher/chart-options/#external-tls-termination).
+
+Rancher relies on [cert-manager](https://github.com/kubernetes/charts/tree/master/stable/cert-manager) from the official Kubernetes Helm chart repository to issue certificates from Rancher's own generated CA or to request Let's Encrypt certificates.
 
 Install `cert-manager` from Kubernetes Helm chart repository.
 
@@ -31,21 +45,21 @@ helm install stable/cert-manager \
   --namespace kube-system
 ```
 
-### Choose your SSL Configuration
+Wait for `cert-manager` to be rolled out:
 
-Rancher server is designed to be secure by default and requires SSL/TLS configuration.
-
-There are three options for the source of the certificate.
-
-1. `rancher` - (Default) Use Rancher generated CA/Certificates.
-2. `letsEncrypt` - Use [LetsEncrypt](https://letsencrypt.org/) to issue a cert.
-3. `secret` - Configure a Kubernetes Secret with your certificate files.
+```
+kubectl -n kube-system rollout status deploy/cert-manager
+Waiting for deployment "cert-manager" rollout to finish: 0 of 1 updated replicas are available...
+deployment "cert-manager" successfully rolled out
+```
 
 <br/>
 
-#### (Default) Rancher Generated Certificates
+#### Rancher Generated Certificates
 
-The default is for Rancher to generate a CA and use the `cert-manager` to issue the certificate for access to the Rancher server interface.
+> **Note:** You need to have [cert-manager](#optional-install-cert-manager) installed before proceeding.
+
+The default is for Rancher to generate a CA and uses `cert-manager` to issue the certificate for access to the Rancher server interface. Because `rancher` is the default option for `ingress.tls.source`, we are not specifying `ingress.tls.source` when running the `helm install` command.
 
 - Replace `<CHART_REPO>` with the repository that you configured in [Add the Helm Chart Repository](#add-the-helm-chart-repository) (i.e. `latest` or `stable`).
 - Set the `hostname` to the DNS name you pointed at your load balancer.
@@ -59,12 +73,22 @@ helm install rancher-<CHART_REPO>/rancher \
   --set hostname=rancher.my.org
 ```
 
-#### LetsEncrypt
+Wait for Rancher to be rolled out:
 
-Use [LetsEncrypt](https://letsencrypt.org/)'s free service to issue trusted SSL certs. This configuration uses http validation so the Load Balancer must have a Public DNS record and be accessible from the internet.
+```
+kubectl -n cattle-system rollout status deploy/rancher
+Waiting for deployment "rancher" rollout to finish: 0 of 3 updated replicas are available...
+deployment "rancher" successfully rolled out
+```
+
+#### Let's Encrypt
+
+> **Note:** You need to have [cert-manager](#optional-install-cert-manager) installed before proceeding.
+
+This option uses `cert-manager` to automatically request and renew [Let's Encrypt](https://letsencrypt.org/) certificates. This is a free service that provides you with a valid certificate as Let's Encrypt is a trusted CA. This configuration uses HTTP validation (`HTTP-01`) so the load balancer must have a public DNS record and be accessible from the internet.
 
 - Replace `<CHART_REPO>` with the repository that you configured in [Add the Helm Chart Repository](#add-the-helm-chart-repository) (i.e. `latest` or `stable`).
-- Set `hostname`, `ingress.tls.source=letsEncrypt` and LetsEncrypt options.
+- Set `hostname` to the public DNS record, set `ingress.tls.source` to `letsEncrypt` and `letsEncrypt.email` to the email address used for communication about your certificate (for example, expiry notices)
 
 >**Using Air Gap?** [Set the `rancherImage` option]({{< baseurl >}}/rancher/v2.x/en/installation/air-gap-installation/install-rancher/#install-rancher-using-private-registry) in your command, pointing toward your private registry.
 
@@ -77,16 +101,23 @@ helm install rancher-<CHART_REPO>/rancher \
   --set letsEncrypt.email=me@example.org
 ```
 
-#### Certificates from Files (Kubernetes Secret)
+Wait for Rancher to be rolled out:
+
+```
+kubectl -n cattle-system rollout status deploy/rancher
+Waiting for deployment "rancher" rollout to finish: 0 of 3 updated replicas are available...
+deployment "rancher" successfully rolled out
+```
+
+#### Certificates from Files
 
 Create Kubernetes secrets from your own certificates for Rancher to use.
 
-> **Note:** The common name for the cert will need to match the `hostname` option or the ingress controller will fail to provision the site for Rancher.
+> **Note:** The `Common Name` or a `Subject Alternative Names` entry in the server certificate must match the `hostname` option, or the ingress controller will fail to configure correctly. Although an entry in the `Subject Alternative Names` is technically required, having a matching `Common Name` maximizes compatibility with older browsers/applications. If you want to check if your certificates are correct, see [How do I check Common Name and Subject Alternative Names in my server certificate?]({{< baseurl >}}/rancher/v2.x/en/faq/technical/#how-do-i-check-common-name-and-subject-alternative-names-in-my-server-certificate)
 
 - Replace `<CHART_REPO>` with the repository that you configured in [Add the Helm Chart Repository](#add-the-helm-chart-repository) (i.e. `latest` or `stable`).
-- Set `hostname` and `ingress.tls.source=secret`.
-
-> **Note:** If you are using a Private CA signed cert, add `--set privateCA=true`
+- Set `hostname` and set `ingress.tls.source` to `secret`.
+- If you are using a Private CA signed certificate , add `--set privateCA=true` to the command shown below.
 
 ```
 helm install rancher-<CHART_REPO>/rancher \
@@ -96,7 +127,25 @@ helm install rancher-<CHART_REPO>/rancher \
   --set ingress.tls.source=secret
 ```
 
-Now that Rancher is running, see [Adding TLS Secrets]({{< baseurl >}}/rancher/v2.x/en/installation/ha/helm-rancher/tls-secrets/) to publish the certificate files so Rancher and the ingress controller can use them.
+Now that Rancher is deployed, see [Adding TLS Secrets]({{< baseurl >}}/rancher/v2.x/en/installation/ha/helm-rancher/tls-secrets/) to publish the certificate files so Rancher and the ingress controller can use them.
+
+After adding the secrets, check if Rancher was rolled out successfully:
+
+```
+kubectl -n cattle-system rollout status deploy/rancher
+Waiting for deployment "rancher" rollout to finish: 0 of 3 updated replicas are available...
+deployment "rancher" successfully rolled out
+```
+
+If you see the following error: `error: deployment "rancher" exceeded its progress deadline`, you can check the status of the deployment by running the following command:
+
+```
+kubectl -n cattle-system get deploy rancher
+NAME      DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
+rancher   3         3         3            3           3m
+```
+
+It should show the same count for `DESIRED` and `AVAILABLE`.
 
 ### Advanced Configurations
 
@@ -116,4 +165,4 @@ Make sure you save the `--set` options you used. You will need to use the same o
 
 That's it you should have a functional Rancher server. Point a browser at the hostname you picked and you should be greeted by the colorful login page.
 
-Doesn't Work? Take a look at the [Troubleshooting]({{< baseurl >}}/rancher/v2.x/en/installation/ha/helm-rancher/troubleshooting/) Page
+Doesn't work? Take a look at the [Troubleshooting]({{< baseurl >}}/rancher/v2.x/en/installation/ha/helm-rancher/troubleshooting/) Page

--- a/content/rancher/v2.x/en/installation/ha/helm-rancher/chart-options/_index.md
+++ b/content/rancher/v2.x/en/installation/ha/helm-rancher/chart-options/_index.md
@@ -86,7 +86,7 @@ We recommend configuring your load balancer as a Layer 4 balancer, forwarding pl
 
 You may terminate the SSL/TLS on a L7 load balancer external to the Rancher cluster (ingress). Use the `--set tls=external` option and point your load balancer at port http 80 on all of the Rancher cluster nodes. This will expose the Rancher interface on http port 80. Be aware that clients that are allowed to connect directly to the Rancher cluster will not be encrypted. If you choose to do this we recommend that you restrict direct access at the network level to just your load balancer.
 
-> **Note:** If you are using a Private CA signed cert, add `--set privateCA=true` and see [Adding TLS Secrets - Private CA Signed - Additional Steps]({{< baseurl >}}/rancher/v2.x/en/installation/ha/helm-rancher/tls-secrets/#private-ca-signed---additional-steps) to add the CA cert for Rancher.
+> **Note:** If you are using a Private CA signed certificate, add `--set privateCA=true` and see [Adding TLS Secrets - Using a Private CA Signed Certificate]({{< baseurl >}}/rancher/v2.x/en/installation/ha/helm-rancher/tls-secrets/#using-a-private-ca-signed-certificate) to add the CA cert for Rancher.
 
 Your load balancer must support long lived websocket connections and will need to insert proxy headers so Rancher can route links correctly.
 

--- a/content/rancher/v2.x/en/installation/ha/helm-rancher/tls-secrets/_index.md
+++ b/content/rancher/v2.x/en/installation/ha/helm-rancher/tls-secrets/_index.md
@@ -5,7 +5,7 @@ weight: 276
 
 Kubernetes will create all the objects and services for Rancher, but it will not become available until we populate the `tls-rancher-ingress` secret in the `cattle-system` namespace with the certificate and key.
 
-Combine the server certificate followed by the intermediate cert chain your CA provided into a file named `tls.crt`. Copy your key into a file name `tls.key`.
+Combine the server certificate followed by any intermediate certificate(s) needed into a file named `tls.crt`. Copy your certificate key into a file named `tls.key`.
 
 Use `kubectl` with the `tls` secret type to create the secrets.
 
@@ -15,13 +15,13 @@ kubectl -n cattle-system create secret tls tls-rancher-ingress \
   --key=tls.key
 ```
 
-### Private CA Signed - Additional Steps
+### Using a Private CA Signed Certificate
 
-If you are using a private CA, Rancher will need to have a copy of the CA cert to include when generating agent configs.
+If you are using a private CA, Rancher requires a copy of the CA certificate which is used by the Rancher Agent to validate the connection to the server.
 
-Copy the CA cert into a file named `cacerts.pem` and use `kubectl` to create the `tls-ca` secret in the `cattle-system` namespace.
+Copy the CA certificate into a file named `cacerts.pem` and use `kubectl` to create the `tls-ca` secret in the `cattle-system` namespace.
 
->**Important:** Make sure the file is called `cacerts.pem` as Rancher uses that filename to configure the CA cert.
+>**Important:** Make sure the file is called `cacerts.pem` as Rancher uses that filename to configure the CA certificate.
 
 ```
 kubectl -n cattle-system create secret generic tls-ca \


### PR DESCRIPTION
- Moves the SSL configuration options to the top indicating wether `cert-manager` is required for the option or not
- Consistent use of option names and chart options key/value parameters
- Corrected spelling of terminology
- Added check commands for cert-manager and rancher deployment to make sure it's up and running before proceeding
- Added check steps for bring your own certificate files