### PR TITLE
Edits to security hardening and benchmark guides

### DIFF
--- a/content/rancher/v2.x/en/security/_index.md
+++ b/content/rancher/v2.x/en/security/_index.md
@@ -22,19 +22,21 @@ weight: 7505
 
 ### Rancher Hardening Guide
 
-The Rancher Hardening Guide is based off of controls and best practices found in the [CIS Kubernetes Benchmark](https://www.cisecurity.org/benchmark/kubernetes/).  See Rancher's [Self Assessment of the CIS Kubernetes Benchmark](#CIS-Benchmark-Rancher-Self-Assessment) for the full list of security controls.
+The Rancher Hardening Guide is based off of controls and best practices found in the [CIS Kubernetes Benchmark](https://www.cisecurity.org/benchmark/kubernetes/). The hardening guide provides prescriptive guidance for hardening a production installation of Rancher v2.1.x. See Rancher's [Self Assessment of the CIS Kubernetes Benchmark](#CIS-Benchmark-Rancher-Self-Assessment) for the full list of security controls.
 
 * [CIS Kubernetes Benchmark 1.3.0 - Rancher 2.1.x with Kubernetes 1.11]({{< baseurl >}}/rancher/v2.x/en/security/hardening-2.1/)
 
 ### CIS Benchmark Rancher Self-Assessment
 
-Since Rancher and RKE install Kubernetes services as Docker containers many of the control verification checks in the CIS Kubernetes Benchmark don't apply. This guide will walk through the various controls and provide updated example commands to audit compliance in Rancher created clusters.  The original benchmark documents can be downloaded from the [CIS website](https://www.cisecurity.org/benchmark/kubernetes/).
+This document is a companion to the Rancher v2.1.x security hardening guide. While the hardening guide shows you how to harden the cluster, the benchmark guide is meant to help you evaluate the level of security of the hardened cluster.
+
+Because Rancher and RKE install Kubernetes services as Docker containers, many of the control verification checks in the CIS Kubernetes Benchmark don't apply. This guide will walk through the various controls and provide updated example commands to audit compliance in Rancher created clusters. The original benchmark documents can be downloaded from the [CIS website](https://www.cisecurity.org/benchmark/kubernetes/).
 
 * [CIS Kubernetes Benchmark 1.3.0 - Rancher 2.1.x with Kubernetes 1.11]({{< baseurl >}}/rancher/v2.x/en/security/benchmark-2.1/)
 
 ### Rancher CVEs and Resolutions
 
-Rancher is committed to informing the community of security issues in our products. Rancher will publish CVEs for issues we have resolved.
+Rancher is committed to informing the community of security issues in our products. Rancher will publish CVEs (Common Vulnerabilities and Exposures) for issues we have resolved.
 
 | ID | Description | Date | Resolution |
 |----|-------------|------|------------|

--- a/content/rancher/v2.x/en/security/benchmark-2.1/_index.md
+++ b/content/rancher/v2.x/en/security/benchmark-2.1/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Benchmark - Rancher v2.1.x
+title: CIS Benchmark Rancher Self-Assessment Guide - Rancher v2.1.x
 weight: 100
 ---
 
@@ -9,7 +9,15 @@ weight: 100
 
 #### Overview
 
-The following document scores a Kubernetes 1.11.x RKE cluster provisioned according to the Rancher 2.1.x hardening guide against the CIS 1.3.0 Kubernetes benchmark. This document is to be used by Rancher operators, security teams, auditors and decision makers.
+This document is a companion to the Rancher v2.1.x security hardening guide. The hardening guide provides prescriptive guidance for hardening a production installation of Rancher v2.1.x, and this benchmark guide is meant to help you evaluate the level of security of the hardened cluster.
+
+The scope of this document is limited to scoring a Kubernetes v1.11.x RKE cluster against the CIS Kubernetes benchmark v1.3.0. The hardened cluster is evaluated against each recommendation from the Center for Internet Security (CIS) in the benchmark.
+
+Because Rancher and RKE install Kubernetes services as Docker containers, many of the control verification checks in the CIS Kubernetes Benchmark don't apply. This guide will walk through the various controls and provide updated example commands to audit compliance in Rancher-created clusters.
+
+This document is to be used by Rancher operators, security teams, auditors and decision makers.
+
+For more detail about each audit, including rationales and remediations for failing tests, you can refer to the corresponding section of the CIS Kubernetes Benchmark v1.3.0. You can download the benchmark after logging in to [CISecurity.org]( https://www.cisecurity.org/benchmark/kubernetes/).
 
 #### Testing controls methodology
 
@@ -477,19 +485,19 @@ docker inspect kube-apiserver | jq -e '.[0].Args[] | match("--tls-cipher-suites=
 docker inspect kube-apiserver | jq -e '.[0].Args[] | match("--tls-cipher-suites=.*(TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256).*").captures[].string'
 ```
 
-**Returned Value:**
+**Returned Value:** The return should be blank.
 
 ``` bash
 docker inspect kube-apiserver | jq -e '.[0].Args[] | match("--tls-cipher-suites=.*(TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384).*").captures[].string'
 ```
 
-**Returned Value:**
+**Returned Value:** The return should be blank.
 
 ``` bash
 docker inspect kube-apiserver | jq -e '.[0].Args[] | match("--tls-cipher-suites=.*(TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305).*").captures[].string'
 ```
 
-**Returned Value:**
+**Returned Value:** The return should be blank.
 
 ``` bash
 docker inspect kube-apiserver | jq -e '.[0].Args[] | match("--tls-cipher-suites=.*(TLS_RSA_WITH_AES_128_GCM_SHA256).*").captures[].string'
@@ -1020,7 +1028,7 @@ stat -c %U:%G /var/lib/etcd
 
 **Notes**
 
-RKE does not store the kubernetes default kubeconfig credentials file on the nodes.  It's presented to user where RKE is run. We recommend that this kube_config_cluster.yml file be kept in secure store.
+RKE does not store the kubernetes default kubeconfig credentials file on the nodes.  It's presented to user where RKE is run. We recommend that this `kube_config_cluster.yml` file be kept in secure store.
 
 **Result:** Pass (Not Applicable)
 
@@ -1132,7 +1140,7 @@ docker inspect etcd | jq -e '.[0].Args[] | match("--auto-tls(?:(?!=false).*)").s
 
 #### 1.5.4 - Ensure that the `--peer-cert-file` and `--peer-key-file` arguments are set as appropriate (Scored)
 
-**Audit** (`--peer-cert-file)
+**Audit** (`--peer-cert-file`)
 
 ``` bash
 docker inspect etcd | jq -e '.[0].Args[] | match("--peer-cert-file=.*").string'
@@ -1140,7 +1148,7 @@ docker inspect etcd | jq -e '.[0].Args[] | match("--peer-cert-file=.*").string'
 
 **Returned Value:** `--peer-cert-file=/etc/kubernetes/ssl/kube-etcd-172-31-22-135.pem`
 
-**Audit** (`--peer-key-file)
+**Audit** (`--peer-key-file`)
 
 ``` bash
 docker inspect etcd | jq -e '.[0].Args[] | match("--peer-key-file=.*").string'
@@ -1154,7 +1162,7 @@ docker inspect etcd | jq -e '.[0].Args[] | match("--peer-key-file=.*").string'
 
 **Notes**
 
-Setting "--peer-client-cert-auth" is the equivalent of setting "--peer-client-cert-auth=true".
+Setting `--peer-client-cert-auth` is the equivalent of setting `--peer-client-cert-auth=true`.
 
 **Audit**
 
@@ -1223,7 +1231,7 @@ Since this requires the enabling of AllAlpha feature gates we would not recommen
 
 #### 1.6.5 - Apply security context to your pods and containers (Not Scored)
 
-This practice does go against control 1.1.13, but we prefer using PSP and allowing security context to be set over a blanket deny.
+This practice does go against control 1.1.13, but we prefer using `PodSecurityPolicy` and allowing security context to be set over a blanket deny.
 
 Rancher allows users to set various Security Context options when launching pods via the GUI interface.
 
@@ -1237,7 +1245,7 @@ Rancher can (optionally) automatically create Network Policies to isolate projec
 
 See the _Cluster Options_ section when creating a cluster with Rancher to turn on network isolation.
 
-#### 1.6.8 - Place compensating controls in the form of PSP and RBAC for privileged container usage (Not Scored)
+#### 1.6.8 - Place compensating controls in the form of PodSecurityPolicy (PSP) and RBAC for privileged container usage (Not Scored)
 
 Section 1.7 of this guide shows how to add and configure a default "restricted" PSP based on controls.
 
@@ -1255,7 +1263,7 @@ This RKE configuration has two Pod Security Policies.
 
 **Notes**
 
-The restricted PSP is available to all ServiceAccounts.
+The restricted PodSecurityPolicy (PSP) is available to all ServiceAccounts.
 
 **Audit**
 
@@ -1271,7 +1279,7 @@ kubectl get psp restricted -o jsonpath='{.spec.privileged}' | grep "true"
 
 **Notes**
 
-The restricted PSP is available to all ServiceAccounts.
+The restricted PodSecurityPolicy (PSP) is available to all ServiceAccounts.
 
 **Audit**
 
@@ -1287,7 +1295,7 @@ kubectl get psp restricted -o jsonpath='{.spec.hostPID}' | grep "true"
 
 **Notes**
 
-The restricted PSP is available to all ServiceAccounts.
+The restricted PodSecurityPolicy (PSP) is available to all ServiceAccounts.
 
 **Audit**
 
@@ -1303,7 +1311,7 @@ kubectl get psp restricted -o jsonpath='{.spec.hostIPC}' | grep "true"
 
 **Notes**
 
-The restricted PSP is available to all ServiceAccounts.
+The restricted PodSecurityPolicy (PSP) is available to all ServiceAccounts.
 
 **Audit**
 
@@ -1319,7 +1327,7 @@ kubectl get psp restricted -o jsonpath='{.spec.hostNetwork}' | grep "true"
 
 **Notes**
 
-The restricted PSP is available to all ServiceAccounts.
+The restricted PodSecurityPolicy (PSP) is available to all ServiceAccounts.
 
 **Audit**
 
@@ -1335,7 +1343,7 @@ kubectl get psp restricted -o jsonpath='{.spec.allowPrivilegeEscalation}' | grep
 
 **Notes**
 
-The restricted PSP is available to all ServiceAccounts.
+The restricted PodSecurityPolicy (PSP) is available to all ServiceAccounts.
 
 **Audit**
 
@@ -1351,7 +1359,7 @@ kubectl get psp restricted -o jsonpath='{.spec.runAsUser.rule}' | grep "RunAsAny
 
 **Notes**
 
-The restricted PSP is available to all ServiceAccounts.
+The restricted PodSecurityPolicy (PSP) is available to all ServiceAccounts.
 
 **Audit**
 

--- a/content/rancher/v2.x/en/security/hardening-2.1/_index.md
+++ b/content/rancher/v2.x/en/security/hardening-2.1/_index.md
@@ -9,13 +9,15 @@ weight: 100
 
 ### Overview
 
-This document provides prescriptive guidance for hardening a production installation of Rancher v2.1.x. It outlines the configurations and controls required to address CIS-Kubernetes benchmark controls.
+This document provides prescriptive guidance for hardening a production installation of Rancher v2.1.x. It outlines the configurations and controls required to address Kubernetes benchmark controls from the Center for Information Security (CIS).
 
-[CIS Benchmark Rancher Self-Assessment Guide]({{< baseurl >}}/rancher/v2.x/en/security/benchmark-2.1/)
+For more detail on how a hardened cluster scores against the official CIS benchmark, refer to the [CIS Benchmark Rancher Self-Assessment Guide]({{< baseurl >}}/rancher/v2.x/en/security/benchmark-2.1/).
 
 ### Profile Definitions
 
-The following profile definitions agree with the CIS Benchmarks for Kubernetes.
+The following profile definitions agree with the CIS benchmarks for Kubernetes.
+
+A profile is a set of configurations that provide a certain amount of hardening. Generally, the more hardened an environment is, the more it affects performance.
 
 #### Level 1
 
@@ -325,7 +327,7 @@ plugins:
   path: /etc/kubernetes/event.yaml
 ```
 
-- For event.yaml set the contents to:
+- For `event.yaml` set the contents to:
 
 ``` yaml
 apiVersion: eventratelimit.admission.k8s.io/v1alpha1
@@ -354,10 +356,10 @@ Ensure Kubelet options are configured to match CIS controls.
 
 To pass the following controls in the CIS benchmark, ensure the appropriate flags are passed to the Kubelet.
 
-- 2.1.6 - Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Scored)
-- 2.1.7 - Ensure that the --protect-kernel-defaults argument is set to true (Scored)
-- 2.1.8 - Ensure that the --make-iptables-util-chains argument is set to true (Scored)
-- 2.1.10 - Ensure that the --event-qps argument is set to 0 (Scored)
+- 2.1.6 - Ensure that the `--streaming-connection-idle-timeout` argument is not set to 0 (Scored)
+- 2.1.7 - Ensure that the `--protect-kernel-defaults` argument is set to true (Scored)
+- 2.1.8 - Ensure that the `--make-iptables-util-chains` argument is set to true (Scored)
+- 2.1.10 - Ensure that the `--event-qps` argument is set to 0 (Scored)
 
 **Audit**
 
@@ -550,9 +552,9 @@ Set the appropriate arguments on the Kubernetes controller manager.
 
 To address the following controls the options need to be passed to the Kubernetes controller manager.
 
-- 1.3.1 - Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Scored)
-- 1.3.2 - Ensure that the --profiling argument is set to false (Scored)
-- 1.3.7 - Ensure that the --address argument is set to 127.0.0.1 (Scored)
+- 1.3.1 - Ensure that the `--terminated-pod-gc-threshold` argument is set as appropriate (Scored)
+- 1.3.2 - Ensure that the `--profiling` argument is set to false (Scored)
+- 1.3.7 - Ensure that the `--address` argument is set to 127.0.0.1 (Scored)
 
 **Audit**
 
@@ -572,7 +574,7 @@ docker inspect kube-controller-manager
 
 **Remediation**
 
-- In the RKE cluster.yml file ensure the following options are set:
+- In the RKE `cluster.yml` file ensure the following options are set:
 
 ``` yaml
 services:
@@ -597,7 +599,7 @@ rke up --config cluster.yml
 
 **Description**
 
-Configure a restrictive pod security policy (PSP) as the default and create role bindings for system level services to use the less restrictive default PSP.
+Configure a restrictive PodSecurityPolicy (PSP) as the default and create role bindings for system level services to use the less restrictive default PSP.
 
 **Rationale**
 


### PR DESCRIPTION
This PR is a follow-up to https://github.com/rancher/docs/pull/1556

In this PR, formatting and style edits are the same in both versions of both the benchmark and hardening guides. In addition to that, the main security page lists both versions of each document. 