### PR TITLE
Change TLS args in Docker configuration example

### DIFF
--- a/content/os/v1.x/en/installation/configuration/docker/_index.md
+++ b/content/os/v1.x/en/installation/configuration/docker/_index.md
@@ -14,7 +14,12 @@ In your cloud-config, Docker configuration is located under the `rancher.docker`
 rancher:
   docker:
     tls: true
-    tls_args: [--tlsverify, --tlscacert=ca.pem, --tlscert=server-cert.pem, --tlskey=server-key.pem, '-H=0.0.0.0:2376']
+    tls_args:
+      - "--tlsverify"
+      - "--tlscacert=/etc/docker/tls/ca.pem"
+      - "--tlscert=/etc/docker/tls/server-cert.pem"
+      - "--tlskey=/etc/docker/tls/server-key.pem"
+      - "-H=0.0.0.0:2376"
     storage_driver: overlay
 ```
 


### PR DESCRIPTION
The TLS args given in this example were misleading, because they were preventing the Docker daemon to listen on the port 2376 (even if the daemon still succeeds to start...).

The reason is very simple: when using `sudo ros tls gen --server ...`, the server and CA certificates will be stored in `/etc/docker/tls`. But their paths were given as relative paths, and not absolute paths, in the previous example.