### PR TITLE
Move HA installation reference docs so air gap readers can see them

### DIFF
--- a/content/rancher/v2.x/en/catalog/globaldns/_index.md
+++ b/content/rancher/v2.x/en/catalog/globaldns/_index.md
@@ -7,7 +7,7 @@ _Available as of v2.2.0_
 
 Rancher's Global DNS feature provides a way to program an external DNS provider to route traffic to your Kubernetes applications. Since the DNS programming supports spanning applications across different Kubernetes clusters, Global DNS is configured at a global level. An application can become highly available as it allows you to have one application run on different Kubernetes clusters. If one of your Kubernetes clusters goes down, the application would still be accessible.
 
-> **Note:** Global DNS is only available in [HA setups]({{< baseurl >}}/rancher/v2.x/en/installation/ha/) with the [`local` cluster enabled]({{< baseurl >}}/rancher/v2.x/en/installation/ha/helm-rancher/chart-options/#import-local-cluster).
+> **Note:** Global DNS is only available in [HA setups]({{< baseurl >}}/rancher/v2.x/en/installation/ha/) with the [`local` cluster enabled]({{< baseurl >}}/rancher/v2.x/en/installation/chart-options/#import-local-cluster).
 
 ## Global DNS Providers
 
@@ -63,7 +63,7 @@ By default, only [global administrators]({{< baseurl >}}/rancher/v2.x/en/admin-s
 
 >**Notes:**
 >
->- Alibaba Cloud SDK uses TZ data. It needs to be present on `/usr/share/zoneinfo` path of the nodes running [`local` cluster]({{< baseurl >}}/rancher/v2.x/en/installation/ha/helm-rancher/chart-options/#import-local-cluster), and it is mounted to the external DNS pods. If it is not available on the nodes, please follow the [instruction](https://www.ietf.org/timezones/tzdb-2018f/tz-link.html) to prepare it.
+>- Alibaba Cloud SDK uses TZ data. It needs to be present on `/usr/share/zoneinfo` path of the nodes running [`local` cluster]({{< baseurl >}}/rancher/v2.x/en/installation/chart-options/#import-local-cluster), and it is mounted to the external DNS pods. If it is not available on the nodes, please follow the [instruction](https://www.ietf.org/timezones/tzdb-2018f/tz-link.html) to prepare it.
 >- Different versions of AliDNS have different allowable TTL range, where the default TTL for a global DNS entry may not be valid. Please see the [reference](https://www.alibabacloud.com/help/doc-detail/34338.htm) before adding an AliDNS entry.
 {{% /accordion %}}
 

--- a/content/rancher/v2.x/en/installation/air-gap-high-availability/config-rancher-system-charts/_index.md
+++ b/content/rancher/v2.x/en/installation/air-gap-high-availability/config-rancher-system-charts/_index.md
@@ -48,3 +48,9 @@ In the catalog management page in the Rancher UI, follow these steps:
 1. Click **Send Request**
 
 **Result:** Rancher is configured to download all the required catalog items from your `system-charts` repository.
+
+### Finishing Up
+
+That's it. You should have a functional Rancher server. Point a browser at the hostname you picked and you should be greeted by the colorful login page.
+
+Doesn't work? Take a look at the [Troubleshooting]({{< baseurl >}}/rancher/v2.x/en/installation/troubleshooting/) Page.

--- a/content/rancher/v2.x/en/installation/air-gap-high-availability/install-rancher/_index.md
+++ b/content/rancher/v2.x/en/installation/air-gap-high-availability/install-rancher/_index.md
@@ -38,7 +38,7 @@ Rancher Server is designed to be secure by default and requires SSL/TLS configur
 
 For HA air gap configurations, there are two recommended options for the source of the certificate.
 
-> **Note:** If you want terminate SSL/TLS externally, see [TLS termination on an External Load Balancer]({{< baseurl >}}/rancher/v2.x/en/installation/chart-options/#external-tls-termination).
+> **Note:** If you want to terminate SSL/TLS externally, see [TLS termination on an External Load Balancer]({{< baseurl >}}/rancher/v2.x/en/installation/chart-options/#external-tls-termination).
 
 | Configuration | Chart option | Description | Requires cert-manager |
 |-----|-----|-----|-----|
@@ -103,7 +103,6 @@ By default, Rancher generates a CA and uses cert manager to issue the certificat
       --set hostname=<RANCHER.YOURDOMAIN.COM> \
       --set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \
       --set ingress.tls.source=secret
-<<<<<<< HEAD
       --set 'extraEnv[0].name=CATTLE_SYSTEM_DEFAULT_REGISTRY'
       --set 'extraEnv[0].value=<REGISTRY.YOURDOMAIN.COM:PORT>'
     ```
@@ -115,9 +114,6 @@ By default, Rancher generates a CA and uses cert manager to issue the certificat
     `<REGISTRY.YOURDOMAIN.COM:PORT>` | The DNS name for your private registry. This configures Rancher to use your private registry when starting the `rancher/rancher` container.
     
     > **Note:** If you are using a Private CA signed cert, add `--set privateCA=true` following `--set ingress.tls.source=secret`
-=======
-    ```
->>>>>>> Move HA installation reference docs so air gap readers can see them
 
 1.    See [Adding TLS Secrets]({{<baseurl>}}/rancher/v2.x/en/installation/tls-secrets/) to publish the certificate files so Rancher and the ingress controller can use them. 
 {{% /accordion %}}

--- a/content/rancher/v2.x/en/installation/air-gap-high-availability/install-rancher/_index.md
+++ b/content/rancher/v2.x/en/installation/air-gap-high-availability/install-rancher/_index.md
@@ -38,7 +38,7 @@ Rancher Server is designed to be secure by default and requires SSL/TLS configur
 
 For HA air gap configurations, there are two recommended options for the source of the certificate.
 
-> **Note:** If you want terminate SSL/TLS externally, see [TLS termination on an External Load Balancer]({{< baseurl >}}/rancher/v2.x/en/installation/ha/helm-rancher/chart-options/#external-tls-termination).
+> **Note:** If you want terminate SSL/TLS externally, see [TLS termination on an External Load Balancer]({{< baseurl >}}/rancher/v2.x/en/installation/chart-options/#external-tls-termination).
 
 | Configuration | Chart option | Description | Requires cert-manager |
 |-----|-----|-----|-----|
@@ -103,6 +103,7 @@ By default, Rancher generates a CA and uses cert manager to issue the certificat
       --set hostname=<RANCHER.YOURDOMAIN.COM> \
       --set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \
       --set ingress.tls.source=secret
+<<<<<<< HEAD
       --set 'extraEnv[0].name=CATTLE_SYSTEM_DEFAULT_REGISTRY'
       --set 'extraEnv[0].value=<REGISTRY.YOURDOMAIN.COM:PORT>'
     ```
@@ -114,8 +115,11 @@ By default, Rancher generates a CA and uses cert manager to issue the certificat
     `<REGISTRY.YOURDOMAIN.COM:PORT>` | The DNS name for your private registry. This configures Rancher to use your private registry when starting the `rancher/rancher` container.
     
     > **Note:** If you are using a Private CA signed cert, add `--set privateCA=true` following `--set ingress.tls.source=secret`
+=======
+    ```
+>>>>>>> Move HA installation reference docs so air gap readers can see them
 
-1.    See [Adding TLS Secrets]({{< baseurl >}}/rancher/v2.x/en/installation/ha/helm-rancher/tls-secrets/) to publish the certificate files so Rancher and the ingress controller can use them. 
+1.    See [Adding TLS Secrets]({{<baseurl>}}/rancher/v2.x/en/installation/tls-secrets/) to publish the certificate files so Rancher and the ingress controller can use them. 
 {{% /accordion %}}
 
 ## D. Install Rancher
@@ -137,12 +141,17 @@ kubectl create namespace cattle-system
 kubectl -n cattle-system apply -R -f ./rancher
 ```
 
-### Additional Resources
+### Advanced Configurations
 
-These resources could be helpful when you install Rancher:
+The Rancher chart configuration has many options for customizing the install to suit your specific environment. Here are some common advanced scenarios.
 
-- [Rancher Helm chart options]({{<baseurl>}}rancher/v2.x/en/installation/ha/helm-rancher/chart-options/)
-- [Adding TLS secrets]({{<baseurl>}}/rancher/v2.x/en/installation/ha/helm-rancher/tls-secrets/)
-- [Troubleshooting Rancher HA installations]({{<baseurl>}}/rancher/v2.x/en/installation/ha/helm-rancher/troubleshooting/)
+* [HTTP Proxy]({{< baseurl >}}/rancher/v2.x/en/installation/chart-options/#http-proxy)
+* [TLS Termination on an External Load Balancer]({{< baseurl >}}/rancher/v2.x/en/installation/chart-options/#external-tls-termination)
 
-### [Next: Configure Rancher System Charts]({{< baseurl >}}/rancher/v2.x/en/installation/air-gap-high-availability/config-rancher-system-charts/)
+See the [Chart Options]({{< baseurl >}}/rancher/v2.x/en/installation/chart-options/) for the full list of options.
+
+### Troubleshooting
+
+Doesn't work? Take a look at the [Troubleshooting]({{< baseurl >}}/rancher/v2.x/en/installation/troubleshooting/) Page.
+
+### [Next: Configure Rancher for the Private Registry]({{< baseurl >}}/rancher/v2.x/en/installation/air-gap-high-availability/config-rancher-for-private-reg/)

--- a/content/rancher/v2.x/en/installation/chart-options/_index.md
+++ b/content/rancher/v2.x/en/installation/chart-options/_index.md
@@ -1,7 +1,9 @@
 ---
 title: Chart Options
-weight: 276
+weight: 7900
 ---
+
+This section explains the Helm chart options that you can configure during a high-availability installation of Rancher.
 
 ### Common Options
 
@@ -150,7 +152,7 @@ We recommend configuring your load balancer as a Layer 4 balancer, forwarding pl
 
 You may terminate the SSL/TLS on a L7 load balancer external to the Rancher cluster (ingress). Use the `--set tls=external` option and point your load balancer at port http 80 on all of the Rancher cluster nodes. This will expose the Rancher interface on http port 80. Be aware that clients that are allowed to connect directly to the Rancher cluster will not be encrypted. If you choose to do this we recommend that you restrict direct access at the network level to just your load balancer.
 
-> **Note:** If you are using a Private CA signed certificate, add `--set privateCA=true` and see [Adding TLS Secrets - Using a Private CA Signed Certificate]({{< baseurl >}}/rancher/v2.x/en/installation/ha/helm-rancher/tls-secrets/#using-a-private-ca-signed-certificate) to add the CA cert for Rancher.
+> **Note:** If you are using a Private CA signed certificate, add `--set privateCA=true` and see [Adding TLS Secrets - Using a Private CA Signed Certificate]({{<baseurl>}}/rancher/v2.x/en/installation/tls-secrets/#using-a-private-ca-signed-certificate) to add the CA cert for Rancher.
 
 Your load balancer must support long lived websocket connections and will need to insert proxy headers so Rancher can route links correctly.
 

--- a/content/rancher/v2.x/en/installation/ha/helm-rancher/_index.md
+++ b/content/rancher/v2.x/en/installation/ha/helm-rancher/_index.md
@@ -23,7 +23,7 @@ Rancher Server is designed to be secure by default and requires SSL/TLS configur
 
 There are three recommended options for the source of the certificate.
 
-> **Note:** If you want terminate SSL/TLS externally, see [TLS termination on an External Load Balancer]({{< baseurl >}}/rancher/v2.x/en/installation/ha/helm-rancher/chart-options/#external-tls-termination).
+> **Note:** If you want terminate SSL/TLS externally, see [TLS termination on an External Load Balancer]({{< baseurl >}}/rancher/v2.x/en/installation/chart-options/#external-tls-termination).
 
 | Configuration | Chart option | Description | Requires cert-manager |
 |-----|-----|-----|-----|
@@ -33,7 +33,7 @@ There are three recommended options for the source of the certificate.
 
 ### Optional: Install cert-manager
 
-> **Note:** cert-manager is only required for certificates issued by Rancher's generated CA (`ingress.tls.source=rancher`) and Let's Encrypt issued certificates (`ingress.tls.source=letsEncrypt`). You should skip this step if you are using your own certificate files (option `ingress.tls.source=secret`) or if you use [TLS termination on an External Load Balancer]({{< baseurl >}}/rancher/v2.x/en/installation/ha/helm-rancher/chart-options/#external-tls-termination).
+> **Note:** cert-manager is only required for certificates issued by Rancher's generated CA (`ingress.tls.source=rancher`) and Let's Encrypt issued certificates (`ingress.tls.source=letsEncrypt`). You should skip this step if you are using your own certificate files (option `ingress.tls.source=secret`) or if you use [TLS termination on an External Load Balancer]({{< baseurl >}}/rancher/v2.x/en/installation/chart-options/#external-tls-termination).
 
 > **Important:** Due to an issue with Helm v2.12.0 and cert-manager, please use Helm v2.12.1 or higher.
 
@@ -125,7 +125,7 @@ helm install rancher-<CHART_REPO>/rancher \
   --set ingress.tls.source=secret
 ```
 
-Now that Rancher is deployed, see [Adding TLS Secrets]({{< baseurl >}}/rancher/v2.x/en/installation/ha/helm-rancher/tls-secrets/) to publish the certificate files so Rancher and the ingress controller can use them.
+Now that Rancher is deployed, see [Adding TLS Secrets]({{< baseurl >}}/rancher/v2.x/en/installation/tls-secrets/) to publish the certificate files so Rancher and the ingress controller can use them.
 
 After adding the secrets, check if Rancher was rolled out successfully:
 
@@ -149,11 +149,11 @@ It should show the same count for `DESIRED` and `AVAILABLE`.
 
 The Rancher chart configuration has many options for customizing the install to suit your specific environment. Here are some common advanced scenarios.
 
-* [HTTP Proxy]({{< baseurl >}}/rancher/v2.x/en/installation/ha/helm-rancher/chart-options/#http-proxy)
-* [Private Docker Image Registry]({{< baseurl >}}/rancher/v2.x/en/installation/ha/helm-rancher/chart-options/#private-registry-and-air-gap-installs)
-* [TLS Termination on an External Load Balancer]({{< baseurl >}}/rancher/v2.x/en/installation/ha/helm-rancher/chart-options/#external-tls-termination)
+* [HTTP Proxy]({{< baseurl >}}/rancher/v2.x/en/installation/chart-options/#http-proxy)
+* [Private Docker Image Registry]({{< baseurl >}}/rancher/v2.x/en/installation/chart-options/#private-registry-and-air-gap-installs)
+* [TLS Termination on an External Load Balancer]({{< baseurl >}}/rancher/v2.x/en/installation/chart-options/#external-tls-termination)
 
-See the [Chart Options]({{< baseurl >}}/rancher/v2.x/en/installation/ha/helm-rancher/chart-options/) for the full list of options.
+See the [Chart Options]({{< baseurl >}}/rancher/v2.x/en/installation/chart-options/) for the full list of options.
 
 ### Save your options
 
@@ -161,6 +161,6 @@ Make sure you save the `--set` options you used. You will need to use the same o
 
 ### Finishing Up
 
-That's it you should have a functional Rancher server. Point a browser at the hostname you picked and you should be greeted by the colorful login page.
+That's it. You should have a functional Rancher server. Point a browser at the hostname you picked and you should be greeted by the colorful login page.
 
-Doesn't work? Take a look at the [Troubleshooting]({{< baseurl >}}/rancher/v2.x/en/installation/ha/helm-rancher/troubleshooting/) Page
+Doesn't work? Take a look at the [Troubleshooting]({{< baseurl >}}/rancher/v2.x/en/installation/troubleshooting/) Page.

--- a/content/rancher/v2.x/en/installation/options/api-audit-log/_index.md
+++ b/content/rancher/v2.x/en/installation/options/api-audit-log/_index.md
@@ -17,7 +17,7 @@ The Audit Log is enabled and configured by passing environment variables to the 
 
 - [Single Node Install]({{< baseurl >}}/rancher/v2.x/en/installation/single-node/#api-audit-log)
 
-- [HA Install]({{< baseurl >}}/rancher/v2.x/en/installation/ha/helm-rancher/chart-options/#api-audit-log)
+- [HA Install]({{< baseurl >}}/rancher/v2.x/en/installation/chart-options/#api-audit-log)
 
 ## API Audit Log Options
 

--- a/content/rancher/v2.x/en/installation/options/custom-ca-root-certificate/_index.md
+++ b/content/rancher/v2.x/en/installation/options/custom-ca-root-certificate/_index.md
@@ -23,4 +23,4 @@ For details on starting a Rancher container with your private CA certificates mo
 
 - [Single Node Install]({{< baseurl >}}/rancher/v2.x/en/installation/single-node/#custom-ca-certificate)
 
-- [HA Install]({{< baseurl >}}/rancher/v2.x/en/installation/ha/helm-rancher/chart-options/#additional-trusted-cas)
+- [HA Install]({{< baseurl >}}/rancher/v2.x/en/installation/chart-options/#additional-trusted-cas)

--- a/content/rancher/v2.x/en/installation/options/tls-settings/_index.md
+++ b/content/rancher/v2.x/en/installation/options/tls-settings/_index.md
@@ -15,7 +15,7 @@ The Audit Log is enabled and configured by passing environment variables to the 
 
 - [Single Node Install]({{< baseurl >}}/rancher/v2.x/en/installation/single-node/#tls-settings)
 
-- [HA Install]({{< baseurl >}}/rancher/v2.x/en/installation/ha/helm-rancher/chart-options/#tls-settings)
+- [HA Install]({{< baseurl >}}/rancher/v2.x/en/installation/chart-options/#tls-settings)
 
 ## TLS settings
 

--- a/content/rancher/v2.x/en/installation/tls-secrets/_index.md
+++ b/content/rancher/v2.x/en/installation/tls-secrets/_index.md
@@ -1,7 +1,9 @@
 ---
 title: Adding TLS Secrets
-weight: 276
+weight: 7700
 ---
+
+This section explains how to configure TLS secrets during a high-availability installation of Rancher.
 
 Kubernetes will create all the objects and services for Rancher, but it will not become available until we populate the `tls-rancher-ingress` secret in the `cattle-system` namespace with the certificate and key.
 

--- a/content/rancher/v2.x/en/installation/troubleshooting/_index.md
+++ b/content/rancher/v2.x/en/installation/troubleshooting/_index.md
@@ -1,6 +1,6 @@
 ---
-title: Troubleshooting
-weight: 276
+title: HA Installation Troubleshooting
+weight: 8000
 ---
 
 ### Where is everything

--- a/content/rancher/v2.x/en/security/hardening-2.1/_index.md
+++ b/content/rancher/v2.x/en/security/hardening-2.1/_index.md
@@ -866,7 +866,7 @@ Upgrade the Rancher server installation using Helm, and configure the audit log 
 
 #### Reference
 
-- <https://rancher.com/docs/rancher/v2.x/en/installation/ha/helm-rancher/chart-options/#advanced-options>
+- [Advanced Rancher Chart Options]({{<baseurl>}}/rancher/v2.x/en/installation/chart-options/#advanced-options)
 
 ## 3.2 - Rancher Management Control Plane Authentication
 

--- a/content/rancher/v2.x/en/security/hardening-2.2/_index.md
+++ b/content/rancher/v2.x/en/security/hardening-2.2/_index.md
@@ -892,7 +892,7 @@ Upgrade the Rancher server installation using Helm, and configure the audit log 
 
 #### Reference
 
-- <https://rancher.com/docs/rancher/v2.x/en/installation/ha/helm-rancher/chart-options/#advanced-options>
+- [Advanced Rancher Chart Options]({{<baseurl>}}/rancher/v2.x/en/installation/chart-options/#advanced-options)
 
 ## 3.2 - Rancher Management Control Plane Authentication
 


### PR DESCRIPTION
This PR addresses this issue: https://github.com/rancher/docs/issues/1645