### PR TITLE
Fix hardening guide instructions for k8s config files

### DIFF
--- a/content/rancher/v2.x/en/security/benchmark-2.2/_index.md
+++ b/content/rancher/v2.x/en/security/benchmark-2.2/_index.md
@@ -561,7 +561,7 @@ In Kubernetes 1.13.x this flag is `--encryption-provider-config`
 docker inspect kube-apiserver | jq -e '.[0].Args[] | match("--encryption-provider-config=.*").string'
 ```
 
-**Returned Value:** `encryption-provider-config=/etc/kubernetes/encryption.yaml`
+**Returned Value:** `encryption-provider-config=/opt/kubernetes/encryption.yaml`
 
 **Result:** Pass
 
@@ -574,7 +574,7 @@ Only the first provider in the list is active.
 **Audit**
 
 ``` bash
-grep -A 1 providers: /etc/kubernetes/encryption.yaml | grep aescbc
+grep -A 1 providers: /opt/kubernetes/encryption.yaml | grep aescbc
 ```
 
 **Returned Value:**  `- aescbc:`
@@ -587,8 +587,8 @@ grep -A 1 providers: /etc/kubernetes/encryption.yaml | grep aescbc
 
 The `EventRateLimit` plugin requires setting the `--admission-control-config-file` option and configuring details in the following files:
 
-- `/etc/kubernetes/admission.yaml`
-- `/etc/kubernetes/event.yaml`
+- `/opt/kubernetes/admission.yaml`
+- `/opt/kubernetes/event.yaml`
 
 See Host Configuration for details.
 
@@ -606,7 +606,7 @@ docker inspect kube-apiserver | jq -e '.[0].Args[] | match("--enable-admission-p
 docker inspect kube-apiserver | jq -e '.[0].Args[] | match("--admission-control-config-file=.*").string'
 ```
 
-**Returned Value:** `--admission-control-config-file=/etc/kubernetes/admission.yaml`
+**Returned Value:** `--admission-control-config-file=/opt/kubernetes/admission.yaml`
 
 **Result:** Pass
 
@@ -630,7 +630,7 @@ docker inspect kube-apiserver | jq -e '.[0].Args[] | match("--feature-gates=.*(A
 docker inspect kube-apiserver | jq -e '.[0].Args[] | match("--audit-policy-file=.*").string'
 ```
 
-**Returned Value:** `--audit-policy-file=/etc/kubernetes/audit.yaml`
+**Returned Value:** `--audit-policy-file=/opt/kubernetes/audit.yaml`
 
 **Result:** Pass
 

--- a/content/rancher/v2.x/en/security/hardening-2.2/_index.md
+++ b/content/rancher/v2.x/en/security/hardening-2.2/_index.md
@@ -115,7 +115,7 @@ This supports the following controls:
 On the control plane hosts for the Rancher HA cluster run:
 
 ``` bash
-stat /etc/kubernetes/encryption.yaml
+stat /opt/kubernetes/encryption.yaml
 ```
 
 Ensure that:
@@ -147,14 +147,14 @@ Where `aescbc` is the key type, and `secret` is populated with a 32-byte base64 
 
 ``` bash
 head -c 32 /dev/urandom | base64 -i -
-touch /etc/kubernetes/encryption.yaml
+touch /opt/kubernetes/encryption.yaml
 ```
 
 - Set the file ownership to `root:root` and the permissions to `0600`
 
 ``` bash
-chown root:root /etc/kubernetes/encryption.yaml
-chmod 0600 /etc/kubernetes/encryption.yaml
+chown root:root /opt/kubernetes/encryption.yaml
+chmod 0600 /opt/kubernetes/encryption.yaml
 ```
 
 - Set the contents to:
@@ -202,7 +202,7 @@ This supports the following controls:
 On each control plane node, run:
 
 ``` bash
-stat /etc/kubernetes/audit.yaml
+stat /opt/kubernetes/audit.yaml
 ```
 
 Ensure that:
@@ -226,14 +226,14 @@ On nodes with the `controlplane` role:
 - Generate an empty configuration file:
 
 ``` bash
