### PR TITLE
Fix role names for creating GKE cluster

### DIFF
--- a/content/rancher/v2.x/en/cluster-provisioning/hosted-kubernetes-clusters/gke/_index.md
+++ b/content/rancher/v2.x/en/cluster-provisioning/hosted-kubernetes-clusters/gke/_index.md
@@ -12,9 +12,10 @@ Create a service account using [Google Cloud Platform](https://console.cloud.goo
 
 The service account requires the following roles:
 
--	`project/viewer`
--	`kubernetes-engine/admin`
--	`service-account/user`
+- **Compute Viewer:** `roles/compute.viewer`
+- **Project Viewer:** `roles/viewer`
+- **Kubernetes Engine Admin:** `roles/container.admin` 
+- **Service Account User:** `roles/iam.serviceAccountUser`
 
 [Google Documentation: Creating and Enabling Service Accounts](https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances)
 


### PR DESCRIPTION
Changed role names for creating GKE cluster according to issue #1087, "GKE install - role names incorrect"