### PR TITLE
Update and clarify docs on global and cluster permissions 

### DIFF
--- a/content/rancher/v2.x/en/admin-settings/rbac/cluster-project-roles/_index.md
+++ b/content/rancher/v2.x/en/admin-settings/rbac/cluster-project-roles/_index.md
@@ -51,20 +51,6 @@ For details on how each cluster role can access Kubernetes resources, you can go
 > **Note:**
 >When viewing the resources associated with default roles created by Rancher, if there are multiple Kubernetes API resources on one line item, the resource will have `(Custom)` appended to it. These are not custom resources but just an indication that there are multiple Kubernetes API resources as one resource.
 
-### Configuring the Default Permissions for Cluster Owners
-
-Admins can configure the default role of cluster creators from the Rancher UI. To change the default role for a cluster creator,
-
-1. Go to the **Global** view.
-
-1. Click **Security > Roles** and go to the **Clusters** tab.
-
-1. Go to the cluster role that you want to make the default for cluster owners and click **Ellipsis (...) > Edit.**
-
-1. In the **Cluster Creator Default** section, click the option **Yes: Default role for new cluster creation.**
-
-> **Result:** The role will be used by default for the creator of a new cluster.
-
 ### Giving a Custom Cluster Role to a Cluster Member
 
 Admins can set up custom cluster roles that can be assigned to cluster owners and members.

--- a/content/rancher/v2.x/en/admin-settings/rbac/cluster-project-roles/_index.md
+++ b/content/rancher/v2.x/en/admin-settings/rbac/cluster-project-roles/_index.md
@@ -88,7 +88,7 @@ To assign the role to a new cluster member,
 
 1. When you click **Create**, the member should have the assigned role.
 
-To assign the role to an existing cluster member,
+To assign any custom role to an existing cluster member,
 
 1. Go to the member you want to give the role to. Click the **Ellipsis (...) > View in API.**
 

--- a/content/rancher/v2.x/en/admin-settings/rbac/cluster-project-roles/_index.md
+++ b/content/rancher/v2.x/en/admin-settings/rbac/cluster-project-roles/_index.md
@@ -31,26 +31,68 @@ Rancher lets you assign _custom cluster roles_ to a user instead of the typical 
 
 #### Cluster Role Reference
 
-The following table lists each built-in custom cluster role available in Rancher and whether it is also granted by the `Owner` or `Member` role.
+The following table lists each built-in custom cluster role available and whether that level of access is included in the default cluster-level permissions, `Cluster Owner` and `Cluster Member`.
 
 | Custom Cluster Role                | Owner         | Member <a id="clus-roles"></a> |
 | ---------------------------------- | ------------- | --------------------------------- |
+| Create Projects                    | ✓             |                                   |
+| Manage Cluster Backups			 | ✓             |                                   |
+| Manage Cluster Catalogs            | ✓             |                                   |
 | Manage Cluster Members             | ✓             |                                   |
-| Manage Cluster Catalogs			 | ✓             |
 | Manage Nodes                       | ✓             |                                   |
-| Manage Snapshots                   | ✓             ||
 | Manage Storage                     | ✓             |                                   |
-| View All Projects                  | ✓             |                                   |
-| Create Project                     | ✓             | ✓                                 |
-| View Cluster Members               | ✓             | ✓                                 |
+| View All Projects                  | ✓             | ✓                                 |
 | View Cluster Catalogs              | ✓             | ✓                                 |
+| View Cluster Members               | ✓             | ✓                                 |
 | View Nodes                         | ✓             | ✓                                 |
-| View Snapshots                     | ✓             | ✓                                 |
 
