### PR TITLE
fixing misstyped reference

### DIFF
--- a/content/rancher/v2.x/en/k8s-in-rancher/pipelines/example-repos/_index.md
+++ b/content/rancher/v2.x/en/k8s-in-rancher/pipelines/example-repos/_index.md
@@ -67,4 +67,4 @@ After enabling an example repository, run the pipeline to see how it works.
 
 ## What's Next?
 
-For detailed information about setting up your own pipeline for your repository, [configure a version control provider]({{< baseurl >}}/rancher/v2.x/en/project-admin/tools/pipelines), [enable a repository](#configure-repositories) and finally [configure your pipeline]({{< baseurl >}}/rancher/v2.x/en/k8s-in-rancer/pipelines/#pipeline-configuration).
+For detailed information about setting up your own pipeline for your repository, [configure a version control provider]({{< baseurl >}}/rancher/v2.x/en/project-admin/tools/pipelines), [enable a repository](#configure-repositories) and finally [configure your pipeline]({{< baseurl >}}/rancher/v2.x/en/k8s-in-rancher/pipelines/#pipeline-configuration).


### PR DESCRIPTION
fixing typo

Clinking the bottom link of **configure your pipeline** is leading to a 404 page.