### PR TITLE
[k3s] Should download charts first when building from source

### DIFF
--- a/content/k3s/latest/en/building/_index.md
+++ b/content/k3s/latest/en/building/_index.md
@@ -13,10 +13,11 @@ The clone will be much faster on this repo if you do
 
 This repo includes all of Kubernetes history so `--depth 1` will avoid most of that.
 
-To build the full release binary run `make` and that will create `./dist/artifacts/k3s`. 
+To build the full release binary run `make` and that will create `./dist/artifacts/k3s`.
+
 Optionally to build the binaries without running linting or building docker images:
 ```sh
-./scripts/build && ./scripts/package-cli
+./scripts/download && ./scripts/build && ./scripts/package-cli
 ```
 
 For development, you just need go 1.12 and a sane GOPATH.  To compile the binaries run:


### PR DESCRIPTION
[k3s] Should download charts first when building from source (local build), otherwise the chartsTraefik tgz will not be compiled into the k3s binary.

xref: https://github.com/rancher/k3s/pull/729#issuecomment-521501318