-> **Notes:**
->
->- Each cluster role listed above, including `Owner` and `Member`, is comprised of multiple rules granting access to various resources. You can view the roles and their rules on the Global > Security > Roles page.   
->- When viewing the resources associated with default roles created by Rancher, if there are multiple Kuberenetes API resources on one line item, the resource will have `(Custom)` appended to it. These are not custom resources but just an indication that there are multiple Kubernetes API resources as one resource.
+For details on how each cluster role can access Kubernetes resources, you can go to the **Global** view in the Rancher UI. Then click **Security > Roles** and go to the **Clusters** tab. If you click an individual role, you can refer to the **Grant Resources** table to see all of the operations and resources that are permitted by the role.
+
+> **Note:**
+>When viewing the resources associated with default roles created by Rancher, if there are multiple Kubernetes API resources on one line item, the resource will have `(Custom)` appended to it. These are not custom resources but just an indication that there are multiple Kubernetes API resources as one resource.
+
+### Configuring the Default Permissions for Cluster Owners
+
+Admins can configure the default role of cluster creators from the Rancher UI. To change the default role for a cluster creator,
+
+1. Go to the **Global** view.
+
+1. Click **Security > Roles** and go to the **Clusters** tab.
+
+1. Go to the cluster role that you want to make the default for cluster owners and click **Ellipsis (...) > Edit.**
+
+1. In the **Cluster Creator Default** section, click the option **Yes: Default role for new cluster creation.**
+
+> **Result:** The role will be used by default for the creator of a new cluster.
+
+### Giving a Custom Cluster Role to a Cluster Member
+
+Admins can set up custom cluster roles that can be assigned to cluster owners and members.
+
+Cluster owners and admins can then assign those roles to cluster members.
+
+To create a custom cluster role,
+
+1. In the **Global** view under **Security > Roles,** click **Add Cluster Role.**
+
+1. In the **Grant Resources** section, choose any combination of operations on Kubernetes resources that will be allowed by the new role. Give the new cluster role a name and click **Create.**
+
+Then, from the **Cluster** view, go to the **Members** tab. From this tab, you can give the cluster role to members in two ways:
+
+- You can assign the role to a new member with the Rancher UI.
+- You can assign the role to an existing member with the Rancher API view.
+
+To assign the role to a new cluster member,
+
+1. Click **Add Member.** Then in the **Cluster Permissions** section, you can choose your custom cluster role. 
+
+1. When you click **Create**, the member should have the assigned role.
+
+To assign the role to an existing cluster member,
+
+1. Go to the member you want to give the role to. Click the **Ellipsis (...) > View in API.**
+
+1. In the **roleTemplateId** field, go to the drop-down menu and choose the role you want to assign to the member. Click **Show Request** and **Send Request.** After that, the member's role should be updated.
 
 ### Project Roles
 

--- a/content/rancher/v2.x/en/admin-settings/rbac/cluster-project-roles/_index.md
+++ b/content/rancher/v2.x/en/admin-settings/rbac/cluster-project-roles/_index.md
@@ -158,7 +158,7 @@ There are two methods for changing default cluster/project roles:
 >- Although you can [lock]({{< baseurl >}}/rancher/v2.x/en/admin-settings/rbac/locked-roles/) a default role, the system still assigns the role to users who create a cluster/project.
 >- Only users that create clusters/projects inherit their roles. Users added to the cluster/project membership afterward must be explicitly assigned their roles.
 
-### Configuring Default Roles
+### Configuring Default Roles for Cluster and Project Creators
 
 You can change the cluster or project role(s) that are automatically assigned to the creating user.
 

--- a/content/rancher/v2.x/en/admin-settings/rbac/global-permissions/_index.md
+++ b/content/rancher/v2.x/en/admin-settings/rbac/global-permissions/_index.md
@@ -56,7 +56,7 @@ The following table lists each custom global permission available and whether it
 | Create Clusters                    | ✓             | ✓             |
 | Manage Authentication              | ✓             |               |
 | Manage Catalogs                    | ✓             |               |
-| Manager Cluster Drivers            | ✓             |               |
+| Manage Cluster Drivers            | ✓             |               |
 | Manage Node Drivers                | ✓             |               |
 | Manage PodSecurityPolicy Templates | ✓             |               |
 | Manage Roles                       | ✓             |               |

--- a/content/rancher/v2.x/en/admin-settings/rbac/global-permissions/_index.md
+++ b/content/rancher/v2.x/en/admin-settings/rbac/global-permissions/_index.md
@@ -84,7 +84,7 @@ To change the default global permissions that are assigned to external users upo
 
 1. Find the permissions set that you want to use as default. Then edit the permission by selecting **Ellipsis > Edit**.
 
