### PR TITLE
fix typo in system_images

### DIFF
--- a/content/rke/v0.1.x/en/upgrades/_index.md
+++ b/content/rke/v0.1.x/en/upgrades/_index.md
@@ -14,14 +14,14 @@ For example, to change the deployed Kubernetes version, you update the `rancher/
 Original YAML
 
 ```yaml
-system-images:
+system_images:
     kubernetes: rancher/hyperkube:v1.9.7
 ```
 
 Updated YAML
 
 ```yaml
-system-images:
+system_images:
     kubernetes: rancher/hyperkube:v1.10.3
 ```
 


### PR DESCRIPTION
we incorrectly reference the key `system-images` when it should be `system_images`