### PR TITLE
Update _index.md

### DIFF
--- a/content/os/v1.x/en/overview/_index.md
+++ b/content/os/v1.x/en/overview/_index.md
@@ -11,7 +11,7 @@ Another way in which RancherOS is designed specifically for running Docker is th
 
 Like other minimalist Linux distributions, RancherOS boots incredibly quickly. Starting Docker containers is nearly instant, similar to starting any other process. This speed is ideal for organizations adopting microservices and autoscaling.
 
-Docker is an open-source platform designed for developers, system admins, and DevOps. It is used to build, ship, and run containers, using a simple and powerful command line interface (CLI). To get started with Docker, please visit the [Docker user guide](https://docs.docker.com/engine/userguide/).
+Docker is an open-source platform designed for developers, system admins, and DevOps. It is used to build, ship, and run containers, using a simple and powerful command line interface (CLI). To get started with Docker, please visit the [Docker user guide](https://docs.docker.com/config/daemon/).
 
 ### Hardware Requirements
 
@@ -25,11 +25,11 @@ VMWare     | 1GB                       | 1280MB (rancheros.iso) <br> 2048MB (ran
 GCE        | 1GB                       | 1280MB
 AWS        | 1GB                       | 1.7GB
 
-You can adjust memory requirements by custom building RancherOS, please refer to [reduce-memory-requirements]({{< baseurl >}}/os/v1.x/en/installation/custom-builds/custom-rancheros-iso/#reduce-memory-requirements)
+You can adjust memory requirements by custom building RancherOS, please refer to [reduce-memory-requirements](https://rancher.com/docs/os/v1.x/en/installation/custom-builds/custom-rancheros-iso/#reduce-memory-requirements)
 
 ### How RancherOS Works
 
-Everything in RancherOS is a Docker container. We accomplish this by launching two instances of Docker. One is what we call **System Docker** and is the first process on the system. All other system services, like `ntpd`, `syslog`, and `console`, are running in Docker containers. System Docker replaces traditional init systems like `systemd` and is used to launch [additional system services](installation/system-services/adding-system-services/).
+Everything in RancherOS is a Docker container. We accomplish this by launching two instances of Docker. One is what we call **System Docker** and is the first process on the system. All other system services, like `ntpd`, `syslog`, and `console`, are running in Docker containers. System Docker replaces traditional init systems like `systemd` and is used to launch [additional system services](https://rancher.com/docs/os/v1.x/en/installation/system-services/adding-system-services/).
 
 System Docker runs a special container called **Docker**, which is another Docker daemon responsible for managing all of the user’s containers. Any containers that you launch as a user from the console will run inside this Docker. This creates isolation from the System Docker containers and ensures that normal user commands don’t impact system services.
 
@@ -39,7 +39,7 @@ System Docker runs a special container called **Docker**, which is another Docke
 
 ### Running RancherOS
 
-To get started with RancherOS, head over to our [Quick Start Guide](quick-start-guide/).
+To get started with RancherOS, head over to our [Quick Start Guide](https://rancher.com/docs/os/v1.x/en/quick-start-guide/).
 
 ### Latest Release
 

--- a/content/os/v1.x/en/overview/_index.md
+++ b/content/os/v1.x/en/overview/_index.md
@@ -25,11 +25,11 @@ VMWare     | 1GB                       | 1280MB (rancheros.iso) <br> 2048MB (ran
 GCE        | 1GB                       | 1280MB
 AWS        | 1GB                       | 1.7GB
 
-You can adjust memory requirements by custom building RancherOS, please refer to [reduce-memory-requirements](https://rancher.com/docs/os/v1.x/en/installation/custom-builds/custom-rancheros-iso/#reduce-memory-requirements)
+You can adjust memory requirements by custom building RancherOS, please refer to [reduce-memory-requirements]({{< baseurl >}}/os/v1.x/en/installation/custom-builds/custom-rancheros-iso/#reduce-memory-requirements)
 
 ### How RancherOS Works
 
-Everything in RancherOS is a Docker container. We accomplish this by launching two instances of Docker. One is what we call **System Docker** and is the first process on the system. All other system services, like `ntpd`, `syslog`, and `console`, are running in Docker containers. System Docker replaces traditional init systems like `systemd` and is used to launch [additional system services](https://rancher.com/docs/os/v1.x/en/installation/system-services/adding-system-services/).
+Everything in RancherOS is a Docker container. We accomplish this by launching two instances of Docker. One is what we call **System Docker** and is the first process on the system. All other system services, like `ntpd`, `syslog`, and `console`, are running in Docker containers. System Docker replaces traditional init systems like `systemd` and is used to launch [additional system services]({{< baseurl >}}/os/v1.x/en/installation/system-services/adding-system-services/).
 
 System Docker runs a special container called **Docker**, which is another Docker daemon responsible for managing all of the user’s containers. Any containers that you launch as a user from the console will run inside this Docker. This creates isolation from the System Docker containers and ensures that normal user commands don’t impact system services.
 
@@ -39,7 +39,7 @@ System Docker runs a special container called **Docker**, which is another Docke
 
 ### Running RancherOS
 
-To get started with RancherOS, head over to our [Quick Start Guide](https://rancher.com/docs/os/v1.x/en/quick-start-guide/).
+To get started with RancherOS, head over to our [Quick Start Guide]({{< baseurl >}}/os/v1.x/en/quick-start-guide/).
 
 ### Latest Release
 


### PR DESCRIPTION
Updated URL that was redirecting to the Docker user guide and fixed broken links to adding system services, the quick start guide and the README.

I used absolute paths as it was formatting oddly and not working correctly for me. I'm not sure how the {{< baseurl >}} expression works in Markdown or if you are doing something else to get it pulled into your Rancher docs but feel free to do whatever you have to to get it working. I think what is happening is that you moved the files out of the overview directory and into different folders which would break the < base url > path directive.

Either way, perhaps it would be a good idea to implement checks to follow through the URLs to ensure they don't 404 as this is the first documentation that prospective users will see.