### PR TITLE
changing alpine to busybox in instructions

### DIFF
--- a/content/rancher/v2.x/en/backups/backups/single-node-backups/_index.md
+++ b/content/rancher/v2.x/en/backups/backups/single-node-backups/_index.md
@@ -13,7 +13,7 @@ After completing your single node installation of Rancher, we recommend creating
 During the creation of your backup, you'll enter a series of commands, replacing placeholders with data from your environment. These placeholders are denoted with angled brackets and all capital letters (`<EXAMPLE>`). Here's an example of a command with a placeholder:
 
 ```
-docker run  --volumes-from rancher-data-<DATE> -v $PWD:/backup alpine tar zcvf /backup/rancher-data-backup-<RANCHER_VERSION>-<DATE>.tar.gz /var/lib/rancher
+docker run  --volumes-from rancher-data-<DATE> -v $PWD:/backup busybox tar zcvf /backup/rancher-data-backup-<RANCHER_VERSION>-<DATE>.tar.gz /var/lib/rancher
 ```
 
 In this command, `<DATE>` is a placeholder for the date that the data container and backup were created. `9-27-18` for example.
@@ -54,7 +54,7 @@ This procedure creates a backup that you can restore if Rancher encounters a dis
 1. <a id="tarball"></a>From the data container that you just created (`rancher-data-<DATE>`), create a backup tarball (`rancher-data-backup-<RANCHER_VERSION>-<DATE>.tar.gz`). Use the following command, replacing each [placeholder](#before-you-start).
 
     ```
-    docker run  --volumes-from rancher-data-<DATE> -v $PWD:/backup:z alpine tar zcvf /backup/rancher-data-backup-<RANCHER_VERSION>-<DATE>.tar.gz /var/lib/rancher
+    docker run  --volumes-from rancher-data-<DATE> -v $PWD:/backup:z busybox tar zcvf /backup/rancher-data-backup-<RANCHER_VERSION>-<DATE>.tar.gz /var/lib/rancher
     ```
 
     **Step Result:** A stream of commands runs on the screen.

--- a/content/rancher/v2.x/en/backups/restorations/single-node-restoration/_index.md
+++ b/content/rancher/v2.x/en/backups/restorations/single-node-restoration/_index.md
@@ -14,7 +14,7 @@ During restoration of your backup, you'll enter a series of commands, filling pl
 
 ```
 docker run  --volumes-from <RANCHER_CONTAINER_NAME> -v $PWD:/backup \
-alpine sh -c "rm /var/lib/rancher/* -rf  && \
+busybox sh -c "rm /var/lib/rancher/* -rf  && \
 tar zxvf /backup/rancher-data-backup-<RANCHER_VERSION>-<DATE>"
 ```
 
@@ -56,7 +56,7 @@ Using a [backup]({{< baseurl >}}/rancher/v2.x/en/backups/backups/single-node-bac
 
     ```
     docker run  --volumes-from <RANCHER_CONTAINER_NAME> -v $PWD:/backup \
-    alpine sh -c "rm /var/lib/rancher/* -rf  && \
+    busybox sh -c "rm /var/lib/rancher/* -rf  && \
     tar zxvf /backup/rancher-data-backup-<RANCHER_VERSION>-<DATE>.tar.gz"
     ```
 

--- a/content/rancher/v2.x/en/upgrades/rollbacks/single-node-rollbacks/_index.md
+++ b/content/rancher/v2.x/en/upgrades/rollbacks/single-node-rollbacks/_index.md
@@ -67,7 +67,7 @@ If you have issues upgrading Rancher, roll it back to its lastest known healthy 
 
     ```
     docker run  --volumes-from rancher-data \
-    -v $PWD:/backup alpine sh -c "rm /var/lib/rancher/* -rf \
+    -v $PWD:/backup busybox sh -c "rm /var/lib/rancher/* -rf \
     && tar zxvf /backup/rancher-data-backup-<RANCHER_VERSION>-<DATE>.tar.gz"
     ```
 

--- a/content/rancher/v2.x/en/upgrades/upgrades/single-node-upgrade/_index.md
+++ b/content/rancher/v2.x/en/upgrades/upgrades/single-node-upgrade/_index.md
@@ -12,7 +12,7 @@ During upgrade, you'll enter a series of commands, filling placeholders with dat
 
 
 ```
-docker run  --volumes-from rancher-data -v $PWD:/backup alpine tar zcvf /backup/rancher-data-backup-<RANCHER_VERSION>-<DATE>.tar.gz /var/lib/rancher
+docker run  --volumes-from rancher-data -v $PWD:/backup busybox tar zcvf /backup/rancher-data-backup-<RANCHER_VERSION>-<DATE>.tar.gz /var/lib/rancher
 ```
 
 In this command, `<RANCHER_VERSION>-<DATE>` is the version number and date of creation for a backup of Rancher.
@@ -63,7 +63,7 @@ During upgrade, you create a copy of the data from your current Rancher containe
 
 
     ```
-    docker run --volumes-from rancher-data -v $PWD:/backup alpine tar zcvf /backup/rancher-data-backup-<RANCHER_VERSION>-<DATE>.tar.gz /var/lib/rancher
+    docker run --volumes-from rancher-data -v $PWD:/backup busybox tar zcvf /backup/rancher-data-backup-<RANCHER_VERSION>-<DATE>.tar.gz /var/lib/rancher
     ```
 
     **Step Result:** When you enter this command, a series of commands should run.


### PR DESCRIPTION
Addresses: https://github.com/rancher/rancher/issues/21650

Since we are including busybox image for fixing https://github.com/rancher/rancher/issues/20780, why not use the same for other purposes as well?