### PR TITLE
Interactive radio instead of CHART_REPO placeholders

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -47,7 +47,7 @@ pipeline:
       branch: master
       event: push
 
-  publish-algolia:
+  publish-latest-algolia:
     image: plugins/docker
     dockerfile: Dockerfile.algolia
     repo: rancher/docs

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -117,9 +117,27 @@ const bootstrapIdLinks = function() {
   });
 }
 
+const replaceReleaseChannel = function() {
+  const form = $('#release-channel')[0];
+  if ( form ) {
+    const val = form.channel.value;
+
+    $('CODE').each((idx, code) => {
+      const $code = $(code);
+      const text = $code.data('original') || code.innerHTML;
+
+      if ( text.includes('&lt;CHART_REPO&gt;') ) {
+        $code.data('original', text);
+        code.innerHTML = text.replace(/&lt;CHART_REPO&gt;/g, val);
+      }
+    });
+  }
+};
+
 $(document).ready(() => {
   bootstrapDocsSearch();
   bootstrapIdLinks();
+  replaceReleaseChannel();
 });
 
 

--- a/content/rancher/v2.x/en/installation/air-gap-high-availability/install-rancher/_index.md
+++ b/content/rancher/v2.x/en/installation/air-gap-high-availability/install-rancher/_index.md
@@ -18,12 +18,12 @@ From a system that has access to the internet, render the installs and copy the 
 
 2. Use `helm repo add` command to add the Helm chart repository that contains charts to install Rancher. For more information about the repository choices and which is best for your use case, see [Choosing a Version of Rancher]({{< baseurl >}}/rancher/v2.x/en/installation/server-tags/#helm-chart-repositories).
 
-    Replace both occurences of `<CHART_REPO>` with the Helm chart repository that you want to use (i.e. `latest` or `stable`).
-    
+    {{< release-channel >}}
+
     ```
     helm repo add rancher-<CHART_REPO> https://releases.rancher.com/server-charts/<CHART_REPO>
     ```
-3. Fetch the latest Rancher chart. This will pull down the chart and save it in the current directory as a `.tgz` file. Replace `<CHART_REPO>` with the repo you're using (`latest` or `stable`).
+3. Fetch the latest Rancher chart. This will pull down the chart and save it in the current directory as a `.tgz` file.
 
     ```plain
     helm fetch rancher-<CHART_REPO>/rancher

--- a/content/rancher/v2.x/en/installation/ha/helm-rancher/_index.md
+++ b/content/rancher/v2.x/en/installation/ha/helm-rancher/_index.md
@@ -11,7 +11,7 @@ Rancher installation is managed using the Helm package manager for Kubernetes.  
 
 Use `helm repo add` command to add the Helm chart repository that contains charts to install Rancher. For more information about the repository choices and which is best for your use case, see [Choosing a Version of Rancher]({{< baseurl >}}/rancher/v2.x/en/installation/server-tags/#helm-chart-repositories).
 
-Replace both occurences of `<CHART_REPO>` with the Helm chart repository that you want to use (i.e. `latest` or `stable`).
+{{< release-channel >}}
 
 ```
 helm repo add rancher-<CHART_REPO> https://releases.rancher.com/server-charts/<CHART_REPO>
@@ -65,7 +65,6 @@ deployment "cert-manager" successfully rolled out
 
 The default is for Rancher to generate a CA and uses `cert-manager` to issue the certificate for access to the Rancher server interface. Because `rancher` is the default option for `ingress.tls.source`, we are not specifying `ingress.tls.source` when running the `helm install` command.
 
-- Replace `<CHART_REPO>` with the repository that you configured in [Add the Helm Chart Repository](#add-the-helm-chart-repository) (i.e. `latest` or `stable`).
 - Set the `hostname` to the DNS name you pointed at your load balancer.
 
 ```
@@ -88,8 +87,6 @@ deployment "rancher" successfully rolled out
 > **Note:** You need to have [cert-manager](#optional-install-cert-manager) installed before proceeding.
 
 This option uses `cert-manager` to automatically request and renew [Let's Encrypt](https://letsencrypt.org/) certificates. This is a free service that provides you with a valid certificate as Let's Encrypt is a trusted CA. This configuration uses HTTP validation (`HTTP-01`) so the load balancer must have a public DNS record and be accessible from the internet.
-
-- Replace `<CHART_REPO>` with the repository that you configured in [Add the Helm Chart Repository](#add-the-helm-chart-repository) (i.e. `latest` or `stable`).
 
 - Set `hostname` to the public DNS record, set `ingress.tls.source` to `letsEncrypt` and `letsEncrypt.email` to the email address used for communication about your certificate (for example, expiry notices)
 
@@ -117,7 +114,6 @@ Create Kubernetes secrets from your own certificates for Rancher to use.
 
 > **Note:** The `Common Name` or a `Subject Alternative Names` entry in the server certificate must match the `hostname` option, or the ingress controller will fail to configure correctly. Although an entry in the `Subject Alternative Names` is technically required, having a matching `Common Name` maximizes compatibility with older browsers/applications. If you want to check if your certificates are correct, see [How do I check Common Name and Subject Alternative Names in my server certificate?]({{< baseurl >}}/rancher/v2.x/en/faq/technical/#how-do-i-check-common-name-and-subject-alternative-names-in-my-server-certificate)
 
-- Replace `<CHART_REPO>` with the repository that you configured in [Add the Helm Chart Repository](#add-the-helm-chart-repository) (i.e. `latest` or `stable`).
 - Set `hostname` and set `ingress.tls.source` to `secret`.
 - If you are using a Private CA signed certificate , add `--set privateCA=true` to the command shown below.
 

--- a/content/rancher/v2.x/en/installation/server-tags/_index.md
+++ b/content/rancher/v2.x/en/installation/server-tags/_index.md
@@ -66,6 +66,8 @@ After installing Rancher, if you want to change which Helm chart repository to i
 
 >**Note:** Because the rancher-alpha repository contains only alpha charts, switching between the rancher-alpha repository and the rancher-stable or rancher-latest repository for upgrades is not supported.
 
+{{< release-channel >}}
+
 1. List the current Helm chart repositories.
 
     ```
@@ -73,7 +75,7 @@ After installing Rancher, if you want to change which Helm chart repository to i
 
     NAME          	      URL
     stable        	      https://kubernetes-charts.storage.googleapis.com
-    rancher-<CHART_REPO>	https://releases.rancher.com/server-charts/<CHART_REPO>
+    rancher-<CHART_REPO>		https://releases.rancher.com/server-charts/<CHART_REPO>
     ```
 
 2. Remove the existing Helm Chart repository that contains your charts to install Rancher, which will either be `rancher-stable` or `rancher-latest` depending on what you had initially added.
@@ -82,7 +84,7 @@ After installing Rancher, if you want to change which Helm chart repository to i
     helm repo remove rancher-<CHART_REPO>
     ```
 
-3. Add the Helm chart repository that you want to start installing Rancher from. Replace `<CHART_REPO>` with the chart repository that you want to use (i.e. `latest` or `stable`).
+3. Add the Helm chart repository that you want to start installing Rancher from.
 
     ```
     helm repo add rancher-<CHART_REPO> https://releases.rancher.com/server-charts/<CHART_REPO>

--- a/content/rancher/v2.x/en/upgrades/upgrades/ha-server-upgrade-helm-airgap/_index.md
+++ b/content/rancher/v2.x/en/upgrades/upgrades/ha-server-upgrade-helm-airgap/_index.md
@@ -43,6 +43,8 @@ Upgrades _to_ or _from_ any chart in the  [rancher-alpha repository]({{< baseurl
 
     For information about the repos and their differences, see [Helm Chart Repositories]({{< baseurl >}}/rancher/v2.x/en/installation/server-tags/#helm-chart-repositories).
 
+    {{< release-channel >}}
+
     ```
     helm repo list
 
@@ -56,8 +58,7 @@ Upgrades _to_ or _from_ any chart in the  [rancher-alpha repository]({{< baseurl
 
 3. Fetch the latest chart to install Rancher from the Helm chart repository.
 
-    This command will pull down the latest chart and save it in the current directory as a `.tgz` file. Replace `<CHART_REPO>` with the name of the repository name that was listed (i.e. `latest` or `stable`).
-
+    This command will pull down the latest chart and save it in the current directory as a `.tgz` file.
 
     ```plain
     helm fetch rancher-<CHART_REPO>/rancher

--- a/content/rancher/v2.x/en/upgrades/upgrades/ha-server-upgrade-helm/_index.md
+++ b/content/rancher/v2.x/en/upgrades/upgrades/ha-server-upgrade-helm/_index.md
@@ -54,6 +54,8 @@ Upgrades _to_ or _from_ any chart in the  [rancher-alpha repository]({{< baseurl
 
     For information about the repos and their differences, see [Helm Chart Repositories]({{< baseurl >}}/rancher/v2.x/en/installation/server-tags/#helm-chart-repositories).
 
+    {{< release-channel >}}
+
     ```
     helm repo list
 
@@ -76,7 +78,6 @@ Upgrades _to_ or _from_ any chart in the  [rancher-alpha repository]({{< baseurl
 
 4. Upgrade Rancher to the latest version based on values from the previous steps.
 
-    - Replace `<CHART_REPO>` with the repository that was listed (i.e. `latest` or `stable`).
     - Take all the values from the previous step and append them to the command using `--set key=value`.
 
     ```

--- a/layouts/shortcodes/release-channel.html
+++ b/layouts/shortcodes/release-channel.html
@@ -1,0 +1,22 @@
+<form id="release-channel">
+  <p>
+    <label>
+      <input type="radio" name="channel" value="latest" checked onchange="replaceReleaseChannel()">
+      Latest: Recommended for trying out the newest features
+    </label>
+  </p>
+  <p>
+    <label>
+      <input type="radio" name="channel" value="stable" onchange="replaceReleaseChannel()">
+      Stable: Recommended for production environments
+    </label>
+  </p>
+  <p>
+    <label>
+      <input type="radio" name="channel" value="alpha" onchange="replaceReleaseChannel()">
+      Alpha: Experimental preview of upcoming releases.
+      <br/>
+      <span class="text-sm">Note: Upgrades are not supported to, from, or between Alphas.</span>
+    </label>
+  </p>
+</form>


### PR DESCRIPTION
This adds a shortcode `{{< release-channel >}}` which when placed on a page adds a set of radio buttons to choose between latest/stable/alpha and then replaces all occurrences of `<CHART_REPO>` in code blocks with the selected channel.  So you can actually copy and paste the commands instead of infuriatingly manually replacing the token.

@lvuch You'll probably want to make it less ugly.

![image](https://user-images.githubusercontent.com/753917/52843134-69e44d80-30be-11e9-8458-5baea8e1f4c0.png)
