### PR TITLE
Added missing "=" while creating cluster-admin.

### DIFF
--- a/content/rancher/v2.x/en/installation/ha/helm-init/_index.md
+++ b/content/rancher/v2.x/en/installation/ha/helm-init/_index.md
@@ -22,7 +22,7 @@ Helm installs the `tiller` service on your cluster to manage charts. Since RKE e
 kubectl -n kube-system create serviceaccount tiller
 
 kubectl create clusterrolebinding tiller \
-  --clusterrole cluster-admin \
+  --clusterrole=cluster-admin \
   --serviceaccount=kube-system:tiller
 
 helm init --service-account tiller


### PR DESCRIPTION
The "=" was missing in this snip, after --clusterrole.  '--clusterrole cluster-admin \'
When the command is executed without = , the ntillre won't function properly. 
Refer https://stackoverflow.com/questions/54683563/helm-error-error-the-server-has-asked-for-the-client-to-provide-credentials