### PR TITLE
Update the example to backup to use the correct tag

### DIFF
--- a/content/rancher/v2.x/en/upgrades/upgrades/single-node-upgrade/_index.md
+++ b/content/rancher/v2.x/en/upgrades/upgrades/single-node-upgrade/_index.md
@@ -12,7 +12,7 @@ During upgrade, you'll enter a series of commands, filling placeholders with dat
 
 
 ```
-docker run  --volumes-from rancher-data -v $PWD:/backup alpine tar zcvf /backup/rancher-data-backup-<RANCHER_VERSION>-<DATE>.tar.gz /var/lib/rancher
+docker run  --volumes-from <RANCHER_CONTAINER_TAG> -v $PWD:/backup alpine tar zcvf /backup/rancher-data-backup-<RANCHER_VERSION>-<DATE>.tar.gz /var/lib/rancher
 ```
 
 In this command, `<RANCHER_VERSION>-<DATE>` is the the version number and date of creation for a backup of Rancher.


### PR DESCRIPTION
The documentation states to use `<RANCHER_CONTAINER_TAG>` but the example has `rancher-data` as the container tag which would result most likely in something like `docker: Error response from daemon: No such container: rancher-data.`. 

So replaced `rancher-data` with `<RANCHER_CONTAINER_TAG>` to make consistent with the existing documentation.