-touch /etc/kubernetes/audit.yaml
+touch /opt/kubernetes/audit.yaml
 ```
 
 - Set the file ownership to `root:root` and the permissions to `0600`
 
 ``` bash
-chown root:root /etc/kubernetes/audit.yaml
-chmod 0600 /etc/kubernetes/audit.yaml
+chown root:root /opt/kubernetes/audit.yaml
+chmod 0600 /opt/kubernetes/audit.yaml
 ```
 
 - Set the contents to:
@@ -268,8 +268,8 @@ This supports the following control:
 On nodes with the `controlplane` role run:
 
 ``` bash
-stat /etc/kubernetes/admission.yaml
-stat /etc/kubernetes/event.yaml
+stat /opt/kubernetes/admission.yaml
+stat /opt/kubernetes/event.yaml
 ```
 
 For each file, ensure that:
@@ -285,7 +285,7 @@ apiVersion: apiserver.k8s.io/v1alpha1
 kind: AdmissionConfiguration
 plugins:
 - name: EventRateLimit
-  path: /etc/kubernetes/event.yaml
+  path: /opt/kubernetes/event.yaml
 ```
 
 For `event.yaml` ensure that the file contains:
@@ -306,17 +306,17 @@ On nodes with the `controlplane` role:
 - Generate an empty configuration file:
 
 ``` bash
-touch /etc/kubernetes/admission.yaml
-touch /etc/kubernetes/event.yaml
+touch /opt/kubernetes/admission.yaml
+touch /opt/kubernetes/event.yaml
 ```
 
 - Set the file ownership to `root:root` and the permissions to `0600`
 
 ``` bash
-chown root:root /etc/kubernetes/admission.yaml
-chown root:root /etc/kubernetes/event.yaml
-chmod 0600 /etc/kubernetes/admission.yaml
-chmod 0600 /etc/kubernetes/event.yaml
+chown root:root /opt/kubernetes/admission.yaml
+chown root:root /opt/kubernetes/event.yaml
+chmod 0600 /opt/kubernetes/admission.yaml
+chmod 0600 /opt/kubernetes/event.yaml
 ```
 
 - For `admission.yaml` set the contents to:
@@ -326,7 +326,7 @@ apiVersion: apiserver.k8s.io/v1alpha1
 kind: AdmissionConfiguration
 plugins:
 - name: EventRateLimit
-  path: /etc/kubernetes/event.yaml
+  path: /opt/kubernetes/event.yaml
 ```
 
 - For `event.yaml` set the contents to:
@@ -457,14 +457,14 @@ To pass the following controls for the kube-api server ensure RKE configuration 
 --profiling=false
 --service-account-lookup=true
 --enable-admission-plugins= "ServiceAccount,NamespaceLifecycle,LimitRanger,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds,AlwaysPullImages,DenyEscalatingExec,NodeRestriction,EventRateLimit,PodSecurityPolicy"
---encryption-provider-config=/etc/kubernetes/encryption.yaml
---admission-control-config-file=/etc/kubernetes/admission.yaml
+--encryption-provider-config=/opt/kubernetes/encryption.yaml
+--admission-control-config-file=/opt/kubernetes/admission.yaml
 --audit-log-path=/var/log/kube-audit/audit-log.json
 --audit-log-maxage=5
 --audit-log-maxbackup=5
 --audit-log-maxsize=100
 --audit-log-format=json
---audit-policy-file=/etc/kubernetes/audit.yaml
+--audit-policy-file=/opt/kubernetes/audit.yaml
 --tls-cipher-suites: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256"
 ```
 
@@ -487,14 +487,14 @@ services:
       profiling: "false"
       service-account-lookup: "true"
       enable-admission-plugins: "ServiceAccount,NamespaceLifecycle,LimitRanger,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds,AlwaysPullImages,DenyEscalatingExec,NodeRestriction,EventRateLimit,PodSecurityPolicy"
