### PR TITLE
Fix config key for S3 backups in Rancher HA Clusters created by RKE

### DIFF
--- a/content/rancher/v2.x/en/backups/backups/ha-backups/_index.md
+++ b/content/rancher/v2.x/en/backups/backups/ha-backups/_index.md
@@ -57,7 +57,7 @@ To take recurring snapshots, enable the `etcd-snapshot` service, which is a serv
           interval_hours: 6 # time increment between snapshots
           retention: 60     # time in days before snapshot purge
           # Optional S3
-          s3_backup_config:
+          s3backupconfig:
             access_key: "myaccesskey"
             secret_key:  "myaccesssecret"
             bucket_name: "my-backup-bucket"


### PR DESCRIPTION
The [RKE Docs](https://rancher.com/docs/rke/latest/en/etcd-snapshots/#options-for-the-etcd-snapshot-service) use `s3backupconfig` as the configuration key for ETCD Backups to S3. However, the Rancher docs incorrectly use `s3_backup_config`. After changing the key and `rke up`'ing my cluster it appears to be properly configured to now ship ETCD snapshots to S3.