### PR TITLE
Add docs for RKE cluster user authentication

### DIFF
--- a/content/rancher/v2.x/en/cluster-provisioning/rke-clusters/options/_index.md
+++ b/content/rancher/v2.x/en/cluster-provisioning/rke-clusters/options/_index.md
@@ -30,7 +30,7 @@ From this section you can choose:
 
         In v2.0.0 - v2.0.4 and v2.0.6, this was the default option for these clusters was Canal with network isolation. With the network isolation automatically enabled, it prevented any pod communication between [projects]({{< baseurl >}}/rancher/v2.x/en/k8s-in-rancher/projects-and-namespaces/).
 
-        As of release v2.0.7, if you use Canal, you also have the option of using **Project Network Isolation**, which will enable or disable communication between pods in different [projects]({{< baseurl >}}/rancher/v2.x/en/k8s-in-rancher/projects-and-namespaces/).
+        As of v2.0.7, if you use Canal, you also have the option of using **Project Network Isolation**, which will enable or disable communication between pods in different [projects]({{< baseurl >}}/rancher/v2.x/en/k8s-in-rancher/projects-and-namespaces/).
 
         >**Attention Rancher v2.0.0 - v2.0.6 Users**
         >
@@ -52,7 +52,7 @@ From this section you can choose:
 
     >**Note:** If your cloud provider is not listed as an option, you will need to use the [config file option](#config-file) to use that cloud provider. Please reference the [RKE's cloud provider documentation]({{< baseurl >}}/rke/v0.1.x/en/config-options/cloud-providers/) on how to configure these other cloud providers.
 
-- Whether or not to allow the cluster to act as an _authorized cluster endpoint_. Enabling will allow users to directly access a Kubernetes API server in the cluster without requiring communication through Rancher server. Providing an FQDN and certificate will generate kubeconfig files which use those values for accessing the cluster behind a load balancer, otherwise node IP addresses and kubernetes API certs will be used. See the [kubeconfig documentation]({{< baseurl >}}/rancher/v2.x/en/k8s-in-rancher/kubeconfig/) for more information.
+- As of v2.2.0, whether or not to allow the cluster to act as an _authorized cluster endpoint_. Enabling will allow users to directly access the Kubernetes API server in the cluster without requiring communication through Rancher server. Providing an FQDN and certificate will generate kubeconfig files which use those values for accessing the cluster behind a load balancer, otherwise node IP addresses and Kubernetes API certificates will be used. See the [kubeconfig documentation]({{< baseurl >}}/rancher/v2.x/en/k8s-in-rancher/kubeconfig/) for more information.
 
 - Whether or not to use a [pod security policy]({{< baseurl >}}/rancher/v2.x/en/admin-settings/pod-security-policies). You must have an existing pod security policy configured before you can use this option.
 

--- a/content/rancher/v2.x/en/cluster-provisioning/rke-clusters/options/_index.md
+++ b/content/rancher/v2.x/en/cluster-provisioning/rke-clusters/options/_index.md
@@ -52,6 +52,8 @@ From this section you can choose:
 
     >**Note:** If your cloud provider is not listed as an option, you will need to use the [config file option](#config-file) to use that cloud provider. Please reference the [RKE's cloud provider documentation]({{< baseurl >}}/rke/v0.1.x/en/config-options/cloud-providers/) on how to configure these other cloud providers.
 
+- Whether or not to allow the cluster to act as an _authorized cluster endpoint_. Enabling will allow users to directly access a Kubernetes API server in the cluster without requiring communication through Rancher server. Providing an FQDN and certificate will generate kubeconfig files which use those values for accessing the cluster behind a load balancer, otherwise node IP addresses and kubernetes API certs will be used. See the [kubeconfig documentation]({{< baseurl >}}/rancher/v2.x/en/k8s-in-rancher/kubeconfig/) for more information.
+
 - Whether or not to use a [pod security policy]({{< baseurl >}}/rancher/v2.x/en/admin-settings/pod-security-policies). You must have an existing pod security policy configured before you can use this option.
 
 ## Config File

--- a/content/rancher/v2.x/en/k8s-in-rancher/kubeconfig/_index.md
+++ b/content/rancher/v2.x/en/k8s-in-rancher/kubeconfig/_index.md
@@ -19,3 +19,20 @@ For more information, see [Using kubectl to Access a Cluster]({{< baseurl >}}/ra
 >```
 kubectl --kubeconfig /custom/path/kube.config get pods
 ```
+
+Rancher generates kubeconfig files that by default proxy through Rancher server to connect to the Kubernetes API server on a cluster.
+
+For RKE clusters which are configured as _authorized cluster endpoints_ we will generate extra contexts in the kubeconfig file for connecting directly to a cluster.
+If an FQDN is defined for the cluster then a single extra context will be created, otherwise an extra context which points to the IP address of each node in the control plane will be created.
+Please examine the kubeconfig file for a complete list of available contexts.
+
+>Example of using the FQDN context for an RKE cluster:
+>```
+kubectl --context rke-fqdn api-resources
+```
+>or node context without FQDN defined:
+>```
+kubectl --context rke-node1 api-resources
+```
+
+See [Cluster Options for Provisioning RKE in Rancher]({{< baseurl >}}/rancher/v2.x/en/cluster-provisioning/rke-clusters/options/) and [RKE Config Options]({{< baseurl >}}/rke/v0.1.x/en/config-options/authentication/) for more information on user authentication in a cluster.

--- a/content/rancher/v2.x/en/k8s-in-rancher/kubeconfig/_index.md
+++ b/content/rancher/v2.x/en/k8s-in-rancher/kubeconfig/_index.md
@@ -30,8 +30,6 @@ For [Rancher Launched Kubernetes]({{< baseurl >}}/rancher/v2.x/en/cluster-provis
 
 To find the name of the context(s), view the kubeconfig file. 
 
-See [Cluster Options for Provisioning RKE in Rancher]({{< baseurl >}}/rancher/v2.x/en/cluster-provisioning/rke-clusters/options/) and [RKE Config Options]({{< baseurl >}}/rke/v0.1.x/en/config-options/authentication/) for more information on user authentication in a cluster.
-
 ### Clusters with FQDN defined as an Authorized Cluster Endpoint
 
 If an FQDN is defined for the cluster, a single context referencing the FQDN will be created. The context will be named `<CLUSTER_NAME>-fqdn`. When you want to use `kubectl` to access this cluster without Rancher, you will need to use this context. 

--- a/content/rancher/v2.x/en/k8s-in-rancher/kubeconfig/_index.md
+++ b/content/rancher/v2.x/en/k8s-in-rancher/kubeconfig/_index.md
@@ -15,24 +15,43 @@ This kubeconfig file and its contents are specific to the cluster you are viewin
 
 For more information, see [Using kubectl to Access a Cluster]({{< baseurl >}}/rancher/v2.x/en//k8s-in-rancher/kubectl).
 
->**Note:** By default, kubectl checks `~/.kube/config` for kubeconfig files, but you can use any directory you want using the `--kubeconfig` flag. For example:
+>**Note:** By default, kubectl checks `~/.kube/config` for a kubeconfig file, but you can use any directory you want using the `--kubeconfig` flag. For example:
 >```
-kubectl --kubeconfig /custom/path/kube.config get pods
-```
-
-Rancher generates kubeconfig files that by default proxy through Rancher server to connect to the Kubernetes API server on a cluster.
-
-For RKE clusters which are configured as _authorized cluster endpoints_ we will generate extra contexts in the kubeconfig file for connecting directly to a cluster.
-If an FQDN is defined for the cluster then a single extra context will be created, otherwise an extra context which points to the IP address of each node in the control plane will be created.
-Please examine the kubeconfig file for a complete list of available contexts.
-
->Example of using the FQDN context for an RKE cluster:
+>kubectl --kubeconfig /custom/path/kube.config get pods
 >```
-kubectl --context rke-fqdn api-resources
-```
->or node context without FQDN defined:
->```
-kubectl --context rke-node1 api-resources
-```
+
+## Accessing Rancher Launched Kubernetes clusters without Rancher server running
+
+By default, Rancher generates a kubeconfig file that will proxy through the Rancher server to connect to the Kubernetes API server on a cluster.
+
+For [Rancher Launched Kubernetes]({{< baseurl >}}/rancher/v2.x/en/cluster-provisioning/rke-clusters) clusters, which have  _[authorized cluster endpoints]({{< baseurl >}}/rancher/v2.x/en/cluster-provisioning/rke-clusters/options)_ enabled, Rancher generates extra context(s) in the kubeconfig file in order to connect directly to the cluster. 
+
+> **Note:** By default, all Rancher Launched Kubernetes clusters are enabled as _[authorized cluster endpoints]({{< baseurl >}}/rancher/v2.x/en/cluster-provisioning/rke-clusters/options)_. 
+
+To find the name of the context(s), view the kubeconfig file. 
 
 See [Cluster Options for Provisioning RKE in Rancher]({{< baseurl >}}/rancher/v2.x/en/cluster-provisioning/rke-clusters/options/) and [RKE Config Options]({{< baseurl >}}/rke/v0.1.x/en/config-options/authentication/) for more information on user authentication in a cluster.
+
+### Clusters with FQDN defined as an Authorized Cluster Endpoint
+
+If an FQDN is defined for the cluster, a single context referencing the FQDN will be created. The context will be named `<CLUSTER_NAME>-fqdn`. When you want to use `kubectl` to access this cluster without Rancher, you will need to use this context. 
+
+```
+# Assuming the kubeconfig file is located at ~/.kube/config
+kubectl --context <CLUSTER_NAME>-fqdn get nodes
+
+# Directly referencing the location of the kubeconfig file
+kubectl --kubeconfig /custom/path/kube.config --context <CLUSTER_NAME>-fqdn get pods
+```
+
+### Clusters without FQDN defined as an Authorized Cluster Endpoint
+
+If there is no FQDN defined for the cluster, extra contexts will be created referencing the IP address of each node in the control plane. Each context will be named `<CLUSTER_NAME>-<NODE_NAME>`. When you want to use `kubectl` to access this cluster without Rancher, you will need to use this context. 
+
+```
+# Assuming the kubeconfig file is located at ~/.kube/config
+kubectl --context <CLUSTER_NAME>-<NODE_NAME> get nodes
+
+# Directly referencing the location of the kubeconfig file
+kubectl --kubeconfig /custom/path/kube.config --context <CLUSTER_NAME>-<NODE_NAME> get pods
+```

--- a/content/rancher/v2.x/en/k8s-in-rancher/kubectl/_index.md
+++ b/content/rancher/v2.x/en/k8s-in-rancher/kubectl/_index.md
@@ -47,4 +47,6 @@ Alternatively, you can access your clusters by installing kubectl on your workst
         ```
 4. From your workstation, launch kubectl. Use it to interact with your kubernetes cluster.
 
+     For information on using cluster contexts, see [Kubeconfig Files]({{< baseurl >}}/rancher/v2.x/en//k8s-in-rancher/kubeconfig).
+
      For more information on using kubectl, see [Kubernetes Documentation: Overview of kubectl](https://kubernetes.io/docs/reference/kubectl/overview/).

--- a/content/rancher/v2.x/en/k8s-in-rancher/kubectl/_index.md
+++ b/content/rancher/v2.x/en/k8s-in-rancher/kubectl/_index.md
@@ -47,6 +47,6 @@ Alternatively, you can access your clusters by installing kubectl on your workst
         ```
 4. From your workstation, launch kubectl. Use it to interact with your kubernetes cluster.
 
-     For information on using cluster contexts, see [Kubeconfig Files]({{< baseurl >}}/rancher/v2.x/en//k8s-in-rancher/kubeconfig).
+     If you have launched a [Rancher Launched Kubernetes cluster]({{< baseurl >}}/rancher/v2.x/en/cluster-provisioning/rke-clusters) and want to use kubectl without using Rancher, see [Kubeconfig Files]({{< baseurl >}}/rancher/v2.x/en/k8s-in-rancher/kubeconfig/).
 
      For more information on using kubectl, see [Kubernetes Documentation: Overview of kubectl](https://kubernetes.io/docs/reference/kubectl/overview/).

--- a/content/rke/v0.1.x/en/config-options/authentication/_index.md
+++ b/content/rke/v0.1.x/en/config-options/authentication/_index.md
@@ -14,6 +14,7 @@ authentication:
 ```
 
 RKE also supports the webhook authentication strategy. You can enable both x509 and webhook strategies by using a `|` separator in the configuration. Contents of the webhook config file should be provided, see [Kubernetes webhook documentation](https://kubernetes.io/docs/reference/access-authn-authz/webhook/) for information on the file format. Additionally, a cache timeout for webhook authentication responses can be set.
+
 ```yaml
 authentication:
     strategy: x509|webhook

--- a/content/rke/v0.1.x/en/config-options/authentication/_index.md
+++ b/content/rke/v0.1.x/en/config-options/authentication/_index.md
@@ -12,3 +12,12 @@ authentication:
       - "10.18.160.10"
       - "my-loadbalancer-1234567890.us-west-2.elb.amazonaws.com"
 ```
+
+RKE also supports the webhook authentication strategy. You can enable both x509 and webhook strategies by using a `|` separator in the configuration. Contents of the webhook config file should be provided, see [Kubernetes webhook documentation](https://kubernetes.io/docs/reference/access-authn-authz/webhook/) for information on the file format. Additionally, a cache timeout for webhook authentication responses can be set.
+```yaml
+authentication:
+    strategy: x509|webhook
+    webhook:
+      config_file: "...."
+      cache_timeout: 5s
+```


### PR DESCRIPTION
Information on configuring RKE authn webhooks, provisioning RKE
clusters as authorized cluster endpoints, and using kubeconfig contexts
for connecting directly to a cluster.

For rancher/docs/issues/1010