### PR TITLE
Update Catalogs to reflect nav-bar UI changes in rancher/rancher#18847

### DIFF
--- a/content/rancher/v2.x/en/catalog/_index.md
+++ b/content/rancher/v2.x/en/catalog/_index.md
@@ -23,7 +23,8 @@ Rancher improves on Helm catalogs and charts. All native Helm charts can work wi
 
 Within Rancher, there are default catalogs packaged as part of Rancher. These can be enabled or disabled by an administrator.
 
-1. From the **Global** view, choose **Catalogs** from the main menu.
+1. From the **Global** view, choose **Catalogs** from the Tools menu.
+>**Note:** In Rancher 2.0 and 2.1 choose **Catalogs** from the main menu.
 2. Toggle the default catalogs that you want use to a setting of **Enabled**.
 
     - **Library**
@@ -40,7 +41,8 @@ Within Rancher, there are default catalogs packaged as part of Rancher. These ca
 
     	Similar in user experience to Helm Stable, but this catalog is filled with applications in **beta**.
 
- **Result**: The chosen catalogs are enabled. Wait a few minutes for Rancher to replicate the catalog charts. When replication completes, you'll be able to see them in any of your projects by selecting **Catalog Apps** from the main menu.
+ **Result**: The chosen catalogs are enabled. Wait a few minutes for Rancher to replicate the catalog charts. When replication completes, you'll be able to see them in any of your projects by selecting **Apps** from the main menu.
+>**Note:** In Rancher 2.0 and 2.1 select **Catalogs Apps* from the main menu.
 
 ## Adding Custom Catalogs
 