-1. Select **Yes: Default role for new users** and then click **Save**.
+1. If you want to add the permission as a default, Select **Yes: Default role for new users** and then click **Save**.
 
 1. If you want to remove a default permission, edit the permission and select **No** from **New User Default**.
 

--- a/content/rancher/v2.x/en/admin-settings/rbac/global-permissions/_index.md
+++ b/content/rancher/v2.x/en/admin-settings/rbac/global-permissions/_index.md
@@ -82,7 +82,7 @@ To change the default global permissions that are assigned to external users upo
 
 1. From the **Global** view, select **Security > Roles** from the main menu. Make sure the **Global** tab is selected.
 
-1. Find the permissions set that you want to use as default. Then edit the permission by selecting **Ellipsis > Edit**.
+1. Find the permissions set that you want to add or remove as a default. Then edit the permission by selecting **Ellipsis > Edit**.
 
 1. If you want to add the permission as a default, Select **Yes: Default role for new users** and then click **Save**.
 

--- a/content/rancher/v2.x/en/admin-settings/rbac/global-permissions/_index.md
+++ b/content/rancher/v2.x/en/admin-settings/rbac/global-permissions/_index.md
@@ -3,6 +3,8 @@ title: Global Permissions
 weight: 1126
 ---
 
+_Permissions_ are individual access rights that you can assign when selecting a custom permission for a user.
+
 Global Permissions define user authorization outside the scope of any particular cluster. Out-of-the-box, there are two default global permissions: `Administrator` and `Standard User`.
 
 - **Administrator:**
@@ -15,7 +17,7 @@ Global Permissions define user authorization outside the scope of any particular
 
 >**Note:** You cannot create, update, or delete Global Permissions.
 
-### Global Permission Assignment
+# Global Permission Assignment
 
 Assignment of global permissions to a user depends on their authentication source: external or local.
 
@@ -27,45 +29,56 @@ Assignment of global permissions to a user depends on their authentication sourc
 
     When you create a new local user, you assign them a global permission as you complete the **Add User** form.
 
-### Custom Global Permissions
+# Custom Global Permissions
 
-Rather than assigning users the default global permissions of `Administrator` or `Standard User`, you can assign them a custom set of permissions.
+Using custom permissions is convenient for providing users with narrow or specialized access to Rancher.
 
-_Permissions_ are individual access rights that you can assign when selecting a custom permission for a user.
+When a user from an [external authentication source]({{< baseurl >}}/rancher/v2.x/en/admin-settings/authentication/) signs into Rancher for the first time, they're automatically assigned a set of global permissions (hereafter, permissions). By default, new users are assigned the user permissions.
 
