### PR TITLE
Adding Documentation for RKE --quiet flag

### DIFF
--- a/content/rancher/v2.x/en/installation/air-gap-high-availability/prepare-private-registry/_index.md
+++ b/content/rancher/v2.x/en/installation/air-gap-high-availability/prepare-private-registry/_index.md
@@ -33,7 +33,7 @@ Start by collecting all the images needed to install Rancher in an air gap envir
 1. From the directory that contains the RKE binary, add RKE's images to `rancher-images.txt`, which is a list of all the files needed to install Rancher.
 
     ```
-    rke config --system-images >> ./rancher-images.txt
+    rke --quiet config --system-images >> ./rancher-images.txt
     ```
 1. **Default Rancher Generated Self-Signed Certificate Users Only:** If you elect to use the Rancher default self-signed TLS certificates, you must add the [`cert-manager`](https://github.com/helm/charts/tree/master/stable/cert-manager) image to `rancher-images.txt` as well. You may skip this step if you are using you using your own certificates.
 

--- a/content/rke/latest/en/config-options/_index.md
+++ b/content/rke/latest/en/config-options/_index.md
@@ -74,14 +74,11 @@ Please refer to the [release notes](https://github.com/rancher/rke/releases) of 
 You can also list the supported versions and system images of specific version of RKE release with a quick command.
 
 ```
-$ rke config --system-images --all
-
-INFO[0000] Generating images list for version [v1.13.4-rancher1-2]:
-.......
-INFO[0000] Generating images list for version [v1.11.8-rancher1-1]:
-.......
-INFO[0000] Generating images list for version [v1.12.6-rancher1-2]:
-.......
+$ rke config --list-version --all
+v1.15.3-rancher2-1
+v1.13.10-rancher1-2
+v1.14.6-rancher2-1
+v1.16.0-beta.1-rancher1-1
 ```
 
 #### Using an unsupported Kubernetes version


### PR DESCRIPTION
Adding a --quiet flag to rke so the output appended to the rancher-images.txt doesn't include any debug/info coming from the command.

This PR can be merged if this rancher/rke PR is merged: https://github.com/rancher/rke/pull/1590
Stems from this rancher/rancher issue: https://github.com/rancher/rancher/issues/20781