### PR TITLE
Add warning about running HA Rancher on hosted K8s

### DIFF
--- a/content/rancher/v2.x/en/installation/ha/_index.md
+++ b/content/rancher/v2.x/en/installation/ha/_index.md
@@ -7,6 +7,10 @@ For production environments, we recommend installing Rancher in a high-availabil
 
 This procedure walks you through setting up a 3-node cluster with RKE and installing the Rancher chart with the Helm package manager.
 
+{{% warning %}}
+It is not supported, nor generally a good idea, to run Rancher on top of hosted Kubernetes solutions such as Amazon's EKS, or Google's GKE. These hosted Kubernetes solutions do not expose etcd to a degree that is manageable for Rancher, and their customizations can interfere with Rancher operations. It is strongly recommended to use hosted infrastructure such as EC2 or GCE instead. 
+{{% /warning %}}
+
 > **Important:** For the best performance, we recommend this Kubernetes cluster to be dedicated only to run Rancher. After the Kubernetes cluster to run Rancher is setup, you can [create or import clusters]({{< baseurl >}}/rancher/v2.x/en/cluster-provisioning/#cluster-creation-in-rancher) for running your workloads.
 
 ## Recommended Architecture

--- a/content/rancher/v2.x/en/installation/ha/_index.md
+++ b/content/rancher/v2.x/en/installation/ha/_index.md
@@ -7,9 +7,7 @@ For production environments, we recommend installing Rancher in a high-availabil
 
 This procedure walks you through setting up a 3-node cluster with RKE and installing the Rancher chart with the Helm package manager.
 
-{{% warning %}}
-It is not supported, nor generally a good idea, to run Rancher on top of hosted Kubernetes solutions such as Amazon's EKS, or Google's GKE. These hosted Kubernetes solutions do not expose etcd to a degree that is manageable for Rancher, and their customizations can interfere with Rancher operations. It is strongly recommended to use hosted infrastructure such as EC2 or GCE instead. 
-{{% /warning %}}
+> **Important:** It is not supported, nor generally a good idea, to run Rancher on top of hosted Kubernetes solutions such as Amazon's EKS, or Google's GKE. These hosted Kubernetes solutions do not expose etcd to a degree that is manageable for Rancher, and their customizations can interfere with Rancher operations. It is strongly recommended to use hosted infrastructure such as EC2 or GCE instead. 
 
 > **Important:** For the best performance, we recommend this Kubernetes cluster to be dedicated only to run Rancher. After the Kubernetes cluster to run Rancher is setup, you can [create or import clusters]({{< baseurl >}}/rancher/v2.x/en/cluster-provisioning/#cluster-creation-in-rancher) for running your workloads.
 


### PR DESCRIPTION
A warning should be added to the top of the HA install docs that this is not supported nor recommended on hosted Kubernetes clusters.
I am unsure if the syntax of the warning is correct - if not, I can change it to something appropriate. However, I believe this deserves to be a **warning** instead of just a note. 