### PR TITLE
fix incorrect s3backupconfig key

### DIFF
--- a/content/rancher/v2.x/en/backups/backups/ha-backups/_index.md
+++ b/content/rancher/v2.x/en/backups/backups/ha-backups/_index.md
@@ -57,7 +57,7 @@ To take recurring snapshots, enable the `etcd-snapshot` service, which is a serv
           interval_hours: 6 # time increment between snapshots
           retention: 60     # time in days before snapshot purge
           # Optional S3
-          s3_backup_config:
+          s3backupconfig:
             access_key: "myaccesskey"
             secret_key:  "myaccesssecret"
             bucket_name: "my-backup-bucket"


### PR DESCRIPTION
Sebastiaan helped me figure out that the Rancher docs have an incorrect key (`s3_backup_config`), whereas the RKE docs have it correct (`s3backupconfig`). There's no logging that says the key is invalid; it just ignored it. This fixes the mistake in the docs prior to releasing https://www.youtube.com/watch?v=PtYeoUT5gGk that references it.