### PR TITLE
Improve PassRole IAM example

### DIFF
--- a/content/rancher/v2.x/en/cluster-provisioning/rke-clusters/node-pools/ec2/_index.md
+++ b/content/rancher/v2.x/en/cluster-provisioning/rke-clusters/node-pools/ec2/_index.md
@@ -140,7 +140,7 @@ Use {{< product >}} to create a Kubernetes cluster in Amazon EC2.
                 "arn:aws:ec2:REGION:AWS_ACCOUNT_ID:key-pair/*",
                 "arn:aws:ec2:REGION:AWS_ACCOUNT_ID:network-interface/*",
                 "arn:aws:ec2:REGION:AWS_ACCOUNT_ID:security-group/*",
-                "arn:aws:iam::AWS_ACCOUNT_ID:role/your-role-name"
+                "arn:aws:iam::AWS_ACCOUNT_ID:role/YOUR_ROLE_NAME"
             ]
         },
         {


### PR DESCRIPTION
Make it more obvious that role name in PassRole IAM example needs the role name replaced by capitalizing the spot