### PR TITLE
'Use Catalog Templates', not 'User Catalog Templates'

### DIFF
--- a/content/rancher/v2.x/en/admin-settings/rbac/global-permissions/_index.md
+++ b/content/rancher/v2.x/en/admin-settings/rbac/global-permissions/_index.md
@@ -49,7 +49,7 @@ The following table lists each custom global permission available and whether it
 | Manage Roles                       | ✓             |               |
 | Manage Users                       | ✓             |               |
 | Create Clusters                    | ✓             | ✓             |
-| User Catalog Templates             | ✓             | ✓             |
+| Use Catalog Templates             | ✓             | ✓             |
 | Login Access                       | ✓             | ✓             |
 
 > **Notes:** 


### PR DESCRIPTION
Pretty sure this is a typo. There's a big difference between 'Use Catalog Templates' and 'User Catalog Templates', so it would be good for someone to validate this.

Here's a snapshot from the UI, which says 'Use Catalog Templates':

![image](https://user-images.githubusercontent.com/142752/56059818-e63f8980-5d19-11e9-905c-3bac991cfc30.png)
