### PR TITLE
Correct kubernetes system logs path

### DIFF
--- a/content/rancher/v2.x/en/cluster-admin/tools/logging/_index.md
+++ b/content/rancher/v2.x/en/cluster-admin/tools/logging/_index.md
@@ -46,7 +46,7 @@ You can configure logging at either cluster level or project level.
 Logs that are sent to your logging service are from the following locations:
 
   - Pod logs stored at `/var/log/containers`.
-  - Kubernetes system components logs stored at `/var/lib/rancher/rke/logs/`.
+  - Kubernetes system components logs stored at `/var/lib/rancher/rke/log/`.
 
 ## Enabling Cluster Logging
 


### PR DESCRIPTION
It appears as though the correct directory name for logs is singular **log**, running off of:

rancher/hyperkube:v1.13.5-rancher1
rancher/rke-tools:v0.1.27

```
ls /var/lib/rancher/rke/log
kube-proxy_fc2898322d73c7b65f134bc1ee51df8c5495d30e8dc62ff317b715c48e34b0cf.log
kubelet_56cba883a56640a0237068b10d6fbc2097087e1192d8fdec4baa1a667102f618.log
nginx-proxy_1c6005498a4895db4381e8b86fcff4ee45d728967d68379424c3a2fafed96e12.log
service-sidekick_96eb3ac5f5145022e717c8664aa2b1d964e7b44188412eeb017ea15e26d1adff.log
```