### PR TITLE
Add chart compatibility info to Catalog docs

### DIFF
--- a/content/rancher/v2.x/en/catalog/_index.md
+++ b/content/rancher/v2.x/en/catalog/_index.md
@@ -152,3 +152,8 @@ _Available as v2.2.0_
 When creating applications that span multiple Kubernetes clusters, a Global DNS entry can be created to route traffic to the endpoints in all of the different clusters. An external DNS server will need be programmed to assign a fully qualified domain name (a.k.a FQDN) to your application. Rancher will use the FQDN you provide and the IP addresses where your application is running to program the DNS. Rancher will gather endpoints from all the Kubernetes clusters running your application and program the DNS.
 
 For more information on how to use this feature, see [Global DNS]({{< baseurl >}}/rancher/v2.x/en/admin-settings/globaldns/).
+
+
+## Chart Compatibility with Rancher
+
+Charts now support a field called `rancher_min_version` and `rancher_max_version` in the [`questions.yml` file](https://github.com/rancher/integration-test-charts/blob/master/charts/chartmuseum/v1.6.0/questions.yml) to specify the versions of Rancher that the chart is compatible with. When using the UI, only app versions that are valid for the version of Rancher running will be shown. API validation is done to ensure apps that don't meet the Rancher requirements cannot be launched. An app that is already running will not be affected on a Rancher upgrade if the newer Rancher version does not meet the app's requirements.


### PR DESCRIPTION
This PR adds Dan's feature documentation to the Catalog docs according to this issue: https://github.com/rancher/docs/issues/1481