### PR TITLE
Support for VMDK and regular ISO for vmware in RancherOS

### DIFF
--- a/content/os/v1.x/en/installation/running-rancheros/cloud/vmware-esxi/_index.md
+++ b/content/os/v1.x/en/installation/running-rancheros/cloud/vmware-esxi/_index.md
@@ -5,16 +5,16 @@ weight: 108
 
 As of v1.1.0, RancherOS automatically detects that it is running on VMware ESXi, and automatically adds the `open-vm-tools` service to be downloaded and started, and uses `guestinfo` keys to set the cloud-init data.
 
-As of v1.5.0, We release all stuff for vmware, it will include initrd, regular ISO for vmware, vmdk image, and so on. The open-vm-tools has been built in RancherOS, you don't need to download it.
+As of v1.5.0, RancherOS releases anything required for VMware, which includes initrd, a standard ISO for VMware, a `vmdk` image, and a specific ISO to be used with Docker Machine. The open-vm-tools is built in to RancherOS, there is no need to download it.
 
-| Description  | URL Link |
+| Description  | Downlaod URL |
 |---|---|
 | Booting from ISO   | https://releases.rancher.com/os/latest/vmware/rancheros.iso |
 | For docker-machine | https://releases.rancher.com/os/latest/vmware/rancheros-autoformat.iso |
 | VMDK               | https://releases.rancher.com/os/latest/vmware/rancheros.vmdk |
 | Initrd             | https://releases.rancher.com/os/latest/vmware/initrd |
 
-### VMware guestinfo
+### VMware Guest Info
 
 | VARIABLE | TYPE |
 |---|---|

--- a/content/os/v1.x/en/installation/running-rancheros/cloud/vmware-esxi/_index.md
+++ b/content/os/v1.x/en/installation/running-rancheros/cloud/vmware-esxi/_index.md
@@ -5,22 +5,31 @@ weight: 108
 
 As of v1.1.0, RancherOS automatically detects that it is running on VMware ESXi, and automatically adds the `open-vm-tools` service to be downloaded and started, and uses `guestinfo` keys to set the cloud-init data.
 
+As of v1.5.0, We release all stuff for vmware, it will include initrd, regular ISO for vmware, vmdk image, and so on. The open-vm-tools has been built in RancherOS, you don't need to download it.
+
+| Description  | URL Link |
+|---|---|
+| Booting from ISO   | https://releases.rancher.com/os/latest/vmware/rancheros.iso |
+| For docker-machine | https://releases.rancher.com/os/latest/vmware/rancheros-autoformat.iso |
+| VMDK               | https://releases.rancher.com/os/latest/vmware/rancheros.vmdk |
+| Initrd             | https://releases.rancher.com/os/latest/vmware/initrd |
+
 ### VMware guestinfo
 
 | VARIABLE | TYPE |
 |---|---|
 | `hostname` | hostname |
-| `interface.<n>.name` |	string |
-| `interface.<n>.mac` |	MAC address (is used to match the ethernet device's MAC address, not to set it) |
-| `interface.<n>.dhcp` |	{"yes", "no"} |
-| `interface.<n>.role` |	{"public", "private"} |
-| `interface.<n>.ip.<m>.address` |	CIDR IP address |
-| `interface.<n>.route.<l>.gateway` |	IP address |
-| `interface.<n>.route.<l>.destination` |	CIDR IP address (not available yet) |
+| `interface.<n>.name` | string |
+| `interface.<n>.mac` | MAC address (is used to match the ethernet device's MAC address, not to set it) |
+| `interface.<n>.dhcp` | {"yes", "no"} |
+| `interface.<n>.role` | {"public", "private"} |
+| `interface.<n>.ip.<m>.address` | CIDR IP address |
+| `interface.<n>.route.<l>.gateway` | IP address |
+| `interface.<n>.route.<l>.destination` | CIDR IP address (not available yet) |
 | `dns.server.<x>` | IP address |
-| `dns.domain.<y>` |	DNS search domain |
+| `dns.domain.<y>` | DNS search domain |
 | `cloud-init.config.data` | string |
-| `cloud-init.data.encoding` |	{"", "base64", "gzip+base64"} |
+| `cloud-init.data.encoding` | {"", "base64", "gzip+base64"} |
 | `cloud-init.config.url` | URL |
 
 

--- a/content/os/v1.x/en/installation/running-rancheros/workstation/docker-machine/_index.md
+++ b/content/os/v1.x/en/installation/running-rancheros/workstation/docker-machine/_index.md
@@ -15,8 +15,8 @@ Get the latest ISO artifact from the RancherOS [releases](https://github.com/ran
 Machine Driver | Recommended RancherOS version | ISO File
 -------------- | ----------------------------- | -------------------------------------------------------------
 VirtualBox     | >=v1.0.0 | [rancheros.iso](https://releases.rancher.com/os/latest/rancheros.iso)
-VMWare VSphere | >=v1.4.0 | [rancheros-vmware.iso](https://releases.rancher.com/os/latest/rancheros-vmware.iso)
-VMWare Fusion  | >=v1.4.0 | [rancheros-vmware.iso](https://releases.rancher.com/os/latest/rancheros-vmware.iso)
+VMWare VSphere | >=v1.4.0 | [rancheros-autoformat.iso](https://releases.rancher.com/os/latest/vmware/rancheros-autoformat.iso)
+VMWare Fusion  | >=v1.4.0 | [rancheros-autoformat.iso](https://releases.rancher.com/os/latest/vmware/rancheros-autoformat.iso)
 Hyper-V        | >=v1.5.0 | [rancheros.iso](https://releases.rancher.com/os/latest/hyperv/rancheros.iso)
 
 ### Using Docker Machine
@@ -61,7 +61,7 @@ $ docker-machine create -d vmwarevsphere \
         --vmwarevsphere-username <USERNAME> \
         --vmwarevsphere-password <PASSWORD> \
         --vmwarevsphere-memory-size <MEMORY-SIZE> \
-        --vmwarevsphere-boot2docker-url https://releases.rancher.com/os/latest/rancheros-vmware.iso \
+        --vmwarevsphere-boot2docker-url https://releases.rancher.com/os/latest/vmware/rancheros-autoformat.iso \
         --vmwarevsphere-vcenter <IP-ADDRESS> \
         --vmwarevsphere-vcenter-port <PORT> \
         --vmwarevsphere-disk-size <DISK-SIZE> \
@@ -82,7 +82,7 @@ Here is an example about using the RancherOS latest link:
 $ docker-machine create -d vmwarefusion \
         --vmwarefusion-no-share \
         --vmwarefusion-memory-size <MEMORY> \
-        --vmwarefusion-boot2docker-url https://releases.rancher.com/os/latest/rancheros-vmware.iso \
+        --vmwarefusion-boot2docker-url https://releases.rancher.com/os/latest/vmware/rancheros-autoformat.iso \
         <MACHINE_NAME>
 ```
 


### PR DESCRIPTION
https://github.com/rancher/os/issues/2468

They are the same and are used for docker-machine.
```
old link: https://releases.rancher.com/os/latest/rancheros-vmware.iso
new link: https://releases.rancher.com/os/latest/vmware/rancheros-autoformat.iso
```
I will keep the the old link, but I recommend using the new link, which makes it easier to distinguish.

This is the regular ISO for vmware:
```
https://releases.rancher.com/os/latest/vmware/rancheros.iso
```