### PR TITLE
Update k3s docs for INSTALL_K3S_SYMLINK

### DIFF
--- a/content/k3s/latest/en/installation/_index.md
+++ b/content/k3s/latest/en/installation/_index.md
@@ -43,6 +43,11 @@ The full help text for the install script environment variables are as follows:
    - `INSTALL_K3S_SKIP_DOWNLOAD`
 
      If set to true will not download k3s hash or binary.
+     
+   - INSTALL_K3S_SYMLINK
+
+     If set to 'skip' will not create symlinks, 'force' will overwrite,
+     default will symlink if command does not exist in path.
 
    - `INSTALL_K3S_VERSION`
 


### PR DESCRIPTION
Adds INSTALL_K3S_SYMLINK which can be set to 'skip' or 'force',
default is not to symlink if already in path.