### PR TITLE
fixed broken link

### DIFF
--- a/content/rancher/v2.x/en/cluster-provisioning/rke-clusters/windows-clusters/_index.md
+++ b/content/rancher/v2.x/en/cluster-provisioning/rke-clusters/windows-clusters/_index.md
@@ -215,7 +215,7 @@ If you are using Azure VMs for your nodes, you can use [Azure files](https://doc
 
 In order to have the Azure platform create the required storage resources, follow these steps:
 
-1. [Configure the Azure cloud provider.]({{< baseurl >}}rancher/v2.x/en/cluster-provisioning/rke-clusters/options/cloud-providers/#azure)
+1. [Configure the Azure cloud provider.]({{< baseurl >}}/rancher/v2.x/en/cluster-provisioning/rke-clusters/options/cloud-providers/#azure)
 
 1. Configure `kubectl` to connect to your cluster.
 


### PR DESCRIPTION
Missing a `/` character results in a link which serves a 404