### PR TITLE
Describe RKE v0.2.0 updates in HA restore section

### DIFF
--- a/content/rancher/v2.x/en/backups/restorations/ha-restoration/_index.md
+++ b/content/rancher/v2.x/en/backups/restorations/ha-restoration/_index.md
@@ -7,19 +7,19 @@ aliases:
 
 This procedure describes how to use RKE to restore a snapshot of the Rancher Kubernetes cluster. The cluster snapshot will include Kubernetes configuration and the Rancher database and state.
 
+Additionally, the `pki.bundle.tar.gz` file usage is no longer required as v0.2.0 has changed how the [Kubernetes cluster state is stored]({{< baseurl >}}/rke/latest/en/installation/#kubernetes-cluster-state).
+
 ## Restore Outline
 
 <!-- TOC -->
 
-
 - [1. Preparation](#1-preparation)
-- [2. Place Snapshot and PKI Bundle](#2-place-snapshot-and-pki-bundle)
+- [2. Place Snapshot](#2-snapshot)
 - [3. Configure RKE](#3-configure-rke)
 - [4. Restore Database](#4-restore-database)
 - [5. Bring Up the Cluster](#5-bring-up-the-cluster)
 
 <!-- /TOC -->
-<br/>
 
 ### 1. Preparation
 
@@ -29,14 +29,26 @@ Prepare by creating 3 new nodes to be the target for the restored Rancher instan
 
 We recommend that you start with fresh nodes and a clean state. Alternatively you can clear Kubernetes and Rancher configurations from the existing nodes. This will destroy the data on these nodes. See [Node Cleanup]({{< baseurl >}}/rancher/v2.x/en/faq/cleaning-cluster-nodes/) for the procedure.
 
-> **IMPORTANT:** Before starting the restore make sure all the kubernetes services on the old cluster nodes are stopped. We recommend powering off the nodes to be sure.
+> **IMPORTANT:** Before starting the restore make sure all the Kubernetes services on the old cluster nodes are stopped. We recommend powering off the nodes to be sure.
 
-### 2. Place Snapshot and PKI Bundle
+### 2. Place Snapshot <a name="2-snapshot"></a>
+The snapshot used to restore your etcd cluster is handled differently based on your version of RKE.
 
-Pick a one of the clean nodes. That node will be the "target node" for the initial restore.  Place the snapshot and PKI certificate bundle files in the `/opt/rke/etcd-snapshots` directory on the "target node".
+#### For RKE Prior to v0.2.0: Place Snapshot and PKI Bundle on Local
+Pick one of the clean nodes. That node will be the "target node" for the initial restore. 
+
+Place the snapshot and PKI certificate bundle files in the `/opt/rke/etcd-snapshots` directory on the target node.
+
+When you take a snapshot, RKE saves a backup of the certificates, i.e. a file named `pki.bundle.tar.gz`, in the same location. The snapshot and PKI bundle file are required for the restore process, and they are expected to be in the same location.
 
 * Snapshot - `<snapshot>.db`
 * PKI Bundle - `pki.bundle.tar.gz`
+
+#### For RKE v0.2.0 or Later: Place Snapshot on Local or S3
+
+To restore your etcd cluster from a local snapshot, pick one of the clean nodes. That node will be the "target node" for the initial restore. Place your snapshot in `/opt/rke/etcd-snapshots` on the target node.
+
+RKE v0.2.0 also allows you to restore your cluster from an S3 compatible backend. To restore your cluster from S3, you will use the [S3 configuration options](#restore-from-snapshot) during step 4: Restore Database.
 
 ### 3. Configure RKE
 
@@ -50,7 +62,7 @@ Modify the copy and make the following changes.
 
 * Remove or comment out entire the `addons:` section. The Rancher deployment and supporting configuration is already in the `etcd` database.
 * Change your `nodes:` section to point to the restore nodes.
-* Comment out the nodes that are not your "target node". We want the cluster to only start on that one node.
+* Comment out the nodes that are not your "target node." We want the cluster to only start on that one node.
 
 *Example* `rancher-cluster-restore.yml`
 
@@ -79,17 +91,54 @@ nodes:
 
 ### 4. Restore Database
 
-Use RKE with the new `rancher-cluster-restore.yml` configuration and restore the database to the single "target node".
+Use RKE with the new `rancher-cluster-restore.yml` configuration and restore the database to the single "target node."
+
+#### Example of Restoring from a Local Snapshot
+
+When restoring etcd from a local snapshot, the snapshot is assumed to be located on the target node in the directory `/opt/rke/etcd-snapshots`.
+
+> **Note:** For RKE prior to v0.2.0, the `pki.bundle.tar.gz` file is also expected to be in the same location. 
 
 ```
 rke etcd snapshot-restore --name <snapshot>.db --config ./rancher-cluster-restore.yml
 ```
 
-> **Note:** RKE will create an `etcd` container with the restored database on the "target node". This container will not complete the `etcd` initialization and stay in a running state until the cluster brought up in the next step.
+RKE will create an `etcd` container with the restored database on the target node. This container will not complete the `etcd` initialization and stay in a running state until the cluster brought up in the next step.
+
+#### Example of Restoring from a Snapshot in S3 (For RKE v0.2.0 or Later) <a name="restore-from-snapshot"></a>
+
+When restoring etcd from a snapshot located in S3, the command needs the S3 information in order to connect to the S3 backend and retrieve the snapshot.
+
+> **Note:** Ensure your `cluster.rkestate` is present before starting the restore, as this contains your certificate data for the cluster.
+
+```
+shell
+$ rke etcd snapshot-restore --config cluster.yml --name snapshot-name \
+--s3 --access-key S3_ACCESS_KEY --secret-key S3_SECRET_KEY \
+--bucket-name s3-bucket-name --s3-endpoint s3.amazonaws.com
+```
+The UI should start up after a few minutes; you don't need to re-run helm.
+
+#### Options for `rke etcd snapshot-restore`
+
+S3 specific options are only available for RKE v0.2.0 or later.
+
+| Option | Description | S3 Specific |
+| --- | --- | ---|
+| `--name` value            |  Specify snapshot name | |
+| `--config` value          |  Specify an alternate cluster YAML file (default: "cluster.yml") [$RKE_CONFIG] | |
+| `--s3`                    |  Enabled backup to s3 |* |
+| `--s3-endpoint` value     |  Specify s3 endpoint url (default: "s3.amazonaws.com") | * |
+| `--access-key` value      |  Specify s3 accessKey | *|
+| `--secret-key` value      |  Specify s3 secretKey | *|
+| `--bucket-name` value     |  Specify s3 bucket name | *|
+| `--region` value          |  Specify the s3 bucket location (optional) | *|
+| `--ssh-agent-auth`      |   [Use SSH Agent Auth defined by SSH_AUTH_SOCK]({{< baseurl >}}/rke/latest/en/config-options/#ssh-agent) | |
+| `--ignore-docker-version`  | [Disable Docker version check]({{< baseurl >}}/rke/latest/en/config-options/#supported-docker-versions) |
 
 ### 5. Bring Up the Cluster
 
-Use RKE and bring up the cluster on the single "target node".
+Use RKE and bring up the cluster on the single "target node."
 
 ```
 rke up --config ./rancher-cluster-restore.yml
@@ -179,6 +228,6 @@ rke up --config ./rancher-cluster-restore.yml
 
 #### Finishing Up
 
-Rancher should now be running and available to manage your Kubernetes clusters.  Swap your Rancher DNS or Load Balancer endpoints to target the new cluster.  Once this is done the agents on your managed clusters should automatically reconnect.  This may take 10-15 minutes due to reconnect back off timeouts.
+Rancher should now be running and available to manage your Kubernetes clusters. Swap your Rancher DNS or Load Balancer endpoints to target the new cluster. Once this is done the agents on your managed clusters should automatically reconnect. This may take 10-15 minutes due to reconnect back off timeouts.
 
 > **IMPORTANT:** Remember to save your new RKE config (`rancher-cluster-restore.yml`) and `kubectl` credentials (`kube_config_rancher-cluster-restore.yml`) files in a safe place for future maintenance.


### PR DESCRIPTION
There are two main changes to the section "Restoring Backups—High Availability Installs":
- Update the Rancher restore docs to reflect the fact that the function of restoring the database from an S3 backup was added to RKE.
- Indicate on the Rancher restore docs that the PKI bundle step goes with the older version of RKE. 
