### PR TITLE
Menu clarification on Quickstart Workload pages

### DIFF
--- a/content/rancher/v2.x/en/quick-start-guide/workload/quickstart-deploy-workload-ingress/_index.md
+++ b/content/rancher/v2.x/en/quick-start-guide/workload/quickstart-deploy-workload-ingress/_index.md
@@ -19,17 +19,19 @@ For this workload, you'll be deploying the application Rancher Hello-World.
 
 3.  Open the **Project: Default** project.
 
-4.  Click **Deploy**.
+4.  From the main menu select **Workloads**, then click on the **Workloads** tab.
+
+5.  Click **Deploy**.
 
 	**Step Result:** The **Deploy Workload** page opens.
 
-5.  Enter a **Name** for your workload.
+6.  Enter a **Name** for your workload.
 
-6.  From the **Docker Image** field, enter `rancher/hello-world`. This field is case-sensitive.
+7.  From the **Docker Image** field, enter `rancher/hello-world`. This field is case-sensitive.
 
-7. Leave the remaining options on their default setting. We'll tell you about them later.
+8. Leave the remaining options on their default setting. We'll tell you about them later.
 
-8. Click **Launch**.
+9. Click **Launch**.
 
 **Result:**
 
@@ -47,7 +49,7 @@ Now that the application is up and running it needs to be exposed so that other 
 
 3.  Open the **Default** project.
 
-4.  Click on the **Load Balancing** tab.
+4.  From the main menu select **Workloads**, then click on the **Load Balancing** tab.
 
 5.  Click **Add Ingress**.
 

--- a/content/rancher/v2.x/en/quick-start-guide/workload/quickstart-deploy-workload-nodeport/_index.md
+++ b/content/rancher/v2.x/en/quick-start-guide/workload/quickstart-deploy-workload-nodeport/_index.md
@@ -19,31 +19,33 @@ For this workload, you'll be deploying the application Rancher Hello-World.
 
 3.  Open the **Project: Default** project.
 
-4.  Click **Deploy**.
+4.  From the main menu select **Workloads**, then click on the **Workloads** tab.
+
+5.  Click **Deploy**.
 
 	**Step Result:** The **Deploy Workload** page opens.
 
-5.  Enter a **Name** for your workload.
+6.  Enter a **Name** for your workload.
 
-6.  From the **Docker Image** field, enter `rancher/hello-world`. This field is case-sensitive.
+7.  From the **Docker Image** field, enter `rancher/hello-world`. This field is case-sensitive.
 
-7.  From **Port Mapping**, click **Add Port**.
+8.  From **Port Mapping**, click **Add Port**.
 
-8.  From the **As a** drop-down, make sure that **NodePort (On every node)** is selected.
+9.  From the **As a** drop-down, make sure that **NodePort (On every node)** is selected.
 
 	![As a dropdown, NodePort (On every node selected)]({{< baseurl >}}/img/rancher/nodeport-dropdown.png)
 
-9.  From the **On Listening Port** field, leave the **Random** value in place.
+10.  From the **On Listening Port** field, leave the **Random** value in place.
 
 	![On Listening Port, Random selected]({{< baseurl >}}/img/rancher/listening-port-field.png)
 
-10. From the **Publish the container port** field, enter port `80`.
+11. From the **Publish the container port** field, enter port `80`.
 
 	![Publish the container port, 80 entered]({{< baseurl >}}/img/rancher/container-port-field.png)
 
-11. Leave the remaining options on their default setting. We'll tell you about them later.
+12. Leave the remaining options on their default setting. We'll tell you about them later.
 
-12. Click **Launch**.
+13. Click **Launch**.
 
 **Result:**
 

--- a/content/rancher/v2.x/en/quick-start-guide/workload/quickstart-deploy-workload-nodeport/_index.md
+++ b/content/rancher/v2.x/en/quick-start-guide/workload/quickstart-deploy-workload-nodeport/_index.md
@@ -60,7 +60,7 @@ From the **Workloads** page, click the link underneath your workload. If your de
 
 ### Attention: Cloud-Hosted Sandboxes
 
-When using a cloud-hosted virtual machine, you may not have access to the port running the container. In this event, you can test Nginx in an ssh session on the local machine. Use the port number after the `:` in the link under your workload, which is `31568` in this example.
+When using a cloud-hosted virtual machine, you may not have access to the port running the container. In this event, you can test Nginx in an ssh session on the local machine using `Execute Shell`. Use the port number after the `:` in the link under your workload if available, which is `31568` in this example.
 
 ```sh
 gettingstarted@rancher:~$ curl http://localhost:31568


### PR DESCRIPTION
URLs this PR updates: 
* https://rancher.com/docs/rancher/v2.x/en/quick-start-guide/workload/quickstart-deploy-workload-ingress/
* https://rancher.com/docs/rancher/v2.x/en/quick-start-guide/workload/quickstart-deploy-workload-nodeport/

If you had already clicked around in the cluster before you started this guide, when you do step 3 you will default to the last page you had open. That might be inside the Apps menu item, or Workloads->LB. We should clarify that they want to be on Workloads->Workloads, even though its a bit redundant. 