### PR TITLE
Add "proxy_buffering off" to nginx reverse proxy config

### DIFF
--- a/content/rancher/v2.x/en/installation/ha/rke-add-on/layer-7-lb/nginx/_index.md
+++ b/content/rancher/v2.x/en/installation/ha/rke-add-on/layer-7-lb/nginx/_index.md
@@ -55,6 +55,8 @@ After installing NGINX, you need to create the NGINX config file, `/etc/nginx/co
             proxy_set_header Connection $connection_upgrade;
             # This allows the ability for the execute shell window to remain open for up to 15 minutes. Without this parameter, the default is 1 minute and will automatically close.
             proxy_read_timeout 900s;
+            # Turn off proxy buffering. By default, proxy buffering is turned on and because of that nginx doesn't send the response until it decides to flush proxy buffers. That causes commands that wait for a response (such as `kubectl logs -f` or `kubectl get pods -w`) to not receive anything and just hang. 
+            proxy_buffering off;
         }
     }
 


### PR DESCRIPTION
Add "proxy_buffering off" to the nginx reverse proxy config example.

By default, proxy buffering is turned on and because of that nginx doesn't send the response until it decides to flush proxy buffers. That causes commands that wait for a response (such as `kubectl logs -f` or `kubectl get pods -w`) to not receive anything and just hang.