@@ -61,7 +63,8 @@ An [admin]({{< baseurl >}}/rancher/v2.x/en/admin-settings/#global-Permissions) o
 NEEDS TO BE FIXED FOR 2.0: Any [users]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/configuration/accounts/#account-types) of a Rancher environment has the ability to add or remove environment catalogs in their respective Rancher environment in **Catalog** -> **Manage**.
  -->
 
- 1. From the **Global** view, choose **Catalogs** from the main menu.
+ 1. From the **Global** view, choose **Catalogs** from the Tools menu.
+>**Note:** In Rancher 2.0 and 2.1 choose **Catalogs** from the main menu.
  2. Click **Add Catalog**.
  3. Complete the form and click **Create**.
 
@@ -73,7 +76,8 @@ After you've either enabled the built-in catalogs or added your own custom catal
 
 1. From the **Global** view, open the project that you want to deploy to.
 
-2. From the main menu, choose **Catalog Apps**. Then click **Launch**.
+2. From the main menu, choose **Apps**. Then click **Launch**.
+>**Note:** In Rancher 2.0 and 2.1 choose **Catalog Apps** from the main menu, then click **Launch**.
 
 3. Find the app that you want to launch, and then click **View Now**.
 
@@ -97,7 +101,7 @@ After you've either enabled the built-in catalogs or added your own custom catal
 **Result**: Your application is deployed to your chosen namespace. You can view the application status from the project's:
 
 - **Workloads** view
-- **Catalog Apps** view
+- **Apps** view (**Catalog Apps** view in Rancher 2.0 and 2.1)
 
 ## Deleting Catalog Application Deployments
 

--- a/content/rancher/v2.x/en/catalog/_index.md
+++ b/content/rancher/v2.x/en/catalog/_index.md
@@ -23,8 +23,14 @@ Rancher improves on Helm catalogs and charts. All native Helm charts can work wi
 
 Within Rancher, there are default catalogs packaged as part of Rancher. These can be enabled or disabled by an administrator.
 
+>**Note:**
+>
+>- As of Rancher 2.2 from the Global, Cluster, and Project view, Catalogs have moved from the main menu bar to the Tools menu. Additionally, from the Project view Catalog Apps have been renamed to Apps on the main menu.
+>
+<br/>
+
 1. From the **Global** view, choose **Catalogs** from the Tools menu.
->**Note:** In Rancher 2.0 and 2.1 choose **Catalogs** from the main menu.
+
 2. Toggle the default catalogs that you want use to a setting of **Enabled**.
 
     - **Library**
@@ -42,7 +48,6 @@ Within Rancher, there are default catalogs packaged as part of Rancher. These ca
     	Similar in user experience to Helm Stable, but this catalog is filled with applications in **beta**.
 
  **Result**: The chosen catalogs are enabled. Wait a few minutes for Rancher to replicate the catalog charts. When replication completes, you'll be able to see them in any of your projects by selecting **Apps** from the main menu.
->**Note:** In Rancher 2.0 and 2.1 select **Catalogs Apps* from the main menu.
 
 ## Adding Custom Catalogs
 
@@ -53,6 +58,8 @@ Adding a catalog is as simple as adding a catalog name, a URL and a branch name.
 >- Currently, you can only add custom catalogs to Rancher at the global level. Therefore, any catalog that you add is shared with all clusters and projects.
 >
 >- Currently, only unauthenticated catalogs are supported.
+>
+>- As of Rancher 2.2 from the Global, Cluster, and Project view, Catalogs have moved from the main menu bar to the Tools menu.
 <br/>
 <br/>
 
@@ -64,7 +71,6 @@ NEEDS TO BE FIXED FOR 2.0: Any [users]({{site.baseurl}}/rancher/{{page.version}}
  -->
 
  1. From the **Global** view, choose **Catalogs** from the Tools menu.
->**Note:** In Rancher 2.0 and 2.1 choose **Catalogs** from the main menu.
  2. Click **Add Catalog**.
  3. Complete the form and click **Create**.
 
@@ -74,10 +80,15 @@ NEEDS TO BE FIXED FOR 2.0: Any [users]({{site.baseurl}}/rancher/{{page.version}}
 
 After you've either enabled the built-in catalogs or added your own custom catalog, you can start launching any catalog application.
 
+>**Note:**
+>
+>- As of Rancher 2.2 from the Project view Catalog Apps have been renamed to Apps on the main menu.
+>
+<br/>
+
 1. From the **Global** view, open the project that you want to deploy to.
 
 2. From the main menu, choose **Apps**. Then click **Launch**.
->**Note:** In Rancher 2.0 and 2.1 choose **Catalog Apps** from the main menu, then click **Launch**.
 
 3. Find the app that you want to launch, and then click **View Now**.
 
@@ -101,7 +112,7 @@ After you've either enabled the built-in catalogs or added your own custom catal
 **Result**: Your application is deployed to your chosen namespace. You can view the application status from the project's:
 
 - **Workloads** view
-- **Apps** view (**Catalog Apps** view in Rancher 2.0 and 2.1)
+- **Apps** view
 
 ## Deleting Catalog Application Deployments
 

--- a/content/rancher/v2.x/en/catalog/_index.md
+++ b/content/rancher/v2.x/en/catalog/_index.md
@@ -23,13 +23,7 @@ Rancher improves on Helm catalogs and charts. All native Helm charts can work wi
 
 Within Rancher, there are default catalogs packaged as part of Rancher. These can be enabled or disabled by an administrator.
 
->**Note:**
->
->- As of Rancher 2.2 from the Global, Cluster, and Project view, Catalogs have moved from the main menu bar to the Tools menu. Additionally, from the Project view Catalog Apps have been renamed to Apps on the main menu.
->
-<br/>
-
-1. From the **Global** view, choose **Catalogs** from the Tools menu.
+1. From the **Global** view, choose **Tools > Catalogs** in the navigation bar. In versions prior to v2.2.0, you can select **Catalogs** directly in the navigation bar.
 
 2. Toggle the default catalogs that you want use to a setting of **Enabled**.
 
@@ -47,7 +41,7 @@ Within Rancher, there are default catalogs packaged as part of Rancher. These ca
 
     	Similar in user experience to Helm Stable, but this catalog is filled with applications in **beta**.
 
- **Result**: The chosen catalogs are enabled. Wait a few minutes for Rancher to replicate the catalog charts. When replication completes, you'll be able to see them in any of your projects by selecting **Apps** from the main menu.
+ **Result**: The chosen catalogs are enabled. Wait a few minutes for Rancher to replicate the catalog charts. When replication completes, you'll be able to see them in any of your projects by selecting **Apps** from the main navigation bar. In versions prior to v2.2.0, you can select **Catalog Apps** from the main navigation bar.
 
 ## Adding Custom Catalogs
 
@@ -58,8 +52,6 @@ Adding a catalog is as simple as adding a catalog name, a URL and a branch name.
 >- Currently, you can only add custom catalogs to Rancher at the global level. Therefore, any catalog that you add is shared with all clusters and projects.
 >
 >- Currently, only unauthenticated catalogs are supported.
->
->- As of Rancher 2.2 from the Global, Cluster, and Project view, Catalogs have moved from the main menu bar to the Tools menu.
 <br/>
 <br/>
 
@@ -70,7 +62,7 @@ An [admin]({{< baseurl >}}/rancher/v2.x/en/admin-settings/#global-Permissions) o
 NEEDS TO BE FIXED FOR 2.0: Any [users]({{site.baseurl}}/rancher/{{page.version}}/{{page.lang}}/configuration/accounts/#account-types) of a Rancher environment has the ability to add or remove environment catalogs in their respective Rancher environment in **Catalog** -> **Manage**.
  -->
 
- 1. From the **Global** view, choose **Catalogs** from the Tools menu.
+ 1. From the **Global** view, choose **Tools > Catalogs** in the navigation bar. In versions prior to v2.2.0, you can select **Catalogs** directly in the navigation bar.
  2. Click **Add Catalog**.
  3. Complete the form and click **Create**.
 
@@ -78,17 +70,11 @@ NEEDS TO BE FIXED FOR 2.0: Any [users]({{site.baseurl}}/rancher/{{page.version}}
 
 ## Launching Catalog Applications
 
-After you've either enabled the built-in catalogs or added your own custom catalog, you can start launching any catalog application.
-
->**Note:**
->
->- As of Rancher 2.2 from the Project view Catalog Apps have been renamed to Apps on the main menu.
->
-<br/>
+After you've either enabled the built-in catalogs or added your own custom catalog, you can start launching any catalog application.>
 
 1. From the **Global** view, open the project that you want to deploy to.
 
-2. From the main menu, choose **Apps**. Then click **Launch**.
+2. From the main navigation bar, choose **Apps**. In versions prior to v2.2.0, choose **Catalog Apps** on the main navigation bar. Click **Launch**.
 
 3. Find the app that you want to launch, and then click **View Now**.
 
@@ -112,7 +98,7 @@ After you've either enabled the built-in catalogs or added your own custom catal
 **Result**: Your application is deployed to your chosen namespace. You can view the application status from the project's:
 
 - **Workloads** view
-- **Apps** view
+- **Apps** view (In versions prior to v2.2.0, this is the **Catalog Apps** view).
 
 ## Deleting Catalog Application Deployments
 


### PR DESCRIPTION
Resolves #1246 
Related rancher/rancher issue: https://github.com/rancher/rancher/issues/18847

Updates Catalogs guide to mention the changes in Rancher 2.2 regarding nav changes for Catalogs and rename of Catalog Apps to Apps. There is no need to update child "custom" guide in the catalogs directory.

NOTE: other changes incoming for MCAPP / catalog scope still need to occur this only is for nav changes per the #1246 issue.