### PR TITLE
Pipeline changes

### DIFF
--- a/content/rancher/v2.x/en/k8s-in-rancher/pipelines/_index.md
+++ b/content/rancher/v2.x/en/k8s-in-rancher/pipelines/_index.md
@@ -45,7 +45,7 @@ After the version control provider is authorized, you are automatically re-direc
 
 1. Click on **Configure Repositories**.
 
-1. A list of repositories are displayed. The list of repositories displayed are based on the [user that set up the version control provider]({{< baseurl >}}/rancher/v2.x/en/project-admin/tools/pipelines/#version-control-providers).
+1. A list of repositories are displayed. If you are configuring repositories the first time, click on **Authorize & Fetch Your Own Repositories** to fetch your repository list.
 
 1. For each repository that you want to set up a pipeline, click on **Enable**.
 
@@ -68,36 +68,7 @@ Now that repositories are added to your project, you can start configuring the p
 
     >**Note:** When editing the pipeline configuration, it takes a few moments for Rancher to check for an existing pipeline configuration.
 
-1. Select which `branch` to use from the repository.
-
-    {{% accordion id="branch" label="Branch Selection" %}}
-{{% tabs %}}
-{{% tab "By UI" %}}
-<br>
-Select the **branch** from the list of branches.
-<br>
-<br>
-{{% /tab %}}
-{{% tab "By YAML" %}}
-<br>
-You are required to include a branch in order for the pipeline to work.
-
-```yaml
-stages:
-  - name: Build something
-    steps:
-    - runScriptConfig:
-        image: busybox
-        shellScript: ls
-# branch conditions for the pipeline
-branch:
-  include: [ master, feature/*]
-  exclude: [ dev ]
-```
-<br>
-{{% /tab %}}
-{{% /tabs %}}
-    {{% /accordion %}}
+1. Select which `branch` to use from the list of branches.
 
 1. Pipeline configuration is split into stages and [steps](#step-types). Remember that stages must fully complete before moving onto the next stage, but steps in a stage run concurrently.
 
@@ -527,6 +498,18 @@ Within a pipeline, there are multiple advanced options for different parts of th
 
 When a repository is enabled, a webhook for it is automatically set in the version control system. By default, the project pipeline is triggered by a push event to a specific repository, but you can add (or change) events that trigger a build, such as a pull request or a tagging. When an event type is disabled, pipeline executions will not be triggered by the wehook of that event type.
 
+To change event triggers for a repository:
+
+1. From the **Global** view, navigate to the project that you want to configure pipelines.
+
+1. Select **Workloads** in the navigation bar and then select the Pipelines tab.
+
+1. From the repository for which you want to change the event triggers, select **Ellipsis (...) > Setting**.
+
+1. Click on the check box to enable/disable triggering for **Push**, **Pull Request** or **Tag** event.
+
+1. Click **Save**.
+
 You can also set trigger rules to have fine-grained control of pipeline executions in pipeline configurations. Trigger rules come in two types:
 
 - **Run this when:**
@@ -680,7 +663,7 @@ stages:
 
 If you need to use security-sensitive information in your pipeline scripts (like a password), you can pass them in using Kubernetes [secrets]({{< baseurl >}}/rancher/v2.x/en/k8s-in-rancher/secrets/).
 
->**Prerequisite:** Create a secret in the same project as your pipeline.
+>**Prerequisite:** Create a secret in the same project as your pipeline, or explicitly in the namespace where pipeline build pods run.
 
 >**Note:** Secret injection is disabled on pull request events.
 

--- a/content/rancher/v2.x/en/project-admin/tools/pipelines/_index.md
+++ b/content/rancher/v2.x/en/project-admin/tools/pipelines/_index.md
@@ -70,13 +70,13 @@ After you configure a pipeline, you can trigger it using different methods:
 
 - **Manually:**
 
-    After you configure a pipeline, you can trigger a build using the latest CI definition from either Rancher UI or Git CLI.  When a pipeline execution is triggered, Rancher dynamically provisions a Kubernetes pod to run your CI tasks and then remove it upon completion.
+    After you configure a pipeline, you can trigger a build using the latest CI definition from Rancher UI. When a pipeline execution is triggered, Rancher dynamically provisions a Kubernetes pod to run your CI tasks and then remove it upon completion.
 
 - **Automatically:**
 
     When you enable a repository for a pipeline, webhooks are automatically added to the version control system. When project users interact with the repo—push code, open pull requests, or create a tag—the version control system sends a webhook to Rancher Server, triggering a pipeline execution.
 
-    To use this automation, webhook management permission is required for the repository. Therefore, when users authenticate and fetch their repositories, only those on which they have admin permission will be shown.
+    To use this automation, webhook management permission is required for the repository. Therefore, when users authenticate and fetch their repositories, only those on which they have webhook management permission will be shown.
 
 ## Version Control Providers
 


### PR DESCRIPTION
Changes include:   
1. Repo list is based on the current user, not the project owner that enables project pipeline.
2. Branch selection(both UI/yaml) is to determine where the pipeline file locates, and is different from the branch conditions in pipeline files.
3. Add missing event trigger configuration for a repository.
4. Secrets can be in the pipeline namespace so that the distribution scope is smaller.
5. A manual run is done by UI, the Git CLI way is included in the webhook triggered runs.
6. Change the word `admin permission` to more generic `webhook management permission`, since `admin` is specific to Github.