### PR TITLE
Edit of Windows Cluster Configuration

### DIFF
--- a/content/rancher/v2.x/en/cluster-provisioning/rke-clusters/windows-clusters/_index.md
+++ b/content/rancher/v2.x/en/cluster-provisioning/rke-clusters/windows-clusters/_index.md
@@ -11,18 +11,22 @@ _Available as of v2.3.0-alpha1_
 
 When provisioning a [custom cluster]({{< baseurl >}}/rancher/v2.x/en/cluster-provisioning/custom-clusters/) using Rancher, you can use a mix of Linux and Windows hosts as your cluster nodes.
 
-This guide walks you through create of a custom cluster that includes 3 nodes: a Linux node, which serves as a Kubernetes control plane node; another Linux node, which serves as a Kubernetes worker used to support Rancher Cluster agent, Metrics server, DNS and Ingress for the cluster; and a Windows node, which is assigned the Kubernetes worker role and runs your Windows containers.
+This guide walks you through the creation of a custom cluster that includes three nodes. 
+
+- 1. A Linux node, which serves as a Kubernetes control plane node. 
+- 2. Another Linux node, which serves as a Kubernetes worker used to support Rancher Cluster agent, Metrics server, DNS and Ingress for the cluster. 
+- 3. A Windows node, which is assigned the Kubernetes worker role and runs your Windows containers.
 
 >**Notes:**
 >
 >- For a summary of Kubernetes features supported in Windows, see [Using Windows Server Containers in Kubernetes](https://kubernetes.io/docs/getting-started-guides/windows/#supported-features).
->- Windows worker adding script must run on Windows Server 2019 (core version 1809 or above) hosts. Core version 1803 and earlier versions do not support Kubernetes properly.
+>- The script to add a Windows worker must be ran on Windows Server 2019 (core version 1809 or above) hosts. Core version 1803 and earlier versions do not support Kubernetes properly.
 >- Containers built for Windows Server 1803 or earlier do not run on Windows Server 2019. You must build containers on Windows Server 2019 to run these containers on Windows Server 2019.
 >- Windows Overlay networking requires [KB4489899](https://support.microsoft.com/en-us/help/4489899) hotfix. Most of Cloud-hosted VMs already have this hotfix.
 
 ## Objectives for Creating Cluster with Windows Support
 
-When setting up a custom cluster with support for Windows nodes and containers, complete the series of tasks below.
+To set up a custom cluster with support for Windows nodes and containers, you will need to complete the series of tasks listed below. 
 
 <!-- TOC -->
 
@@ -45,7 +49,7 @@ To begin provisioning a custom cluster with Windows support, prepare your host s
 - VMs from virtualization clusters
 - Bare-metal servers
 
-The table below lists the [Kubernetes roles]({{< baseurl >}}/rancher/v2.x/en/cluster-provisioning/#kubernetes-cluster-node-components) you'll assign to each host, although you won't enable these roles until further along in the configuration process—we're just informing you of each node's purpose. The first node, a Linux host, is primarily responsible for managing the Kubernetes control plane, although, in this use case, we’re installing all three roles on this node. The second node is also a Linux worker, which is responsible for running DNS server, Ingress controller, Metrics server and Rancher Cluster agent. Finally, the third node is the Windows worker, which will run your Windows applications.
+The table below lists the [Kubernetes roles]({{< baseurl >}}/rancher/v2.x/en/cluster-provisioning/#kubernetes-cluster-node-components) you'll assign to each host, although you won't enable these roles until further along in the configuration process—we're just informing you of each node's purpose. The first node, a Linux host, is primarily responsible for managing the Kubernetes control plane, although, in this use case, we’re installing all three roles on this node. The second node is also a Linux worker, which is responsible for running a DNS server, Ingress controller, Metrics server and Rancher Cluster agent. Finally, the third node is the Windows worker, which will run your Windows applications.
 
 Node    | Operating System | Future Cluster Role(s)
 --------|------------------|------
@@ -55,14 +59,14 @@ Node 3  | Windows (Windows Server 2019 required)            | [Worker]({{< baseu
 
 >**Notes:**
 >
->- If you are using AWS, you can choose *Microsoft Windows Server 2019 Base with Containers* as Amazon Machine Image (AMI)
->- If you are using GCE, you can choose *Windows Server 2019 Datacenter for Containers* as OS image
+>- If you are using AWS, you should choose *Microsoft Windows Server 2019 Base with Containers* as the Amazon Machine Image (AMI).
+>- If you are using GCE, you should choose *Windows Server 2019 Datacenter for Containers* as the OS image.
 
 ### Requirements
 
-- You can view node requirements for Linux and Windows nodes in the [installation section]({{< baseurl >}}/rancher/v2.x/en/installation/requirements/).
+- You can view the requirements for Linux and Windows nodes in the [installation section]({{< baseurl >}}/rancher/v2.x/en/installation/requirements/).
 - For **Host Gateway (L2bridge)** networking, it's best to use the same Layer 2 network for all nodes. Otherwise, you need to configure the route rules for them.
-- For **VXLAN (Overlay)** networking, you must confirm the Windows Server 2019 host with [KB4489899](https://support.microsoft.com/en-us/help/4489899) hotfix. Most of Cloud-hosted VMs already have this hotfix.
+- For **VXLAN (Overlay)** networking, you must confirm the Windows Server 2019 has the [KB4489899](https://support.microsoft.com/en-us/help/4489899) hotfix installed. Most of Cloud-hosted VMs already have this hotfix.
 - Your cluster must include at least one Linux worker node to run Rancher Cluster agent, DNS, Metrics server and Ingress related containers.
 - Although we recommend the three node architecture listed in the table above, you can add additional Linux and Windows workers to scale up your cluster for redundancy.
 
@@ -94,7 +98,7 @@ Azure VM   | [Enable or Disable IP Forwarding](https://docs.microsoft.com/en-us/
 
 ## 3. Add Linux Master Node
 
-The first node in your cluster should be a Linux host that fills both *Control Plane* and *etcd* role. Both of this two roles must fulfill before you can add Windows hosts to your cluster. At a minimum, the node must have 2 roles enabled, but we recommend enabling all three. The following table lists our recommended settings (we'll provide the recommended settings for nodes 2 and 3 later).
+The first node in your cluster should be a Linux host that fills both *Control Plane* and *etcd* role. Both of this two roles must be fulfilled before you can add Windows hosts to your cluster. At a minimum, the node must have 2 roles enabled, but we recommend enabling all three. The following table lists our recommended settings (we'll provide the recommended settings for nodes 2 and 3 later).
 
 Option | Setting
 -------|--------
@@ -153,7 +157,7 @@ You can add Windows hosts to a custom cluster by editing the cluster and choosin
 
 ## 6. Cloud-hosted VM Routes Configuration for Host Gateway Mode
 
-If using [**Host Gateway (L2bridge)**](https://github.com/coreos/flannel/blob/master/Documentation/backends.md#host-gw) backend of Flannel, all containers on the same node belong to a private subnet, and traffic routes from a subnet on one node to a subnet on another node through the host network.
+If you are using the [**Host Gateway (L2bridge)**](https://github.com/coreos/flannel/blob/master/Documentation/backends.md#host-gw) backend of Flannel, all containers on the same node belong to a private subnet, and traffic routes from a subnet on one node to a subnet on another node through the host network.
 
 - When worker nodes are provisioned on AWS, virtualization clusters, or bare metal servers, make sure they belong to the same layer 2 subnet. If the nodes don't belong to the same layer 2 subnet, `host-gw` networking will not work.
 

--- a/layouts/shortcodes/requirements_ports_rke.html
+++ b/layouts/shortcodes/requirements_ports_rke.html
@@ -1,309 +1,332 @@
 <div>	
-	<p><strong>etcd nodes:</strong><br/>Nodes with the role <strong>etcd</strong></p>
-	<h3>etcd nodes - Inbound rules</h3>
-	<table>
-	    <tr>
-	        <th>Protocol</th>
-	        <th>Port</th>
-	        <th align="left">Source</th>
-	        <th align="left">Description</th>
-	    </tr>
-            <tr>
-                <td>TCP</td>
-                <td>2376</td>
-                <td><ul><li>Rancher nodes</li></td>
-                <td>Docker daemon TLS port used by Docker Machine<br />(only needed when using Node Driver/Templates)</td>
-            </tr>
-	    <tr>
-	        <td>TCP</td>
-	        <td>2379</td>
-	        <td><ul><li>etcd nodes</li><li>controlplane nodes</li></ul></td>
-	        <td>etcd client requests</td>
-	    </tr>
-	    <tr>
-	        <td>TCP</td>
-	        <td>2380</td>
-	        <td><ul><li>etcd nodes</li><li>controlplane nodes</li></ul></td>
-	        <td>etcd peer communication</td>
-	    </tr>
-	    <tr>
-		<td>UDP</td>
-	        <td>8472</td>
-	        <td><ul><li>etcd nodes</li><li>controlplane nodes</li><li>worker nodes</li></ul></td>
-	        <td>Canal/Flannel VXLAN overlay networking</td>
-	    </tr>
-	    <tr>
-		<td>TCP</td>
-	        <td>9099</td>
-	        <td><ul><li>etcd node itself (local traffic, not across nodes)</li></ul>See <a href=#local-node-traffic>Local node traffic</a></td>
-	        <td>Canal/Flannel livenessProbe/readinessProbe</td>
-	    </tr>
-	    <tr>
-	        <td>TCP</td>
-	        <td>10250</td>
-	        <td><ul><li>controlplane nodes</li></ul></td>
-	        <td>kubelet</td>
-	    </tr>
-	</table>
-	<h3>etcd nodes - Outbound rules</h3>
-	<table>
-	    <tr>
-	        <th>Protocol</th>
-	        <th>Port</th>
-	        <th align="left">Destination</th>
-	        <th align="left">Description</th>
-	    </tr>
-	    <tr>
-	        <td>TCP</td>
-	        <td>443</td>
-	        <td><ul><li>Rancher nodes</li></ul></td>
-	        <td>Rancher agent</td>
-	    </tr>
-	    <tr>
-	        <td>TCP</td>
-	        <td>2379</td>
-	        <td><ul><li>etcd nodes</li></ul></td>
-	        <td>etcd client requests</td>
-	    </tr>
-	    <tr>
-	        <td>TCP</td>
-	        <td>2380</td>
-	        <td><ul><li>etcd nodes</li></ul></td>
-	        <td>etcd peer communication</td>
-	    </tr>
-	    <tr>
-	        <td>TCP</td>
-	        <td>6443</td>
-	        <td><ul><li>controlplane nodes</li></ul></td>
-	        <td>Kubernetes apiserver</td>
-	    </tr>
-	    <tr>
-		<td>UDP</td>
-	        <td>8472</td>
-	        <td><ul><li>etcd nodes</li><li>controlplane nodes</li><li>worker nodes</li></ul></td>
-	        <td>Canal/Flannel VXLAN overlay networking</td>
-	    </tr>
-	    <tr>
-		<td>TCP</td>
-	        <td>9099</td>
-	        <td><ul><li>etcd node itself (local traffic, not across nodes)</li></ul>See <a href=#local-node-traffic>Local node traffic</a></td>
-	        <td>Canal/Flannel livenessProbe/readinessProbe</td>
-	    </tr>
-	</table>
-	<p><strong>controlplane nodes:</strong><br/>Nodes with the role <strong>controlplane</strong></p>
-	<h3>controlplane nodes - Inbound rules</h3>
-	<table>
-	    <tr>
-	        <th>Protocol</th>
-	        <th>Port</th>
-	        <th align="left">Source</th>
-	        <th align="left">Description</th>
-	    </tr>
-	    <tr>
-	        <td>TCP</td>
-	        <td>80</td>
-	        <td><ul><li>Any that consumes Ingress services</li></ul></td>
-	        <td>Ingress controller (HTTP)</td>
-	    </tr>
-	    <tr>
-	        <td>TCP</td>
-	        <td>443</td>
-	        <td><ul><li>Any that consumes Ingress services</li></ul></td>
-	        <td>Ingress controller (HTTPS)</td>
-	    </tr>
-            <tr>
-                <td>TCP</td>
-                <td>2376</td>
-                <td><ul><li>Rancher nodes</li></td>
-                <td>Docker daemon TLS port used by Docker Machine<br />(only needed when using Node Driver/Templates)</td>
-            </tr>
-	    <tr>
-	        <td>TCP</td>
-	        <td>6443</td>
-	        <td><ul><li>etcd nodes</li><li>controlplane nodes</li><li>worker nodes</li></ul></td>
-	        <td>Kubernetes apiserver</td>
-	    </tr>
-	    <tr>
-		<td>UDP</td>
-	        <td>8472</td>
-	        <td><ul><li>etcd nodes</li><li>controlplane nodes</li><li>worker nodes</li></ul></td>
-	        <td>Canal/Flannel VXLAN overlay networking</td>
-	    </tr>
-	    <tr>
-		<td>TCP</td>
-	        <td>9099</td>
-	        <td><ul><li>controlplane node itself (local traffic, not across nodes)</li></ul>See <a href=#local-node-traffic>Local node traffic</a></td>
-	        <td>Canal/Flannel livenessProbe/readinessProbe</td>
-	    </tr>
-	    <tr>
-	        <td>TCP</td>
-	        <td>10250</td>
-	        <td><ul><li>controlplane nodes</li></ul></td>
-	        <td>kubelet</td>
-	    </tr>
-	    <tr>
-	        <td>TCP</td>
-	        <td>10254</td>
-	        <td><ul><li>controlplane node itself (local traffic, not across nodes)</li></ul>See <a href=#local-node-traffic>Local node traffic</a></td>
-	        <td>Ingress controller livenessProbe/readinessProbe</td>
-	    </tr>
-	    <tr>
-	        <td>TCP/UDP</td>
-	        <td>30000-32767</td>
-	        <td><ul><li>Any source that consumes NodePort services</li></ul></td>
-	        <td>NodePort port range</td>
-	    </tr>
-	</table>
-	<h3>controlplane nodes - Outbound rules</h3>
-	<table>
-	    <tr>
-	        <th>Protocol</th>
-	        <th>Port</th>
-	        <th align="left">Destination</th>
-	        <th align="left">Description</th>
-	    </tr>
-	    <tr>
-	        <td>TCP</td>
-	        <td>443</td>
-	        <td><ul><li>Rancher nodes</li></ul></td>
-	        <td>Rancher agent</td>
-	    </tr>
-	    <tr>
-	        <td>TCP</td>
-	        <td>2379</td>
-	        <td><ul><li>etcd nodes</li></ul></td>
-	        <td>etcd client requests</td>
-	    </tr>
-	    <tr>
-	        <td>TCP</td>
-	        <td>2380</td>
-	        <td><ul><li>etcd nodes</li></ul></td>
-	        <td>etcd peer communication</td>
-	    </tr>
-	    <tr>
-		<td>UDP</td>
-	        <td>8472</td>
-	        <td><ul><li>etcd nodes</li><li>controlplane nodes</li><li>worker nodes</li></ul></td>
-	        <td>Canal/Flannel VXLAN overlay networking</td>
-	    </tr>
-	    <tr>
-		<td>TCP</td>
-	        <td>9099</td>
-	        <td><ul><li>controlplane node itself (local traffic, not across nodes)</li></ul>See <a href=#local-node-traffic>Local node traffic</a></td>
-	        <td>Canal/Flannel livenessProbe/readinessProbe</td>
-	    </tr>
-	    <tr>
-	        <td>TCP</td>
-	        <td>10250</td>
-	        <td><ul><li>etcd nodes</li><li>controlplane nodes</li><li>worker nodes</li></ul></td>
-	        <td>kubelet</td>
-	    </tr>
-	    <tr>
-	        <td>TCP</td>
-	        <td>10254</td>
-	        <td><ul><li>controlplane node itself (local traffic, not across nodes)</li></ul>See <a href=#local-node-traffic>Local node traffic</a></td>
-	        <td>Ingress controller livenessProbe/readinessProbe</td>
-	    </tr>
-	</table>
-	<p><strong>worker nodes:</strong><br/>Nodes with the role <strong>worker</strong></p>
-	<h3>worker nodes - Inbound rules</h3>
-	<table>
-	    <tr>
-	        <th>Protocol</th>
-	        <th>Port</th>
-	        <th align="left">Source</th>
-	        <th align="left">Description</th>
-	    </tr>
-	    <tr>
-	        <td>TCP</td>
-	        <td>80</td>
-	        <td><ul><li>Any that consumes Ingress services</li></ul></td>
-	        <td>Ingress controller (HTTP)</td>
-	    </tr>
-	    <tr>
-	        <td>TCP</td>
-	        <td>443</td>
-	        <td><ul><li>Any that consumes Ingress services</li></ul></td>
-	        <td>Ingress controller (HTTPS)</td>
-	    </tr>
-            <tr>
-                <td>TCP</td>
-                <td>2376</td>
-                <td><ul><li>Rancher nodes</li></td>
-                <td>Docker daemon TLS port used by Docker Machine<br />(only needed when using Node Driver/Templates)</td>
-            </tr>
-	    <tr>
-		<td>UDP</td>
-	        <td>8472</td>
-	        <td><ul><li>etcd nodes</li><li>controlplane nodes</li><li>worker nodes</li></ul></td>
-	        <td>Canal/Flannel VXLAN overlay networking</td>
-	    </tr>
-	    <tr>
-		<td>TCP</td>
-	        <td>9099</td>
-	        <td><ul><li>worker node itself (local traffic, not across nodes)</li></ul>See <a href=#local-node-traffic>Local node traffic</a></td>
-	        <td>Canal/Flannel livenessProbe/readinessProbe</td>
-	    </tr>
-	    <tr>
-	        <td>TCP</td>
-	        <td>10250</td>
-	        <td><ul><li>controlplane nodes</li></ul></td>
-	        <td>kubelet</td>
-	    </tr>
-	    <tr>
-	        <td>TCP</td>
-	        <td>10254</td>
-	        <td><ul><li>worker node itself (local traffic, not across nodes)</li></ul>See <a href=#local-node-traffic>Local node traffic</a></td>
-	        <td>Ingress controller livenessProbe/readinessProbe</td>
-	    </tr>
-	    <tr>
-	        <td>TCP/UDP</td>
-	        <td>30000-32767</td>
-	        <td><ul><li>Any source that consumes NodePort services</li></ul></td>
-	        <td>NodePort port range</td>
-	    </tr>
-	</table>
-	<h3>worker nodes - Outbound rules</h3>
-	<table>
-	    <tr>
-	        <th>Protocol</th>
-	        <th>Port</th>
-	        <th align="left">Destination</th>
-	        <th align="left">Description</th>
-	    </tr>
-	    <tr>
-	        <td>TCP</td>
-	        <td>443</td>
-	        <td><ul><li>Rancher nodes</li></ul></td>
-	        <td>Rancher agent</td>
-	    </tr>
-	    <tr>
-	        <td>TCP</td>
-	        <td>6443</td>
-	        <td><ul><li>controlplane nodes</li></ul></td>
-	        <td>Kubernetes apiserver</td>
-	    </tr>
-	    <tr>
-		<td>UDP</td>
-	        <td>8472</td>
-	        <td><ul><li>etcd nodes</li><li>controlplane nodes</li><li>worker nodes</li></ul></td>
-	        <td>Canal/Flannel VXLAN overlay networking</td>
-	    </tr>
-	    <tr>
-		<td>TCP</td>
-	        <td>9099</td>
-	        <td><ul><li>worker node itself (local traffic, not across nodes)</li></ul>See <a href=#local-node-traffic>Local node traffic</a></td>
-	        <td>Canal/Flannel livenessProbe/readinessProbe</td>
-	    </tr>
-	    <tr>
-	        <td>TCP</td>
-	        <td>10254</td>
-	        <td><ul><li>worker node itself (local traffic, not across nodes)</li></ul>See <a href=#local-node-traffic>Local node traffic</a></td>
-	        <td>Ingress controller livenessProbe/readinessProbe</td>
-	    </tr>
-	</table>
-    <br/>
-    <h3 id="local-node-traffic">Information on local node traffic</h3>
-    <p>Kubernetes healthchecks (<code>livenessProbe</code> and <code>readinessProbe</code>) are executed on the host itself. On most nodes, this is allowed by default. When you have applied strict host firewall (i.e. <code>iptables</code>) policies on the node, or when you are using nodes that have multiple interfaces (multihomed), this traffic gets blocked. In this case, you have to explicitly allow this traffic in your host firewall, or in case of public/private cloud hosted machines (i.e. AWS or OpenStack), in your security group configuration. Keep in mind that when using a security group as Source or Destination in your security group, that this only applies to the private interface of the nodes/instances.
-    </p>	
-</div>
+		<p><strong>etcd nodes:</strong><br/>Nodes with the role <strong>etcd</strong></p>
+		<h3>etcd nodes - Inbound rules</h3>
+		<table>
+			<tr>
+				<th>Protocol</th>
+				<th>Port</th>
+				<th align="left">Source</th>
+				<th align="left">Description</th>
+			</tr>
+				<tr>
+					<td>TCP</td>
+					<td>2376</td>
+					<td><ul><li>Rancher nodes</li></td>
+					<td>Docker daemon TLS port used by Docker Machine<br />(only needed when using Node Driver/Templates)</td>
+				</tr>
+			<tr>
+				<td>TCP</td>
+				<td>2379</td>
+				<td><ul><li>etcd nodes</li><li>controlplane nodes</li></ul></td>
+				<td>etcd client requests</td>
+			</tr>
+			<tr>
+				<td>TCP</td>
+				<td>2380</td>
+				<td><ul><li>etcd nodes</li><li>controlplane nodes</li></ul></td>
+				<td>etcd peer communication</td>
+			</tr>
+			<tr>
+			<td>UDP</td>
+				<td>8472</td>
+				<td><ul><li>etcd nodes</li><li>controlplane nodes</li><li>worker nodes</li></ul></td>
+				<td>Canal/Flannel VXLAN overlay networking</td>
+			</tr>
+			<tr>
+			<td>TCP</td>
+				<td>9099</td>
+				<td><ul><li>etcd node itself (local traffic, not across nodes)</li></ul>See <a href=#local-node-traffic>Local node traffic</a></td>
+				<td>Canal/Flannel livenessProbe/readinessProbe</td>
+			</tr>
+			<tr>
+				<td>TCP</td>
+				<td>10250</td>
+				<td><ul><li>controlplane nodes</li></ul></td>
+				<td>kubelet</td>
+			</tr>
+		</table>
+		<h3>etcd nodes - Outbound rules</h3>
+		<table>
+			<tr>
+				<th>Protocol</th>
+				<th>Port</th>
+				<th align="left">Destination</th>
+				<th align="left">Description</th>
+			</tr>
+			<tr>
+				<td>TCP</td>
+				<td>443</td>
+				<td><ul><li>Rancher nodes</li></ul></td>
+				<td>Rancher agent</td>
+			</tr>
+			<tr>
+				<td>TCP</td>
+				<td>2379</td>
+				<td><ul><li>etcd nodes</li></ul></td>
+				<td>etcd client requests</td>
+			</tr>
+			<tr>
+				<td>TCP</td>
+				<td>2380</td>
+				<td><ul><li>etcd nodes</li></ul></td>
+				<td>etcd peer communication</td>
+			</tr>
+			<tr>
+				<td>TCP</td>
+				<td>6443</td>
+				<td><ul><li>controlplane nodes</li></ul></td>
+				<td>Kubernetes apiserver</td>
+			</tr>
+			<tr>
+			<td>UDP</td>
+				<td>8472</td>
+				<td><ul><li>etcd nodes</li><li>controlplane nodes</li><li>worker nodes</li></ul></td>
+				<td>Canal/Flannel VXLAN overlay networking</td>
+			</tr>
+			<tr>
+			<td>TCP</td>
+				<td>9099</td>
+				<td><ul><li>etcd node itself (local traffic, not across nodes)</li></ul>See <a href=#local-node-traffic>Local node traffic</a></td>
+				<td>Canal/Flannel livenessProbe/readinessProbe</td>
+			</tr>
+		</table>
+		<p><strong>controlplane nodes:</strong><br/>Nodes with the role <strong>controlplane</strong></p>
+		<h3>controlplane nodes - Inbound rules</h3>
+		<table>
+			<tr>
+				<th>Protocol</th>
+				<th>Port</th>
+				<th align="left">Source</th>
+				<th align="left">Description</th>
+			</tr>
+			<tr>
+				<td>TCP</td>
+				<td>80</td>
+				<td><ul><li>Any that consumes Ingress services</li></ul></td>
+				<td>Ingress controller (HTTP)</td>
+			</tr>
+			<tr>
+				<td>TCP</td>
+				<td>443</td>
+				<td><ul><li>Any that consumes Ingress services</li></ul></td>
+				<td>Ingress controller (HTTPS)</td>
+			</tr>
+				<tr>
+					<td>TCP</td>
+					<td>2376</td>
+					<td><ul><li>Rancher nodes</li></td>
+					<td>Docker daemon TLS port used by Docker Machine<br />(only needed when using Node Driver/Templates)</td>
+				</tr>
+			<tr>
+				<td>TCP</td>
+				<td>6443</td>
+				<td><ul><li>etcd nodes</li><li>controlplane nodes</li><li>worker nodes</li></ul></td>
+				<td>Kubernetes apiserver</td>
+			</tr>
+			<tr>
+			<td>UDP</td>
+				<td>8472</td>
+				<td><ul><li>etcd nodes</li><li>controlplane nodes</li><li>worker nodes</li></ul></td>
+				<td>Canal/Flannel VXLAN overlay networking</td>
+			</tr>
+			<tr>
+			<td>TCP</td>
+				<td>9099</td>
+				<td><ul><li>controlplane node itself (local traffic, not across nodes)</li></ul>See <a href=#local-node-traffic>Local node traffic</a></td>
+				<td>Canal/Flannel livenessProbe/readinessProbe</td>
+			</tr>
+			<tr>
+				<td>TCP</td>
+				<td>10250</td>
+				<td><ul><li>controlplane nodes</li></ul></td>
+				<td>kubelet</td>
+			</tr>
+			<tr>
+				<td>TCP</td>
+				<td>10254</td>
+				<td><ul><li>controlplane node itself (local traffic, not across nodes)</li></ul>See <a href=#local-node-traffic>Local node traffic</a></td>
+				<td>Ingress controller livenessProbe/readinessProbe</td>
+			</tr>
+			<tr>
+				<td>TCP/UDP</td>
+				<td>30000-32767</td>
+				<td><ul><li>Any source that consumes NodePort services</li></ul></td>
+				<td>NodePort port range</td>
+			</tr>
+		</table>
+		<h3>controlplane nodes - Outbound rules</h3>
+		<table>
+			<tr>
+				<th>Protocol</th>
+				<th>Port</th>
+				<th align="left">Destination</th>
+				<th align="left">Description</th>
+			</tr>
+			<tr>
+				<td>TCP</td>
+				<td>443</td>
+				<td><ul><li>Rancher nodes</li></ul></td>
+				<td>Rancher agent</td>
+			</tr>
+			<tr>
+				<td>TCP</td>
+				<td>2379</td>
+				<td><ul><li>etcd nodes</li></ul></td>
+				<td>etcd client requests</td>
+			</tr>
+			<tr>
+				<td>TCP</td>
+				<td>2380</td>
+				<td><ul><li>etcd nodes</li></ul></td>
+				<td>etcd peer communication</td>
+			</tr>
+			<tr>
+			<td>UDP</td>
+				<td>8472</td>
+				<td><ul><li>etcd nodes</li><li>controlplane nodes</li><li>worker nodes</li></ul></td>
+				<td>Canal/Flannel VXLAN overlay networking</td>
+			</tr>
+			<tr>
+			<td>TCP</td>
+				<td>9099</td>
+				<td><ul><li>controlplane node itself (local traffic, not across nodes)</li></ul>See <a href=#local-node-traffic>Local node traffic</a></td>
+				<td>Canal/Flannel livenessProbe/readinessProbe</td>
+			</tr>
+			<tr>
+				<td>TCP</td>
+				<td>10250</td>
+				<td><ul><li>etcd nodes</li><li>controlplane nodes</li><li>worker nodes</li></ul></td>
+				<td>kubelet</td>
+			</tr>
+			<tr>
+				<td>TCP</td>
+				<td>10254</td>
+				<td><ul><li>controlplane node itself (local traffic, not across nodes)</li></ul>See <a href=#local-node-traffic>Local node traffic</a></td>
+				<td>Ingress controller livenessProbe/readinessProbe</td>
+			</tr>
+		</table>
+		<p><strong>worker nodes:</strong><br/>Nodes with the role <strong>worker</strong></p>
+		<h3>worker nodes - Inbound rules</h3>
+		<table>
+			<tr>
+				<th>Protocol</th>
+				<th>Port</th>
+				<th align="left">Source</th>
+				<th align="left">Description</th>
+			</tr>
+			<tr>
+				<td>TCP</td>
+				<td>22</td>
+				<td>
+					<ul>
+						<li><strong>Linux worker nodes only</strong></li>
+						<li>Any network that you want to be able to remotely access this node from.</li>
+					</ul>
+				</td>
+				<td>Remote access over SSH</td>
+			</tr>
+			<tr>
+				<td>TCP</td>
+				<td>3389</td>
+				<td>
+					<ul>
+						<li><strong>Windows worker nodes only</strong></li>
+						<li>Any network that you want to be able to remotely access this node from.</li>
+					</ul>
+				</td>
+				<td>Remote access over RDP</td>
+			</tr>
+			<tr>
+				<td>TCP</td>
+				<td>80</td>
+				<td><ul><li>Any that consumes Ingress services</li></ul></td>
+				<td>Ingress controller (HTTP)</td>
+			</tr>
+			<tr>
+				<td>TCP</td>
+				<td>443</td>
+				<td><ul><li>Any that consumes Ingress services</li></ul></td>
+				<td>Ingress controller (HTTPS)</td>
+			</tr>
+				<tr>
+					<td>TCP</td>
+					<td>2376</td>
+					<td><ul><li>Rancher nodes</li></td>
+					<td>Docker daemon TLS port used by Docker Machine<br />(only needed when using Node Driver/Templates)</td>
+				</tr>
+			<tr>
+			<td>UDP</td>
+				<td>8472</td>
+				<td><ul><li>etcd nodes</li><li>controlplane nodes</li><li>worker nodes</li></ul></td>
+				<td>Canal/Flannel VXLAN overlay networking</td>
+			</tr>
+			<tr>
+			<td>TCP</td>
+				<td>9099</td>
+				<td><ul><li>worker node itself (local traffic, not across nodes)</li></ul>See <a href=#local-node-traffic>Local node traffic</a></td>
+				<td>Canal/Flannel livenessProbe/readinessProbe</td>
+			</tr>
+			<tr>
+				<td>TCP</td>
+				<td>10250</td>
+				<td><ul><li>controlplane nodes</li></ul></td>
+				<td>kubelet</td>
+			</tr>
+			<tr>
+				<td>TCP</td>
+				<td>10254</td>
+				<td><ul><li>worker node itself (local traffic, not across nodes)</li></ul>See <a href=#local-node-traffic>Local node traffic</a></td>
+				<td>Ingress controller livenessProbe/readinessProbe</td>
+			</tr>
+			<tr>
+				<td>TCP/UDP</td>
+				<td>30000-32767</td>
+				<td><ul><li>Any source that consumes NodePort services</li></ul></td>
+				<td>NodePort port range</td>
+			</tr>
+		</table>
+		<h3>worker nodes - Outbound rules</h3>
+		<table>
+			<tr>
+				<th>Protocol</th>
+				<th>Port</th>
+				<th align="left">Destination</th>
+				<th align="left">Description</th>
+			</tr>
+			<tr>
+				<td>TCP</td>
+				<td>443</td>
+				<td><ul><li>Rancher nodes</li></ul></td>
+				<td>Rancher agent</td>
+			</tr>
+			<tr>
+				<td>TCP</td>
+				<td>6443</td>
+				<td><ul><li>controlplane nodes</li></ul></td>
+				<td>Kubernetes apiserver</td>
+			</tr>
+			<tr>
+			<td>UDP</td>
+				<td>8472</td>
+				<td><ul><li>etcd nodes</li><li>controlplane nodes</li><li>worker nodes</li></ul></td>
+				<td>Canal/Flannel VXLAN overlay networking</td>
+			</tr>
+			<tr>
+			<td>TCP</td>
+				<td>9099</td>
+				<td><ul><li>worker node itself (local traffic, not across nodes)</li></ul>See <a href=#local-node-traffic>Local node traffic</a></td>
+				<td>Canal/Flannel livenessProbe/readinessProbe</td>
+			</tr>
+			<tr>
+				<td>TCP</td>
+				<td>10254</td>
+				<td><ul><li>worker node itself (local traffic, not across nodes)</li></ul>See <a href=#local-node-traffic>Local node traffic</a></td>
+				<td>Ingress controller livenessProbe/readinessProbe</td>
+			</tr>
+		</table>
+		<br/>
+		<h3 id="local-node-traffic">Information on local node traffic</h3>
+		<p>Kubernetes healthchecks (<code>livenessProbe</code> and <code>readinessProbe</code>) are executed on the host itself. On most nodes, this is allowed by default. When you have applied strict host firewall (i.e. <code>iptables</code>) policies on the node, or when you are using nodes that have multiple interfaces (multihomed), this traffic gets blocked. In this case, you have to explicitly allow this traffic in your host firewall, or in case of public/private cloud hosted machines (i.e. AWS or OpenStack), in your security group configuration. Keep in mind that when using a security group as Source or Destination in your security group, that this only applies to the private interface of the nodes/instances.
+		</p>	
+	</div>
+	


### PR DESCRIPTION
This PR represents contains:

1. Some minor grammar and wording fixes to the main windows cluster configuration document. 
2. An addition to the requirements file which defines the required ports for remote access for both Linux and Windows. 

The only major structural change that I made was unpacking the introductory paragraph into a list because I think its a bit easier to read this way. 