### PR TITLE
Add information for cert-manager

### DIFF
--- a/content/rancher/v2.x/en/cluster-admin/upgrade-cert-manager-airgap/_index.md
+++ b/content/rancher/v2.x/en/cluster-admin/upgrade-cert-manager-airgap/_index.md
@@ -1,0 +1,92 @@
+---
+title: Upgrade Cert-manager Airgap
+weight: 2040
+---
+
+[Let's Encrypt will be blocking cert-manager instances older than 0.8.0 starting November 1st 2019.](https://community.letsencrypt.org/t/blocking-old-cert-manager-versions/98753) In order to upgrade cert-manager to the newer version follow these instructions:
+
+>**Note:** The namespaces used in these instructions depends on the namespace cert-manager is currently installed in. If it is in kube-system use that in the instructions below. You can verify by running `kubectl get pods --all-namespaces` and checking which namespace the cert-manager-* pods are listed in. Do not change the namespace cert-manager is running in or this can cause issues. 
+
+## Prerequisites
+
+- **Populate Images**
+
+    Follow the guide to [Prepare the Private Registry]({{< baseurl >}}/rancher/v2.x/en/installation/air-gap-installation/prepare-private-reg/) with the images for the upgrade Rancher release.
+
+- **Prepare cert-manager**
+
+1. From a system connected to the internet, add the cert-manager repo to helm
+
+    ```plain
+    helm repo add jetstack https://charts.jetstack.io
+    helm repo update
+    ```
+
+1. Fetch the latest cert-manager chart available from the [Helm chart repository](https://hub.helm.sh/charts/jetstack/cert-manager). 
+
+    ```plain
+    helm fetch jetstack/cert-manager --version v0.9.1
+    ```
+
+1. Render the cert manager template with the options you would like to use to install the chart. Remember to set the `image.repository` option to pull the image from your private registry. This will create a `cert-manager` directory with the Kubernetes manifest files.
+
+    ```plain
+    helm template ./cert-manager-v0.9.1.tgz --output-dir . \
+    --name cert-manager --namespace kube-system \
+    --set image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-controller
+    ```
+
+1. Download the required CRD file for cert-manager
+
+    ```plain
+    curl -L -o cert-manager/cert-manager-crd.yaml https://raw.githubusercontent.com/jetstack/cert-manager/release-0.9/deploy/manifests/00-crds.yaml
+    ```
+
+## Install cert-manager
+
+1. Back up existing resources as a precaution
+
+    ```plain
+    kubectl get -o yaml --all-namespaces issuer,clusterissuer,certificates > cert-manager-backup.yaml
+    ```
+
+1. Delete the existing deployment
+
+    ```plain
+    helm delete --purge cert-manager
+    ```
+
+1. Install the CustomResourceDefinition resources separately
+
+    ```plain
+    kubectl apply -f cert-manager/cert-manager-crd.yaml
+    ```
+
+1. Label the kube-system namespace to disable resource validation
+
+    ```plain
+    kubectl label namespace kube-system certmanager.k8s.io/disable-validation=true
+    ```
+
+1. Install cert-manager
+
+    ```plain
+    kubectl -n kube-system apply -R -f ./cert-manager
+    ```
+
+Once you’ve installed cert-manager, you can verify it is deployed correctly by checking the kube-system namespace for running pods:
+
+```
+kubectl get pods --namespace kube-system
+
+NAME                                            READY   STATUS      RESTARTS   AGE
+cert-manager-7cbdc48784-rpgnt                   1/1     Running     0          3m
+cert-manager-webhook-5b5dd6999-kst4x            1/1     Running     0          3m
+cert-manager-cainjector-3ba5cd2bcd-de332x       1/1     Running     0          3m
+```
+
+If the ‘webhook’ pod (2nd line) is in a ContainerCreating state, it may still be waiting for the Secret to be mounted into the pod. Wait a couple of minutes for this to happen but if you experience problems, please check the [troubleshooting](https://docs.cert-manager.io/en/latest/getting-started/troubleshooting.html) guide.
+
+[Additional information on the annotation.](https://docs.cert-manager.io/en/latest/tasks/upgrading/upgrading-0.4-0.5.html?highlight=certmanager.k8s.io%2Fdisable-validation#disabling-resource-validation-on-the-cert-manager-namespace)
+
+[Additional information on the webhook feature.](https://docs.cert-manager.io/en/latest/getting-started/webhook.html)

--- a/content/rancher/v2.x/en/cluster-admin/upgrade-cert-manager/_index.md
+++ b/content/rancher/v2.x/en/cluster-admin/upgrade-cert-manager/_index.md
@@ -1,0 +1,47 @@
+---
+title: Upgrade Cert-manager
+weight: 2040
+---
+
+[Let's Encrypt will be blocking cert-manager instances older than 0.8.0 starting November 1st 2019.](https://community.letsencrypt.org/t/blocking-old-cert-manager-versions/98753) In order to upgrade cert-manager to the newer version follow these instructions:
+
+
+```
+# Back up existing resources as a precaution
+kubectl get -o yaml --all-namespaces issuer,clusterissuer,certificates > cert-manager-backup.yaml
+
+# Delete the existing deployment
+helm delete --purge cert-manager
+
+# Install the CustomResourceDefinition resources separately
+kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.9/deploy/manifests/00-crds.yaml
+
+# Label the kube-system namespace to disable resource validation
+kubectl label namespace kube-system certmanager.k8s.io/disable-validation=true
+
+# Add the Jetstack Helm repository
+helm repo add jetstack https://charts.jetstack.io
+
+# Update your local Helm chart repository cache
+helm repo update
+
+# Install the new version of cert-manager
+helm install --version 0.9.1 --name cert-manager --namespace kube-system jetstack/cert-manager
+```
+
+Once you’ve installed cert-manager, you can verify it is deployed correctly by checking the kube-system namespace for running pods:
+
+```
+kubectl get pods --namespace kube-system
+
+NAME                                            READY   STATUS      RESTARTS   AGE
+cert-manager-7cbdc48784-rpgnt                   1/1     Running     0          3m
+cert-manager-webhook-5b5dd6999-kst4x            1/1     Running     0          3m
+cert-manager-cainjector-3ba5cd2bcd-de332x       1/1     Running     0          3m
+```
+
+If the ‘webhook’ pod (2nd line) is in a ContainerCreating state, it may still be waiting for the Secret to be mounted into the pod. Wait a couple of minutes for this to happen but if you experience problems, please check the [troubleshooting](https://docs.cert-manager.io/en/latest/getting-started/troubleshooting.html) guide.
+
+[Additional information on the annotation.](https://docs.cert-manager.io/en/latest/tasks/upgrading/upgrading-0.4-0.5.html?highlight=certmanager.k8s.io%2Fdisable-validation#disabling-resource-validation-on-the-cert-manager-namespace)
+
+[Additional information on the webhook feature.](https://docs.cert-manager.io/en/latest/getting-started/webhook.html)

--- a/content/rancher/v2.x/en/installation/air-gap-high-availability/install-rancher/_index.md
+++ b/content/rancher/v2.x/en/installation/air-gap-high-availability/install-rancher/_index.md
@@ -52,23 +52,43 @@ Based on the choice your made in [B. Choose your SSL Configuration](#b-optional-
 In this section you will configure your cert manager and private registry in the Rancher template.
 
 {{% accordion id="self-signed" label="Option A: Default Self-Signed Certificate" %}}
-By default, Rancher generates a CA and uses cert manager to issue the certificate for access to the Rancher server interface. 
+By default, Rancher generates a CA and uses cert-manger to issue the certificate for access to the Rancher server interface. 
 
-1. From a system connected to the internet, fetch the latest cert-manager chart available from the [official Helm chart repository](https://github.com/helm/charts/tree/master/stable). 
+1. From a system connected to the internet, add the cert-manager repo to helm
 
     ```plain
-    helm fetch stable/cert-manager --version 0.5.2
+    helm repo add jetstack https://charts.jetstack.io
+    helm repo update
+    ```
+
+1. Fetch the latest cert-manager chart available from the [Helm chart repository](https://hub.helm.sh/charts/jetstack/cert-manager). 
+
+    ```plain
+    helm fetch jetstack/cert-manager --version v0.9.1
     ```
 
 1. Render the cert manager template with the options you would like to use to install the chart. Remember to set the `image.repository` option to pull the image from your private registry. This will create a `cert-manager` directory with the Kubernetes manifest files.
 
     ```plain
-    helm template ./cert-manager-v0.5.2.tgz --output-dir . \
-    --name cert-manager --namespace kube-system \
+    helm template ./cert-manager-v0.9.1.tgz --output-dir . \
+    --name cert-manager --namespace cert-manager \
     --set image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-controller
     ```
 
+1. Download the required CRD file for cert-manager
+
+    ```plain
+    curl -L -o cert-manager/cert-manager-crd.yaml https://raw.githubusercontent.com/jetstack/cert-manager/release-0.9/deploy/manifests/00-crds.yaml
+    ```
+
 1. Render the Rancher template, declaring your chosen options. Use the reference table below to replace each placeholder. Rancher needs to be configured to use the private registry in order to provision any Rancher launched Kubernetes clusters or Rancher tools. To configure Rancher to use your private registry when starting the `rancher/rancher` container, use the `CATTLE_SYSTEM_DEFAULT_REGISTRY` variable. You can set the the extra environment variable `extraEnv` to use the same `name` and `value` keys as the container manifest definitions. Remember to quote the values:
+
+    Placeholder | Description
+    ------------|-------------
+    `<VERSION>` | The version number of the output tarball.
+    `<RANCHER.YOURDOMAIN.COM>` | The DNS name you pointed at your load balancer.
+    `<REGISTRY.YOURDOMAIN.COM:PORT>` | The DNS name for your private registry.).
+    
     
      ```plain
     helm template ./rancher-<VERSION>.tgz --output-dir . \
@@ -127,7 +147,8 @@ Use `kubectl` to create namespaces and apply the rendered manifests.
 If you are using self-signed certificates, install cert-manager:
 
 ```plain
-kubectl -n kube-system apply -R -f ./cert-manager
+kubectl apply -f cert-manager/cert-manager-crd.yaml
+kubectl -n cert-manager apply -R -f ./cert-manager
 ```
 
 Install rancher:

--- a/content/rancher/v2.x/en/installation/air-gap-high-availability/prepare-private-registry/_index.md
+++ b/content/rancher/v2.x/en/installation/air-gap-high-availability/prepare-private-registry/_index.md
@@ -50,7 +50,9 @@ Start by collecting all the images needed to install Rancher in an air gap envir
     1.  Fetch the latest `cert-manager` Helm chart and parse the template for image details.
 
         ```plain
-        helm fetch stable/cert-manager --version 0.5.2
+        helm repo add jetstack https://charts.jetstack.io
+        helm repo update
+        helm fetch jetstack/cert-manager --version v0.9.1
         helm template ./cert-manager-<version>.tgz | grep -oP '(?<=image: ").*(?=")' >> ./rancher-images.txt
         ```
 

--- a/content/rancher/v2.x/en/upgrades/upgrades/ha-server-upgrade-helm-airgap/_index.md
+++ b/content/rancher/v2.x/en/upgrades/upgrades/ha-server-upgrade-helm-airgap/_index.md
@@ -5,6 +5,8 @@ weight: 1021
 
 The following instructions will guide you through upgrading a high-availability Rancher Server installed in an air gap environment.
 
+>**Note:** [Let's Encrypt will be blocking cert-manager instances older than 0.8.0 starting November 1st 2019.](https://community.letsencrypt.org/t/blocking-old-cert-manager-versions/98753) In order to upgrade cert-manager to the newer version follow [these instructions.]({{< baseurl >}}/rancher/v2.x/en/cluster-admin/upgrade-cert-manager-airgap)
+
 ## Prerequisites
 
 - **Populate Images**

--- a/content/rancher/v2.x/en/upgrades/upgrades/ha-server-upgrade-helm/_index.md
+++ b/content/rancher/v2.x/en/upgrades/upgrades/ha-server-upgrade-helm/_index.md
@@ -11,6 +11,10 @@ The following instructions will guide you through upgrading a high-availability 
 >
 >       As of release v2.0.8, Rancher supports installation and upgrade by Helm chart, although RKE installs/upgrades are still supported as well. If you want to change upgrade method from RKE Add-on to Helm chart, follow this procedure.
 
+---
+
+>**Note:** [Let's Encrypt will be blocking cert-manager instances older than 0.8.0 starting November 1st 2019.](https://community.letsencrypt.org/t/blocking-old-cert-manager-versions/98753) In order to upgrade cert-manager to the newer version follow [these instructions.]({{< baseurl >}}/rancher/v2.x/en/cluster-admin/upgrade-cert-manager)
+
 
 ## Prerequisites
 


### PR DESCRIPTION
Problem:
cert-manager is old and will be cut off soon

Solution:
Update docs to include current install instructions and instructions on
how to upgrade cert-manager to the current version

Issue: https://github.com/rancher/rancher/issues/22235