-Using custom permissions is convenient for providing users with narrow or specialized access to Rancher. See the [table below](#global-permissions-reference) for a list of individual permissions available.
+However, in some organizations, these permissions may extend too much access. Rather than assigning users the default global permissions of `Administrator` or `Standard User`, you can assign them a more restrictive set of custom global permissions.
 
-### Global Permissions Reference
+The default roles, Admin and User, each come with multiple global permissions built into them. The Admin role includes all global permissions, while the default user role includes three global permissions: Create Clusters, Use Catalog Templates, and User Base, which is equivalent to the minimum permission to log in to Rancher. In other words, the custom global permissions are modularized so that if you want to change the default user role permissions, you can choose which subset of global permissions are included in the new default user role.
 
-The following table lists each custom global permission available and whether it is assigned to the default global permissions, `Administrator` and `Standard User`.
+Administrators can enforce custom global permissions in three ways:
+
+- Changing the [default permissions for new users](#configuring-default-global-permissions)
+
+- Editing the [permissions of a user](#configuring-permissions-for-individual-users)
+
+- Choosing the **Custom** cluster permissions option when [adding a new member to a cluster]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/cluster-members/)
+
+### Custom Global Permissions Reference
+
+The following table lists each custom global permission available and whether it is included in the default global permissions, `Administrator` and `Standard User`.
 
 | Custom Global Permission           | Administrator | Standard User |
 | ---------------------------------- | ------------- | ------------- |
+| Create Clusters                    | ✓             | ✓             |
 | Manage Authentication              | ✓             |               |
 | Manage Catalogs                    | ✓             |               |
-| Manage Cluster Drivers             | ✓             |               |
+| Manager Cluster Drivers            | ✓             |               |
 | Manage Node Drivers                | ✓             |               |
 | Manage PodSecurityPolicy Templates | ✓             |               |
 | Manage Roles                       | ✓             |               |
+| Manage Settings                    | ✓             |               |
 | Manage Users                       | ✓             |               |
-| Create Clusters                    | ✓             | ✓             |
-| Use Catalog Templates             | ✓             | ✓             |
-| Login Access                       | ✓             | ✓             |
+| Use Catalog Templates              | ✓             | ✓             |
+| User Base (Basic log-in access)    | ✓             | ✓             |
+
+For details on which Kubernetes resources correspond to each global permission, you can go to the **Global** view in the Rancher UI. Then click **Security > Roles** and go to the **Global** tab. If you click an individual role, you can refer to the **Grant Resources** table to see all of the operations and resources that are permitted by the role.
 
 > **Notes:** 
 >
 >- Each permission listed above is comprised of multiple individual permissions not listed in the Rancher UI. For a full list of these permissions and the rules they are comprised of, access through the API at `/v3/globalRoles`.
 >- When viewing the resources associated with default roles created by Rancher, if there are multiple Kuberenetes API resources on one line item, the resource will have `(Custom)` appended to it. These are not custom resources but just an indication that there are multiple Kubernetes API resources as one resource.
 
-When a user from an [external authentication source]({{< baseurl >}}/rancher/v2.x/en/admin-settings/authentication/) signs into Rancher for the first time, they're automatically assigned a set of global permissions (hereafter, permissions). By default, new users are assigned the [user](#user) permissions. However, in some organizations, these permissions may extend too much access. In this use case, you can change the default permissions to something more restrictive, such as a set of individual permissions.
+### Configuring Default Global Permissions
 
-You can assign one or more default permissions. For example, the `user` permission assigns new users a [set of individual global permissions](#global-permissions-reference). If you want to restrict the default permissions for new users, you can remove the `user` permission as default role and then assign multiple individual permissions as default instead. Conversely, you can also add administrative permissions on top of a set of other standard permissions.
+If you want to restrict the default permissions for new users, you can remove the `user` permission as default role and then assign multiple individual permissions as default instead. Conversely, you can also add administrative permissions on top of a set of other standard permissions.
 
 >**Note:** Default roles are only assigned to users added from an external authentication provider. For local users, you must explicitly assign global permissions when adding a user to Rancher. You can customize these global permissions when adding the user.
 
-### Configuring Default Global Permissions
-
-You can change the default global permissions that are assigned to external users upon their first log in.
+To change the default global permissions that are assigned to external users upon their first log in, follow these steps:
 
 1. From the **Global** view, select **Security > Roles** from the main menu. Make sure the **Global** tab is selected.
 
@@ -76,3 +89,19 @@ You can change the default global permissions that are assigned to external user
 1. If you want to remove a default permission, edit the permission and select **No** from **New User Default**.
 
 **Result:** The default global permissions are configured based on your changes. Permissions assigned to new users display a check in the **New User Default** column.
+
+### Configuring Global Permissions for Individual Users
+
+To configure permission for a user,
+
+1. Go to the **Users** tab.
+
+1. On this page, go to the user whose access level you want to change and click **Ellipsis (...) > Edit.**
+
+1. In the **Global Permissions** section, click **Custom.**
+
+1. Check the boxes for each subset of permissions you want the user to have access to.
+
+1. Click **Save.**
+
+> **Result:** The user's global permissions have been updated.


### PR DESCRIPTION
This PR includes the following changes:

- I validated the global permissions reference table and the custom cluster role reference table against the lists of roles in the Rancher UI, making sure the roles match the language in the UI and they're in the same order as the UI
- I made some minor organizational changes and section title changes, trying to make it a little clearer
- I added some steps about how to pick custom roles for users from the Users tab in the Rancher UI, because I think it helps give more context about how the roles and users fit together on each level