### PR TITLE
Specify 0.5.2 version for cert-manager

### DIFF
--- a/content/rancher/v2.x/en/installation/air-gap-high-availability/prepare-private-registry/_index.md
+++ b/content/rancher/v2.x/en/installation/air-gap-high-availability/prepare-private-registry/_index.md
@@ -40,7 +40,7 @@ Start by collecting all the images needed to install Rancher in an air gap envir
     1.  Fetch the latest `cert-manager` Helm chart and parse the template for image details.
 
         ```plain
-        helm fetch stable/cert-manager
+        helm fetch stable/cert-manager --version 0.5.2
         helm template ./cert-manager-<version>.tgz | grep -oP '(?<=image: ").*(?=")' >> ./rancher-images.txt
         ```
 


### PR DESCRIPTION
Our air-gap docs currently don't pin cert-manager's version to 0.5.2 when obtaining the chart. This is incorrect, and can lead to issues for users. 