### PR TITLE
Edit node pool docs

### DIFF
--- a/content/rancher/v2.x/en/cluster-provisioning/rke-clusters/node-pools/_index.md
+++ b/content/rancher/v2.x/en/cluster-provisioning/rke-clusters/node-pools/_index.md
@@ -23,11 +23,6 @@ _Available as of Rancher v2.3.0_
 
 If a node is in a node pool, Rancher can automatically recreate the node if it becomes unreachable by enabling the ability to auto-replace nodes. Rancher will use the existing node template for the given node pool to recreate the node.
 
-You can enable node auto-replace in two ways:
-
-- During node pool creation, from the Rancher UI
-- After node pool creation, from the Rancher API view
-
 {{% accordion id="how-does-node-auto-replace-work" label="How does Node Auto-replace Work?" %}}
    Node auto-replace works on top of the Kubernetes node controller. The node controller periodically checks the status of all the nodes (configurable via the `--node-monitor-period` flag of the `kube-controller`). When a node is unreachable, the node controller will taint that node. When this occurs, Rancher will begin its deletion countdown. You can configure the amount of time Rancher waits to delete the node. If the taint is not removed before the deletion countdown ends, Rancher will proceed to delete the node object. Rancher will then provision a node in accordance with the set quantity of the node pool.
 {{% /accordion %}} 

--- a/content/rancher/v2.x/en/cluster-provisioning/rke-clusters/node-pools/_index.md
+++ b/content/rancher/v2.x/en/cluster-provisioning/rke-clusters/node-pools/_index.md
@@ -5,19 +5,64 @@ aliases:
   - /rancher/v2.x/en/concepts/global-configuration/node-templates/
 ---
 
-## Node Pools
-
-Using Rancher, you can create pools of nodes based on a [node template](#node-templates). The benefit of using a node pool is that if a node loses connectivity with the cluster, Rancher will automatically create another node to join the cluster to ensure that the count of the node pool is as expected.
-
-Each node pool is assigned with a [node component]({{< baseurl >}}/rancher/v2.x/en/cluster-provisioning/#node-components) to specify how these nodes should be configured for the Kubernetes cluster.
-
-## Node Templates
+# Node Templates
 
 A node template is the saved configuration for the parameters to use when provisioning nodes in a specific cloud provider. Rancher provides a nice UI to be able to launch these nodes and uses [Docker Machine](https://docs.docker.com/machine/) to provision these nodes. The available cloud providers to create node templates are based on the active node drivers in Rancher.
 
-After you create a node template in Rancher, it's saved so that you can use this template again to create other node pools. Node templates are bound to your login. After you add a template, you can remove them from your user profile.
+After you create a node template in Rancher, it's saved so that you can use this template again to create [node pools.](#node-pools) Node templates are bound to your login. After you add a template, you can remove them from your user profile.
 
-## Cloud Credentials
+# Node Pools
+
+Using Rancher, you can create pools of nodes based on a [node template](#node-templates). The benefit of using a node pool is that if a node is destroyed or deleted, you can increase the number of live nodes to compensate for the node that was lost. The node pool helps you ensure that the count of the node pool is as expected.
+
+Each node pool is assigned with a [node component]({{< baseurl >}}/rancher/v2.x/en/cluster-provisioning/#kubernetes-cluster-node-components) to specify how these nodes should be configured for the Kubernetes cluster.
+
+### Node Auto-replace
+
+_Available as of Rancher v2.3.0_
+
+If a node is in a node pool, Rancher can automatically recreate the node if it becomes unreachable by enabling the ability to auto-replace nodes. Rancher will use the existing node template for the given node pool to recreate the node.
+
+You can enable node auto-replace in two ways:
+
+- During node pool creation, from the Rancher UI
+- After node pool creation, from the Rancher API view
+
+{{% accordion id="how-does-node-auto-replace-work" label="How does Node Auto-replace Work?" %}}
+   Node auto-replace works on top of the Kubernetes node controller. The node controller periodically checks the status of all the nodes (configurable via the `--node-monitor-period` flag of the `kube-controller`). When a node is unreachable, the node controller will taint that node. When this occurs, Rancher will begin its deletion countdown. You can configure the amount of time Rancher waits to delete the node. If the taint is not removed before the deletion countdown ends, Rancher will proceed to delete the node object. Rancher will then provision a node in accordance with the set quantity of the node pool.
+{{% /accordion %}} 
+
+### Enabling Node Auto-replace
+
+When you create the node pool, you can specify the amount of time in minutes that Rancher will wait to replace an unresponsive node.
+
+1. In the form for creating a cluster, go to the **Node Pools** section.
+1. Go to the node pool where you want to enable node auto-replace. In the **Recreate Unreachable After** field, enter the number of minutes that Rancher should wait for a node to respond before replacing the node.
+1. Fill out the rest of the form for creating a cluster.
+
+**Result:** Node auto-replace is enabled for the node pool.
+
+You can also enable node auto-replace after the cluster is created with the following steps:
+
+1. From the Global view, click the Clusters tab.
+1. Go to the cluster where you want to enable node auto-replace, click the vertical ellipsis **(…)**, and click **Edit.**
+1. In the **Node Pools** section, go to the node pool where you want to enable node auto-replace. In the **Recreate Unreachable After** field, enter the number of minutes that Rancher should wait for a node to respond before replacing the node.
+1. Click **Save.**
+
+**Result:** Node auto-replace is enabled for the node pool.
+
+### Disabling Node Auto-replace
+
+You can disable node auto-replace from the Rancher UI with the following steps:
+
+1. From the Global view, click the Clusters tab.
+1. Go to the cluster where you want to enable node auto-replace, click the vertical ellipsis **(…)**, and click **Edit.**
+1. In the **Node Pools** section, go to the node pool where you want to enable node auto-replace. In the **Recreate Unreachable After** field, enter 0.
+1. Click **Save.**
+
+**Result:** Node auto-replace is disabled for the node pool.
+
+# Cloud Credentials
 
 _Available as of v2.2.0_
 
@@ -33,6 +78,6 @@ Node templates can use cloud credentials to store credentials for launching node
 
 After cloud credentials are created, the user can start [managing the cloud credentials that they created]({{< baseurl >}}/rancher/v2.x/en/user-settings/cloud-credentials/).
 
-## Node Drivers
+# Node Drivers
 
 If you don't find the node driver that you want to use, you can see if it is available in Rancher's built-in [node drivers and activate it]({{< baseurl >}}/rancher/v2.x/en/admin-settings/drivers/node-drivers/#activating-deactivating-node-drivers), or you can [add your own custom node driver]({{< baseurl >}}/rancher/v2.x/en/admin-settings/drivers/node-drivers/#adding-custom-node-drivers).


### PR DESCRIPTION
In this PR I have edited Dax's draft of the docs for node auto-replace in node pools, and I have placed it with the existing node pool docs.

I also edited the existing node pool docs to try to clarify what you can do with the 2.3 feature that wasn't previously possible.

The corresponding issue for the feature docs is https://github.com/rancher/docs/issues/1482