-      encryption-provider-config: /etc/kubernetes/encryption.yaml
-      admission-control-config-file: "/etc/kubernetes/admission.yaml"
+      encryption-provider-config: /opt/kubernetes/encryption.yaml
+      admission-control-config-file: "/opt/kubernetes/admission.yaml"
       audit-log-path: "/var/log/kube-audit/audit-log.json"
       audit-log-maxage: "5"
       audit-log-maxbackup: "5"
       audit-log-maxsize: "100"
       audit-log-format: "json"
-      audit-policy-file: /etc/kubernetes/audit.yaml
+      audit-policy-file: /opt/kubernetes/audit.yaml
       tls-cipher-suites: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256"
     extra_binds:
       - "/var/log/kube-audit:/var/log/kube-audit"
@@ -1052,14 +1052,14 @@ services:
       profiling: "false"
       service-account-lookup: "true"
       enable-admission-plugins: "ServiceAccount,NamespaceLifecycle,LimitRanger,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds,AlwaysPullImages,DenyEscalatingExec,NodeRestriction,EventRateLimit,PodSecurityPolicy"
-      encryption-provider-config: /etc/kubernetes/encryption.yaml
-      admission-control-config-file: "/etc/kubernetes/admission.yaml"
+      encryption-provider-config: /opt/kubernetes/encryption.yaml
+      admission-control-config-file: "/opt/kubernetes/admission.yaml"
       audit-log-path: "/var/log/kube-audit/audit-log.json"
       audit-log-maxage: "5"
       audit-log-maxbackup: "5"
       audit-log-maxsize: "100"
       audit-log-format: "json"
-      audit-policy-file: /etc/kubernetes/audit.yaml
+      audit-policy-file: /opt/kubernetes/audit.yaml
       tls-cipher-suites: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256"
     extra_binds:
       - "/var/log/kube-audit:/var/log/kube-audit"

--- a/content/rancher/v2.x/en/security/hardening-2.2/_index.md
+++ b/content/rancher/v2.x/en/security/hardening-2.2/_index.md
@@ -175,6 +175,10 @@ resources:
 
 Where `secret` is the 32-byte base64-encoded string generated in the first step.
 
+**NOTE:**
+
+Files that are placed in `/opt/kubernetes` need to be mounted in using the `extra_binds` functionality in RKE.
+
 ### 1.1.3 - Install the audit log configuration on all control plane nodes.
 
 **Profile Applicability**
@@ -244,6 +248,10 @@ kind: Policy
 rules:
 - level: Metadata
 ```
+
+**NOTE:**
+
+Files that are placed in `/opt/kubernetes` need to be mounted in using the `extra_binds` functionality in RKE.
 
 ### 1.1.4 - Place Kubernetes event limit configuration on each control plane host
 
@@ -339,6 +347,10 @@ limits:
   qps: 5000
   burst: 20000
 ```
+
+**NOTE:**
+
+Files that are placed in `/opt/kubernetes` need to be mounted in using the `extra_binds` functionality in RKE.
 
 ## 2.1 - Rancher HA Kubernetes Cluster Configuration via RKE
 
@@ -498,6 +510,7 @@ services:
       tls-cipher-suites: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256"
     extra_binds:
       - "/var/log/kube-audit:/var/log/kube-audit"
+      - "/opt/kubernetes:/opt/kubernetes"
 ```
 
 - Reconfigure the cluster:
@@ -505,6 +518,10 @@ services:
 ``` bash
 rke up --config cluster.yml
 ```
+
+**NOTE:**
+
+Files that are placed in `/opt/kubernetes` need to be mounted in using the `extra_binds` functionality in RKE.
 
 ### 2.1.3 - Configure scheduler options
 
@@ -1063,6 +1080,7 @@ services:
       tls-cipher-suites: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256"
     extra_binds:
       - "/var/log/kube-audit:/var/log/kube-audit"
+      - "/opt/kubernetes:/opt/kubernetes"
   scheduler:
     extra_args:
       profiling: "false"


### PR DESCRIPTION
- Fixes Path (RKE will remove files from `/etc/kubernetes`)
- Mentions `extra_binds` (required to actually load in these files after they are written to the host)

Should fix https://github.com/rancher/docs/issues/1669, although this is not specific to RancherOS.
Also fixes https://github.com/rancher/docs/issues/1702