### PR TITLE
Update _index.md

### DIFF
--- a/content/rke/latest/en/os/_index.md
+++ b/content/rke/latest/en/os/_index.md
@@ -50,9 +50,9 @@ RKE runs on almost any Linux OS with Docker installed. Most of the development a
      for module in br_netfilter ip6_udp_tunnel ip_set ip_set_hash_ip ip_set_hash_net iptable_filter iptable_nat iptable_mangle iptable_raw nf_conntrack_netlink nf_conntrack nf_conntrack_ipv4   nf_defrag_ipv4 nf_nat nf_nat_ipv4 nf_nat_masquerade_ipv4 nfnetlink udp_tunnel veth vxlan x_tables xt_addrtype xt_conntrack xt_comment xt_mark xt_multiport xt_nat xt_recent xt_set  xt_statistic xt_tcpudp;
      do
        if ! lsmod | grep -q $module; then
-         echo "module $module is not present"
-       fi
-     done;     
+         echo "module $module is not present";
+       fi;
+     done
      ```
 
 Module name |


### PR DESCRIPTION
the bash scripts compiles into a single line which results into something like this:

```
for module in br_netfilter ip6_udp_tunnel ip_set ip_set_hash_ip ip_set_hash_net iptable_filter iptable_nat iptable_mangle iptable_raw nf_conntrack_netlink nf_conntrack nf_conntrack_ipv4 nf_defrag_ipv4 nf_
nat nf_nat_ipv4 nf_nat_masquerade_ipv4 nfnetlink udp_tunnel veth vxlan x_tables xt_addrtype xt_conntrack xt_comment xt_mark xt_multiport xt_nat xt_recent xt_set xt_statistic xt_tcpudp; do if ! lsmod | grep -q $module; then echo "module $m
odule is not present" fi done;
```

to avoid syntax error, extra semicolons fixes the issue