### PR TITLE
Add -n ingress-nginx to the create secret dry-run command

### DIFF
--- a/content/rke/v0.1.x/en/config-options/add-ons/ingress-controllers/_index.md
+++ b/content/rke/v0.1.x/en/config-options/add-ons/ingress-controllers/_index.md
@@ -67,7 +67,7 @@ Setting up a default certificate is especially helpful in environments where a w
 2. Generate a Kubernetes secret from your PEM encoded certificate with the following command, substituting your certificate for `mycert.cert` and `mycert.key`.
 
     ```
-    kubectl create secret tls ingress-default-cert --cert=mycert.cert --key=mycert.key -o yaml --dry-run=true > ingress-default-cert.yaml
+    kubectl -n ingress-nginx create secret tls ingress-default-cert --cert=mycert.cert --key=mycert.key -o yaml --dry-run=true > ingress-default-cert.yaml
     ```
 3. Include the contents of `ingress-default-cert.yml` inline with your RKE `cluster.yml` file. For example:
 


### PR DESCRIPTION
Currently, if you take the contents of `ingress-default-cert.yaml` and paste it into your RKE config, the secret will get created in the namespace `default` which is not desired behavior. By specifying `-n ingress-nginx`, the secret will be created in the correct namespace.