### PR TITLE
simplify Helm upgrade

### DIFF
--- a/content/rancher/v2.x/en/upgrades/upgrades/ha-server-upgrade-helm/_index.md
+++ b/content/rancher/v2.x/en/upgrades/upgrades/ha-server-upgrade-helm/_index.md
@@ -64,23 +64,12 @@ Upgrades _to_ or _from_ any chart in the  [rancher-alpha repository]({{< baseurl
 
     > **Note:** If you want to switch to a different Helm chart repository, please follow the [steps on how to switch repositories]({{< baseurl >}}/rancher/v2.x/en/installation/server-tags/#switching-to-a-different-helm-chart-repository). If you switch repositories, make sure to list the repositories again before continuing onto Step 3 to ensure you have the correct one added.
 
-3. Get the set values from the current Rancher install.
-
-    ```
-    helm get values rancher
-
-    hostname: rancher.my.org
-    ```
-
-    > **Note:** There may be more values that are listed with this command depending on which [SSL configuration option you selected]({{< baseurl >}}/rancher/v2.x/en/installation/ha/helm-rancher/#choose-your-ssl-configuration) when installing Rancher.
-
-4. Upgrade Rancher to the latest version based on values from the previous steps.
+3. Upgrade Rancher to the latest version based on values from the previous steps.
 
     - Replace `<CHART_REPO>` with the repository that was listed (i.e. `latest` or `stable`).
-    - Take all the values from the previous step and append them to the command using `--set key=value`.
 
     ```
-    helm upgrade rancher rancher-<CHART_REPO>/rancher --set hostname=rancher.my.org
+    helm upgrade rancher rancher-<CHART_REPO>/rancher --reuse-values
     ```
 
 **Result:** Rancher is upgraded. Log back into Rancher to confirm that the upgrade succeeded.


### PR DESCRIPTION
Helm upgrade supports the `--reuse-values` parameter which makes it much easier to upgrade. It also helps to prevent mistakes by manually getting values from the prior installation.

```
      --reuse-values             when upgrading, reuse the last release's values and merge in any overrides from the command line via --set and -f. If '--reset-values' is specified, this is ignored.
```