### PR TITLE
docs: Istio Edits

### DIFF
--- a/content/rancher/v2.x/en/cluster-admin/tools/service-mesh/_index.md
+++ b/content/rancher/v2.x/en/cluster-admin/tools/service-mesh/_index.md
@@ -15,7 +15,7 @@ As an [administrator]({{< baseurl >}}/rancher/v2.x/en/admin-settings/rbac/global
 
 1. Select **Tools > Service Mesh** in the navigation bar.
 
-1. Select **Enable** to show the [Service mesh configuration options]({{< baseurl >}}/rancher/v2.x/en/cluster-admin/tools/service-mesh/istio/). Enter in your desired configuration options.
+1. Select **Enable** to show the [Service mesh configuration options]({{< baseurl >}}/rancher/v2.x/en/cluster-admin/tools/service-mesh/istio/). Enter in your desired configuration options. Ensure you have enough resources for service mesh and on your worker nodes to enable service mesh.
 
 1. Click **Save**.
 

--- a/content/rancher/v2.x/en/cluster-admin/tools/service-mesh/_index.md
+++ b/content/rancher/v2.x/en/cluster-admin/tools/service-mesh/_index.md
@@ -11,15 +11,15 @@ Using Rancher, you can connect, secure, control, and observe services through in
 
 As an [administrator]({{< baseurl >}}/rancher/v2.x/en/admin-settings/rbac/global-permissions/) or [cluster owner]({{< baseurl >}}/rancher/v2.x/en/admin-settings/rbac/cluster-project-roles/#cluster-roles), you can configure Rancher to deploy Istio to your Kubernetes cluster.
 
-1. From the **Global** view, navigate to the cluster that you want to configure service mesh.
+1. From the **Global** view, navigate to the cluster that you want to configure the service mesh for.
 
 1. Select **Tools > Service Mesh** in the navigation bar.
 
-1. Select **Enable** to show the [Service mesh configuration options]({{< baseurl >}}/rancher/v2.x/en/cluster-admin/tools/service-mesh/istio/). Ensure you have enough resources for service mesh and on your worker nodes to enable service mesh. Enter in your desired configuration options.
+1. Select **Enable** to show the [Service mesh configuration options]({{< baseurl >}}/rancher/v2.x/en/cluster-admin/tools/service-mesh/istio/). Enter in your desired configuration options.
 
 1. Click **Save**.
 
-**Result:** The istio will be deployed as well as an application. The istio application, `cluster-istio`, is added as an [application]({{< baseurl >}}/rancher/v2.x/en/catalog/apps/) to the cluster's `system` project.  After the application is `active`, you can start using Istio.
+**Result:** The Istio application, `cluster-istio`, is added as an [application]({{< baseurl >}}/rancher/v2.x/en/catalog/apps/) to the cluster's `system` project.  After the application is `active`, you can start using Istio.
 
 > **Note:** When enabling service mesh, you need to ensure your worker nodes and Istio pod have enough resources. In larger deployments, it is strongly advised that the service mesh infrastructure be placed on dedicated nodes in the cluster.
 
@@ -31,13 +31,13 @@ Once the service mesh is `active`, you can:
 1. Access [Jaeger UI](https://www.jaegertracing.io/) by clicking Jaeger UI icon in service mesh page.
 1. Access [Grafana UI](https://grafana.com/) by clicking Grafana UI icon in service mesh page.
 1. Access [Prometheus UI](https://prometheus.io/) by clicking Prometheus UI icon in service mesh page.
-1. Go to project to [view traffic graph, traffic metrics and manage traffic]({{< baseurl >}}/rancher/v2.x/en/project-admin/service-mesh/).
+1. Go to a project to [view traffic graph, traffic metrics and manage traffic]({{< baseurl >}}/rancher/v2.x/en/project-admin/service-mesh/).
 
 ## Disabling Service Mesh
 
 To disable the service mesh:
 
-1. From the **Global** view, navigate to the cluster that you want to disable service mesh.
+1. From the **Global** view, navigate to the cluster that you want to disable the service mesh for.
 
 1. Select **Tools > Service Mesh** in the navigation bar.
 

--- a/content/rancher/v2.x/en/cluster-admin/tools/service-mesh/istio/_index.md
+++ b/content/rancher/v2.x/en/cluster-admin/tools/service-mesh/istio/_index.md
@@ -5,86 +5,86 @@ weight: 1
 
 _Available as of v2.3.0-alpha_
 
-While configuring service mesh, there are multiple options that can be configured.
+There are several configuration options for the service mesh.
 
 ## PILOT
 
-Option | Description| Required | Default 
+Option | Description| Required | Default
 -------|------------|-------|-------
-Pilot CPU Limit | CPU resource limit for the istio-pilot pod.| Yes      | 1000    
-Pilot CPU Reservation | CPU reservation for the istio-pilot pod. | Yes      | 500     
-Pilot Memory Limit | Memory resource limit for the istio-pilot pod. | Yes      | 4096 
-Pilot Memory Reservation | Memory resource requests for the istio-pilot pod. | Yes      | 2048 
-Trace sampling Percentage | [Trace sampling percentage](https://istio.io/docs/tasks/telemetry/distributed-tracing/overview/#trace-sampling) | Yes      | 1 
-Pilot Selector | Ability to select the nodes in which istio-pilot pod is deployed to. To use this option, the nodes must have labels. | No       | n/a 
+Pilot CPU Limit | CPU resource limit for the istio-pilot pod.| Yes      | 1000
+Pilot CPU Reservation | CPU reservation for the istio-pilot pod. | Yes      | 500
+Pilot Memory Limit | Memory resource limit for the istio-pilot pod. | Yes      | 4096
+Pilot Memory Reservation | Memory resource requests for the istio-pilot pod. | Yes      | 2048
+Trace sampling Percentage | [Trace sampling percentage](https://istio.io/docs/tasks/telemetry/distributed-tracing/overview/#trace-sampling) | Yes      | 1
+Pilot Selector | Ability to select the nodes in which istio-pilot pod is deployed to. To use this option, the nodes must have labels. | No       | n/a
 
 ## MIXER
 
-Option | Description| Required | Default 
+Option | Description| Required | Default
 -------|------------|-------|-------
-Mixer Telemetry CPU Limit | CPU resource limit for the istio-telemetry pod.| Yes                      | 4800 
-Mixer Telemetry CPU Reservation | CPU reservation for the istio-telemetry pod.| Yes                      | 1000 
-Mixer Telemetry Memory Limit | Memory resource limit for the istio-telemetry pod.| Yes                      | 4096 
-Mixer Telemetry Memory Reservation | Memory resource requests for the istio-telemetry pod.| Yes                      | 1024 
-Enable Mixer Policy | Whether or not to deploy the istio-policy. | Yes                      | False 
-Mixer Policy CPU Limit | CPU resource limit for the istio-policy pod. | Yes, when policy enabled | 4800 
-Mixer Policy CPU Reservation | CPU reservation for the istio-policy pod. | Yes, when policy enabled | 1000 
-Mixer Policy Memory Limit | Memory resource limit for the istio-policy pod. | Yes, when policy enabled | 4096 
-Mixer Policy Memory Reservation | Memory resource requests for the istio-policy pod. | Yes, when policy enabled | 1024 
-Mixer Selector | Ability to select the nodes in which istio-policy and istio-telemetry pods are deployed to. To use this option, the nodes must have labels. | No                       | n/a 
+Mixer Telemetry CPU Limit | CPU resource limit for the istio-telemetry pod.| Yes                      | 4800
+Mixer Telemetry CPU Reservation | CPU reservation for the istio-telemetry pod.| Yes                      | 1000
+Mixer Telemetry Memory Limit | Memory resource limit for the istio-telemetry pod.| Yes                      | 4096
+Mixer Telemetry Memory Reservation | Memory resource requests for the istio-telemetry pod.| Yes                      | 1024
+Enable Mixer Policy | Whether or not to deploy the istio-policy. | Yes                      | False
+Mixer Policy CPU Limit | CPU resource limit for the istio-policy pod. | Yes, when policy enabled | 4800
+Mixer Policy CPU Reservation | CPU reservation for the istio-policy pod. | Yes, when policy enabled | 1000
+Mixer Policy Memory Limit | Memory resource limit for the istio-policy pod. | Yes, when policy enabled | 4096
+Mixer Policy Memory Reservation | Memory resource requests for the istio-policy pod. | Yes, when policy enabled | 1024
+Mixer Selector | Ability to select the nodes in which istio-policy and istio-telemetry pods are deployed to. To use this option, the nodes must have labels. | No                       | n/a
 
 ## TRACING
 
-Option | Description| Required | Default 
+Option | Description| Required | Default
 -------|------------|-------|-------
-Enable Tracing | Whether or not to deploy the istio-tracing. | Yes | True 
-Tracing CPU Limit | CPU resource limit for the istio-tracing pod.  | Yes      | 500 
-Tracing CPU Reservation | CPU reservation for the istio-tracing pod. | Yes      | 100 
-Tracing Memory Limit | Memory resource limit for the istio-tracing pod. | Yes      | 1024 
-Tracing Memory Reservation | Memory resource requests for the istio-tracing pod.  | Yes      | 100 
-Tracing Selector | Ability to select the nodes in which tracing pod is deployed to. To use this option, the nodes must have labels. | No       | n/a 
+Enable Tracing | Whether or not to deploy the istio-tracing. | Yes | True
+Tracing CPU Limit | CPU resource limit for the istio-tracing pod.  | Yes      | 500
+Tracing CPU Reservation | CPU reservation for the istio-tracing pod. | Yes      | 100
+Tracing Memory Limit | Memory resource limit for the istio-tracing pod. | Yes      | 1024
+Tracing Memory Reservation | Memory resource requests for the istio-tracing pod.  | Yes      | 100
+Tracing Selector | Ability to select the nodes in which tracing pod is deployed to. To use this option, the nodes must have labels. | No       | n/a
 
 ## INGRESS GATEWAY
 
-Option | Description| Required | Default 
+Option | Description| Required | Default
 -------|------------|-------|-------
-Enable Ingress Gateway | Whether or not to deploy the istio-ingressgateway. | Yes      | False 
-Service Type of Istio Ingress Gateway | How to expose the gateway. You can choose NodePort or Loadbalancer | Yes      | NodePort 
-Http2 Port | The NodePort for http2 requests  | Yes      | 31380 
-Https Port | The NodePort for https requests  | Yes      | 31390 
-Load Balancer IP | Ingress Gateway Load Balancer IP | No       | n/a 
-Load Balancer Source Ranges | Ingress Gateway Load Balancer Source Ranges | No       | n/a 
-Ingress Gateway CPU Limit | CPU resource limit for the istio-ingressgateway pod. | Yes      | 2000 
-Ingress Gateway CPU Reservation | CPU reservation for the istio-ingressgateway pod. | Yes      | 100 
-Ingress Gateway Memory Limit | Memory resource limit for the istio-ingressgateway pod. | Yes      | 1024 
-Ingress Gateway Memory Reservation | Memory resource requests for the istio-ingressgateway pod. | Yes      | 128 
-Ingress Gateway Selector | Ability to select the nodes in which istio-ingressgateway pod is deployed to. To use this option, the nodes must have labels. | No       | n/a 
+Enable Ingress Gateway | Whether or not to deploy the istio-ingressgateway. | Yes      | False
+Service Type of Istio Ingress Gateway | How to expose the gateway. You can choose NodePort or Loadbalancer | Yes      | NodePort
+Http2 Port | The NodePort for http2 requests  | Yes      | 31380
+Https Port | The NodePort for https requests  | Yes      | 31390
+Load Balancer IP | Ingress Gateway Load Balancer IP | No       | n/a
+Load Balancer Source Ranges | Ingress Gateway Load Balancer Source Ranges | No       | n/a
+Ingress Gateway CPU Limit | CPU resource limit for the istio-ingressgateway pod. | Yes      | 2000
+Ingress Gateway CPU Reservation | CPU reservation for the istio-ingressgateway pod. | Yes      | 100
+Ingress Gateway Memory Limit | Memory resource limit for the istio-ingressgateway pod. | Yes      | 1024
+Ingress Gateway Memory Reservation | Memory resource requests for the istio-ingressgateway pod. | Yes      | 128
+Ingress Gateway Selector | Ability to select the nodes in which istio-ingressgateway pod is deployed to. To use this option, the nodes must have labels. | No       | n/a
 
 ## PROMETHEUS
 
-Option | Description| Required | Default 
+Option | Description| Required | Default
 -------|------------|-------|-------
-Prometheus CPU Limit | CPU resource limit for the Prometheus pod.| Yes      | 1000 
-Prometheus CPU Reservation | CPU reservation for the Prometheus pod.| Yes      | 750 
-Prometheus Memory Limit | Memory resource limit for the Prometheus pod.| Yes      | 1024 
-Prometheus Memory Reservation | Memory resource requests for the Prometheus pod.| Yes      | 750 
-Retention for Prometheus | How long your Prometheus instance retains data | Yes      | 6 
-Prometheus Selector | Ability to select the nodes in which Prometheus pod is deployed to. To use this option, the nodes must have labels.| No       | n/a 
+Prometheus CPU Limit | CPU resource limit for the Prometheus pod.| Yes      | 1000
+Prometheus CPU Reservation | CPU reservation for the Prometheus pod.| Yes      | 750
+Prometheus Memory Limit | Memory resource limit for the Prometheus pod.| Yes      | 1024
+Prometheus Memory Reservation | Memory resource requests for the Prometheus pod.| Yes      | 750
+Retention for Prometheus | How long your Prometheus instance retains data | Yes      | 6
+Prometheus Selector | Ability to select the nodes in which Prometheus pod is deployed to. To use this option, the nodes must have labels.| No       | n/a
 
 ## GRAFANA
 
-Option | Description| Required | Default 
+Option | Description| Required | Default
 -------|------------|-------|-------
-Enable Grafana | Whether or not to deploy the Grafana.| Yes                                                         | True 
-Grafana CPU Limit | CPU resource limit for the Grafana pod.| Yes, when Grafana enabled                                   | 200 
-Grafana CPU Reservation | CPU reservation for the Grafana pod.| Yes, when Grafana enabled                                   | 100 
-Grafana Memory Limit | Memory resource limit for the Grafana pod.| Yes, when Grafana enabled                                   | 512 
-Grafana Memory Reservation | Memory resource requests for the Grafana pod.| Yes, when Grafana enabled                                   | 100 
-Grafana Selector | Ability to select the nodes in which Grafana pod is deployed to. To use this option, the nodes must have labels. | No                                                          | n/a 
-Enable Persistent Storage for Grafana | Enable Persistent Storage for Grafana | Yes, when Grafana enabled                                   | False 
-Source | Use a Storage Class to provision a new persistent volume or Use an existing persistent volume claim | Yes, when Grafana enabled and enabled PV                    | Use SC 
-Storage Class | Storage Class for provisioning PV for Grafana | Yes, when Grafana enabled, enabled PV and use storage class | Use the default class 
-Persistent Volume Size | The size for the PV you would like to provision for Grafana | Yes, when Grafana enabled, enabled PV and use storage class | 5Gi 
-Existing Claim | Use existing PVC for Grafna | Yes, when Grafana enabled, enabled PV and use existing PVC  | n/a 
+Enable Grafana | Whether or not to deploy the Grafana.| Yes                                                         | True
+Grafana CPU Limit | CPU resource limit for the Grafana pod.| Yes, when Grafana enabled                                   | 200
+Grafana CPU Reservation | CPU reservation for the Grafana pod.| Yes, when Grafana enabled                                   | 100
+Grafana Memory Limit | Memory resource limit for the Grafana pod.| Yes, when Grafana enabled                                   | 512
+Grafana Memory Reservation | Memory resource requests for the Grafana pod.| Yes, when Grafana enabled                                   | 100
+Grafana Selector | Ability to select the nodes in which Grafana pod is deployed to. To use this option, the nodes must have labels. | No                                                          | n/a
+Enable Persistent Storage for Grafana | Enable Persistent Storage for Grafana | Yes, when Grafana enabled                                   | False
+Source | Use a Storage Class to provision a new persistent volume or Use an existing persistent volume claim | Yes, when Grafana enabled and enabled PV                    | Use SC
+Storage Class | Storage Class for provisioning PV for Grafana | Yes, when Grafana enabled, enabled PV and use storage class | Use the default class
+Persistent Volume Size | The size for the PV you would like to provision for Grafana | Yes, when Grafana enabled, enabled PV and use storage class | 5Gi
+Existing Claim | Use existing PVC for Grafna | Yes, when Grafana enabled, enabled PV and use existing PVC  | n/a
 
 

--- a/content/rancher/v2.x/en/project-admin/service-mesh/_index.md
+++ b/content/rancher/v2.x/en/project-admin/service-mesh/_index.md
@@ -9,36 +9,36 @@ Using Rancher, you can connect, secure, control, and observe services through in
 
 >**Prerequisites:**
 >
->- [Service Mesh]({{< baseurl >}}/rancher/v2.x/en/cluster-admin/tools/service-mesh/) must be enabled in cluster level.
->- To be a part of an Istio service mesh, pods and services in a Kubernetes cluster must satisfy the [Istio Pods and Services Requirements](https://istio.io/docs/setup/kubernetes/prepare/requirements/)  
+>- [Service Mesh]({{< baseurl >}}/rancher/v2.x/en/cluster-admin/tools/service-mesh/) must be enabled in the cluster.
+>- To be a part of an Istio service mesh, pods and services in a Kubernetes cluster must satisfy the [Istio Pods and Services Requirements](https://istio.io/docs/setup/kubernetes/prepare/requirements/)
 
 ## Istio sidecar auto injection
 
-In create and edit namespace page, you can enable or disable [Istio sidecar auto injection](https://istio.io/blog/2019/data-plane-setup/#automatic-injection). When you enable it, Rancher will add `istio-injection=enabled` label to the namespace automatically.
+In the create and edit namespace page, you can enable or disable [Istio sidecar auto injection](https://istio.io/blog/2019/data-plane-setup/#automatic-injection). When you enable it, Rancher will add `istio-injection=enabled` label to the namespace automatically.
 
 > **Note:** Injection occurs at pod creation time. If the pod has been created before you enable auto injection. You need to kill the running pod and verify a new pod is created with the injected sidecar.
 
 ## View Traffic Graph
 
-Rancher integrates Kiali Graph into Rancher UI. The Kiali graph provides a powerful way to visualize the topology of your service mesh. It shows you which services communicate with each other.
+Rancher integrates Kiali Graph into the Rancher UI. The Kiali graph provides a powerful way to visualize the topology of your service mesh. It shows you which services communicate with each other.
 
 To see the traffic graph for a particular namespace:
 
-1. From the **Global** view, navigate to the project that you want to view traffic graph.
+1. From the **Global** view, navigate to the project that you want to view traffic graph for.
 
 1. Select **Service Mesh** in the navigation bar.
 
 1. Select **Traffic Graph** in the navigation bar.
 
-1. Select the namespace. Note: It only shows the namespaces which has `istio-injection=enabled` label
+1. Select the namespace. Note: It only shows the namespaces which has `istio-injection=enabled` label.
 
 ## View Traffic Metrics
 
-With Istio’s monitoring features, it provides visibility into the performance of all your services.
+Istio’s monitoring features provide visibility into the performance of all your services.
 
 To see the Success Rate, Request Volume, 4xx Request Count, Project 5xx Request Count and Request Duration metrics:
 
-1. From the **Global** view, navigate to the project that you want to view traffic metrics.
+1. From the **Global** view, navigate to the project that you want to view traffic metrics for.
 
 1. Select **Service Mesh** in the navigation bar.
 
@@ -47,4 +47,5 @@ To see the Success Rate, Request Volume, 4xx Request Count, Project 5xx Request 
 
 ## Other Istio Features
 
-As Istio has been deployed in your cluster, you can use all [Istio Features](https://istio.io/docs/concepts/what-is-istio/#core-features) in the cluster.
+There are many other [Istio Features](https://istio.io/docs/concepts/what-is-istio/#core-features)
+that you can now use in your cluster.


### PR DESCRIPTION
Update the main Istio configuration page to clean up some of the
language, remove repetitive statements, and fix a few minor grammar
issues.

Clean up some of the language in the project-admin Istio documentation
and a small update in the Istio configuration options page.