### PR TITLE
updated drone yaml for 1.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,60 +1,94 @@
 ---
-pipeline:
-  build:
-    # Do things
-    privileged: true
-    image: docker:stable-dind
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    commands:
-      - docker build --pull -f Dockerfile.prod .
-    when:
-      event: [pull_request]
+kind: pipeline
+name: default
 
-  publish-dev:
-    group: publish
-    image: plugins/docker
+platform:
+  os: linux
+  arch: amd64
+
+steps:
+- name: build
+  pull: always
+  image: plugins/docker
+  settings:
+    context: .
+    dockerfile: Dockerfile.prod
+    dry_run: true
+    repo: rancher/docs
+    tag: dev
+  when:
+    event:
+    - pull_request
+
+- name: publish-dev
+  pull: always
+  image: plugins/docker
+  settings:
+    context: .
     dockerfile: Dockerfile.dev
     repo: rancher/docs
-    context: .
     tag: dev
-    secrets: [docker_username, docker_password]
-    when:
-      branch: master
-      event: push
+    password:
+      from_secret: docker_password
+    username:
+      from_secret: docker_username
+  when:
+    branch:
+    - master
+    event:
+    - push
 
-  publish-staging:
-    group: publish
-    image: plugins/docker
+- name: publish-staging
+  pull: always
+  image: plugins/docker
+  settings:
+    context: .
     dockerfile: Dockerfile.staging
     repo: rancher/docs
-    context: .
     tag: staging
-    secrets: [docker_username, docker_password]
-    when:
-      branch: master
-      event: push
+    password:
+      from_secret: docker_password
+    username:
+      from_secret: docker_username
+  when:
+    branch:
+    - staging
+    event:
+    - push
 
-  publish-latest:
-    group: publish
-    image: plugins/docker
-    dockerfile: Dockerfile.prod
-    repo: rancher/docs
+- name: publish-latest
+  pull: always
+  image: plugins/docker
+  settings:
     context: .
+    dockerfile: Dockerfile.prod
+    group: publish
+    repo: rancher/docs
     tag: latest
-    secrets: [docker_username, docker_password]
-    when:
-      branch: master
-      event: push
+    password:
+      from_secret: docker_password
+    username:
+      from_secret: docker_username
+  when:
+    branch:
+    - master
+    event:
+    - push
 
-  publish-latest-algolia:
-    image: plugins/docker
+- name: publish-latest-algolia
+  pull: always
+  image: plugins/docker
+  settings:
+    context: .
     dockerfile: Dockerfile.algolia
     repo: rancher/docs
-    context: .
     tag: algolia
-    secrets: [docker_username, docker_password]
-    when:
-      branch: master
-      event: push
-
+    password:
+      from_secret: docker_password
+    username:
+      from_secret: docker_username
+  when:
+    branch:
+    - master
+    event:
+    - push

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,31 +1,40 @@
 ---
 kind: pipeline
-name: default
+name: pull-request
 
 platform:
   os: linux
   arch: amd64
 
 steps:
-- name: build
-  pull: always
+- name: test
+  pull: default
   image: plugins/docker
   settings:
     context: .
     dockerfile: Dockerfile.prod
     dry_run: true
     repo: rancher/docs
-    tag: dev
   when:
     event:
     - pull_request
 
+---
+kind: pipeline
+name: dev
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
 - name: publish-dev
-  pull: always
+  pull: default
   image: plugins/docker
   settings:
     context: .
     dockerfile: Dockerfile.dev
+    group: publish
     repo: rancher/docs
     tag: dev
     password:
@@ -38,12 +47,22 @@ steps:
     event:
     - push
 
+---
+kind: pipeline
+name: staging
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
 - name: publish-staging
-  pull: always
+  pull: default
   image: plugins/docker
   settings:
     context: .
     dockerfile: Dockerfile.staging
+    group: publish
     repo: rancher/docs
     tag: staging
     password:
@@ -56,8 +75,17 @@ steps:
     event:
     - push
 
+---
+kind: pipeline
+name: production
+
+platform:
+  os: linux
+  arch: amd64
+
+steps:
 - name: publish-latest
-  pull: always
+  pull: default
   image: plugins/docker
   settings:
     context: .
@@ -75,8 +103,8 @@ steps:
     event:
     - push
 
-- name: publish-latest-algolia
-  pull: always
+- name: publish-algolia
+  pull: default
   image: plugins/docker
   settings:
     context: .


### PR DESCRIPTION
Updated so that the PR build uses the docker plugin instead of the docker socket directly.

staging only builds on push events to the stage branch.