### PR TITLE
Replace outdated link in RKE docs

### DIFF
--- a/content/rke/latest/en/config-options/system-images/_index.md
+++ b/content/rke/latest/en/config-options/system-images/_index.md
@@ -8,7 +8,13 @@ As of `v0.1.6`, the functionality of a couple of the system images were consolid
 
 You can configure the [network plug-ins]({{< baseurl >}}/rke/latest/en/config-options/add-ons/network-plugins/), [ingress controller]({{< baseurl >}}/rke/latest/en/config-options/add-ons/ingress-controllers/) and [dns provider]({{< baseurl >}}/rke/latest/en/config-options/add-ons/dns/) as well as the options for these add-ons separately.
 
-This is the example of the full list of system images used to deploy Kubernetes through RKE. The image tags are dependent on the [Kubernetes image/version used](https://github.com/rancher/types/blob/master/apis/management.cattle.io/v3/k8s_defaults.go).
+This is the example of the full list of system images used to deploy Kubernetes through RKE. The image tags are dependent on the Kubernetes version used. For now, this should match the
+version defined in the `rancher/types` defaults map.
+
+  - For RKE v0.2.x and below, the default versions are defined at:
+    https://github.com/rancher/types/blob/release/v2.2/apis/management.cattle.io/v3/k8s_defaults.go
+  - For RKE v0.3.0 and above, the default versions are defined at:
+    https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_defaults.go
 
 > **Note:** As versions of RKE are released, the tags on these images will no longer be up to date. This list is specific for `v1.10.3-rancher2`.
 

--- a/content/rke/latest/en/config-options/system-images/_index.md
+++ b/content/rke/latest/en/config-options/system-images/_index.md
@@ -6,9 +6,12 @@ When RKE is deploying Kubernetes, there are several images that are pulled. Thes
 
 As of `v0.1.6`, the functionality of a couple of the system images were consolidated into a single `rancher/rke-tools` image to simplify and speed the deployment process.
 
-You can configure the [network plug-ins]({{< baseurl >}}/rke/latest/en/config-options/add-ons/network-plugins/), [ingress controller]({{< baseurl >}}/rke/latest/en/config-options/add-ons/ingress-controllers/) and [dns provider]({{< baseurl >}}/rke/latest/en/config-options/add-ons/dns/) as well as the options for these add-ons separately.
+You can configure the [network plug-ins]({{<baseurl>}}/rke/latest/en/config-options/add-ons/network-plugins/), [ingress controller]({{<baseurl>}}/rke/latest/en/config-options/add-ons/ingress-controllers/) and [dns provider]({{<baseurl>}}/rke/latest/en/config-options/add-ons/dns/) as well as the options for these add-ons separately.
 
-The mapping of system images to the appropriate Kubernetes versions has moved to this file: https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_rke_system_images.go
+Below is an example of the list of system images used to deploy Kubernetes through RKE.
+
+- For RKE v0.2.x and below, the default versions of Kubernetes are tied to specific versions of the system images. Therefore, your Kubernetes version should match the version defined in the `rancher/types` defaults map, located here: https://github.com/rancher/types/blob/release/v2.2/apis/management.cattle.io/v3/k8s_defaults.go
+- For RKE v0.3.0 and above, the default Kubernetes versions are no longer tied to specific versions of the system images. If you change the Kubernetes version, you can supply the corresponding system images yourself, according to the mappings in this file: https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_defaults.go
 
 > **Note:** As versions of RKE are released, the tags on these images will no longer be up to date. This list is specific for `v1.10.3-rancher2`.
 

--- a/content/rke/latest/en/config-options/system-images/_index.md
+++ b/content/rke/latest/en/config-options/system-images/_index.md
@@ -11,7 +11,7 @@ You can configure the [network plug-ins]({{<baseurl>}}/rke/latest/en/config-opti
 Below is an example of the list of system images used to deploy Kubernetes through RKE.
 
 - For RKE v0.2.x and below, the default versions of Kubernetes are tied to specific versions of the system images. Therefore, your Kubernetes version should match the version defined in the `rancher/types` defaults map, located here: https://github.com/rancher/types/blob/release/v2.2/apis/management.cattle.io/v3/k8s_defaults.go
-- For RKE v0.3.0 and above, the default Kubernetes versions are no longer tied to specific versions of the system images. If you change the Kubernetes version, you can supply the corresponding system images yourself, according to the mappings in this file: https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_defaults.go
+- For RKE v0.3.0 and above, the default Kubernetes versions are no longer tied to specific versions of the system images. If you change the Kubernetes version, you can supply the corresponding system images yourself, according to the mappings in this file: https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_rke_system_images.go
 
 > **Note:** As versions of RKE are released, the tags on these images will no longer be up to date. This list is specific for `v1.10.3-rancher2`.
 

--- a/content/rke/latest/en/config-options/system-images/_index.md
+++ b/content/rke/latest/en/config-options/system-images/_index.md
@@ -8,13 +8,13 @@ As of `v0.1.6`, the functionality of a couple of the system images were consolid
 
 You can configure the [network plug-ins]({{< baseurl >}}/rke/latest/en/config-options/add-ons/network-plugins/), [ingress controller]({{< baseurl >}}/rke/latest/en/config-options/add-ons/ingress-controllers/) and [dns provider]({{< baseurl >}}/rke/latest/en/config-options/add-ons/dns/) as well as the options for these add-ons separately.
 
-This is the example of the full list of system images used to deploy Kubernetes through RKE. The image tags are dependent on the Kubernetes version used. For now, this should match the
-version defined in the `rancher/types` defaults map.
+For RKE v0.2.x and below, the default versions of Kubernetes are tied to specific versions of the system images. Therefore, your Kubernetes version should match the version defined in the `rancher/types` defaults map, located here:
 
-  - For RKE v0.2.x and below, the default versions are defined at:
-    https://github.com/rancher/types/blob/release/v2.2/apis/management.cattle.io/v3/k8s_defaults.go
-  - For RKE v0.3.0 and above, the default versions are defined at:
-    https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_defaults.go
+https://github.com/rancher/types/blob/release/v2.2/apis/management.cattle.io/v3/k8s_defaults.go
+
+For RKE v0.3.0 and above, you can configure the Kubernetes version independently of the Rancher version. If you change the Kubernetes version, you can supply the corresponding system images yourself, according to the mappings in this file:
+
+https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_rke_system_images.go
 
 > **Note:** As versions of RKE are released, the tags on these images will no longer be up to date. This list is specific for `v1.10.3-rancher2`.
 

--- a/content/rke/latest/en/config-options/system-images/_index.md
+++ b/content/rke/latest/en/config-options/system-images/_index.md
@@ -8,10 +8,11 @@ As of `v0.1.6`, the functionality of a couple of the system images were consolid
 
 You can configure the [network plug-ins]({{<baseurl>}}/rke/latest/en/config-options/add-ons/network-plugins/), [ingress controller]({{<baseurl>}}/rke/latest/en/config-options/add-ons/ingress-controllers/) and [dns provider]({{<baseurl>}}/rke/latest/en/config-options/add-ons/dns/) as well as the options for these add-ons separately.
 
-Below is an example of the list of system images used to deploy Kubernetes through RKE.
+Below is an example of the list of system images used to deploy Kubernetes through RKE. The default versions of Kubernetes are tied to specific versions of system images. 
 
-- For RKE v0.2.x and below, the default versions of Kubernetes are tied to specific versions of the system images. Therefore, your Kubernetes version should match the version defined in the `rancher/types` defaults map, located here: https://github.com/rancher/types/blob/release/v2.2/apis/management.cattle.io/v3/k8s_defaults.go
-- For RKE v0.3.0 and above, the default Kubernetes versions are no longer tied to specific versions of the system images. If you change the Kubernetes version, you can supply the corresponding system images yourself, according to the mappings in this file: https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_rke_system_images.go
+- For RKE v0.2.x and below, the map of versions and the system image versions is located here: https://github.com/rancher/types/blob/release/v2.2/apis/management.cattle.io/v3/k8s_defaults.go
+
+- For RKE v0.3.0 and above, the map of versions and the system image versions is located here: https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_rke_system_images.go
 
 > **Note:** As versions of RKE are released, the tags on these images will no longer be up to date. This list is specific for `v1.10.3-rancher2`.
 

--- a/content/rke/latest/en/config-options/system-images/_index.md
+++ b/content/rke/latest/en/config-options/system-images/_index.md
@@ -8,13 +8,7 @@ As of `v0.1.6`, the functionality of a couple of the system images were consolid
 
 You can configure the [network plug-ins]({{< baseurl >}}/rke/latest/en/config-options/add-ons/network-plugins/), [ingress controller]({{< baseurl >}}/rke/latest/en/config-options/add-ons/ingress-controllers/) and [dns provider]({{< baseurl >}}/rke/latest/en/config-options/add-ons/dns/) as well as the options for these add-ons separately.
 
-For RKE v0.2.x and below, the default versions of Kubernetes are tied to specific versions of the system images. Therefore, your Kubernetes version should match the version defined in the `rancher/types` defaults map, located here:
-
-https://github.com/rancher/types/blob/release/v2.2/apis/management.cattle.io/v3/k8s_defaults.go
-
-For RKE v0.3.0 and above, you can configure the Kubernetes version independently of the Rancher version. If you change the Kubernetes version, you can supply the corresponding system images yourself, according to the mappings in this file:
-
-https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_rke_system_images.go
+The mapping of system images to the appropriate Kubernetes versions has moved to this file: https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_rke_system_images.go
 
 > **Note:** As versions of RKE are released, the tags on these images will no longer be up to date. This list is specific for `v1.10.3-rancher2`.
 

--- a/content/rke/latest/en/example-yamls/_index.md
+++ b/content/rke/latest/en/example-yamls/_index.md
@@ -88,9 +88,19 @@ cluster_name: mycluster
 
 # The Kubernetes version used.
 #
-# The mapping of system images to the corresponding Kubernetes
-# versions has moved to this file:
-# https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_rke_system_images.go
+# For RKE v0.2.x and below, the default versions of
+# Kubernetes are tied to specific versions of the system
+# images. Therefore, your Kubernetes version should match the
+# version defined in the `rancher/types` defaults map,
+# located here:
+# https://github.com/rancher/types/blob/release/v2.2/apis/management.cattle.io/v3/k8s_defaults.go
+#
+# For RKE v0.3.0 and above, the default Kubernetes versions
+# are no longer tied to specific versions of the system images.
+# If you change the Kubernetes version, you can supply the
+# corresponding system images yourself, according to the
+# mappings in this file:
+# https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_defaults.go
 #
 # In case the kubernetes_version and kubernetes image in
 # system_images are defined, the system_images configuration
@@ -100,9 +110,19 @@ kubernetes_version: v1.10.3-rancher2
 # System Image Tags are defaulted to a tag tied with specific
 # kubernetes Versions
 #
-# The mapping of system images to the corresponding Kubernetes
-# versions has moved to this file:
-# https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_rke_system_images.go
+# For RKE v0.2.x and below, the default versions of
+# Kubernetes are tied to specific versions of the system
+# images. Therefore, your Kubernetes version should match the
+# version defined in the `rancher/types` defaults map,
+# located here:
+# https://github.com/rancher/types/blob/release/v2.2/apis/management.cattle.io/v3/k8s_defaults.go
+#
+# For RKE v0.3.0 and above, the default Kubernetes versions
+# are no longer tied to specific versions of the system images.
+# If you change the Kubernetes version, you can supply the
+# corresponding system images yourself, according to the
+# mappings in this file:
+# https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_defaults.go
 system_images:
     kubernetes: rancher/hyperkube:v1.10.3-rancher2
     etcd: rancher/coreos-etcd:v3.1.12

--- a/content/rke/latest/en/example-yamls/_index.md
+++ b/content/rke/latest/en/example-yamls/_index.md
@@ -100,7 +100,7 @@ cluster_name: mycluster
 # If you change the Kubernetes version, you can supply the
 # corresponding system images yourself, according to the
 # mappings in this file:
-# https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_defaults.go
+# https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_rke_system_images.go
 #
 # In case the kubernetes_version and kubernetes image in
 # system_images are defined, the system_images configuration
@@ -122,7 +122,7 @@ kubernetes_version: v1.10.3-rancher2
 # If you change the Kubernetes version, you can supply the
 # corresponding system images yourself, according to the
 # mappings in this file:
-# https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_defaults.go
+# https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_rke_system_images.go
 system_images:
     kubernetes: rancher/hyperkube:v1.10.3-rancher2
     etcd: rancher/coreos-etcd:v3.1.12
@@ -154,10 +154,10 @@ services:
       #   -----BEGIN PRIVATE KEY-----
       #   xxxxxxxxxx
       #   -----END PRIVATE KEY-----
-    # Note for Rancher 2 users: If you are configuring Cluster
-    # Options using a Config File when creating Rancher Launched
+    # Note for Rancher v2.0.5 and v2.0.6 users: If you are configuring
+    # Cluster Options using a Config File when creating Rancher Launched
     # Kubernetes, the names of services should contain underscores
-    # only: `kube_api`. This only applies to Rancher v2.0.5 and v2.0.6.
+    # only: `kube_api`.
     kube-api:
       # IP range for any services created on Kubernetes
       # This must match the service_cluster_ip_range in kube-controller

--- a/content/rke/latest/en/example-yamls/_index.md
+++ b/content/rke/latest/en/example-yamls/_index.md
@@ -88,17 +88,8 @@ cluster_name: mycluster
 
 # The Kubernetes version used.
 #
-# For RKE v0.2.x and below, the default versions of Kubernetes
-# are tied to specific versions of system images. Therefore,
-# your Kubernetes version should match the
-# version defined in the rancher/types defaults map:
-# https://github.com/rancher/types/blob/release/v2.2/apis/management.cattle.io/v3/k8s_defaults.go
-# 
-# For RKE v0.3.0 and above, you can configure
-# the Kubernetes version independently of the Rancher version.
-# If you change the Kubernetes version, you can supply the
-# corresponding system images yourself, according to the
-# mappings in this file:
+# The mapping of system images to the corresponding Kubernetes
+# versions has moved to this file:
 # https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_rke_system_images.go
 #
 # In case the kubernetes_version and kubernetes image in
@@ -109,17 +100,8 @@ kubernetes_version: v1.10.3-rancher2
 # System Image Tags are defaulted to a tag tied with specific
 # kubernetes Versions
 #
-# For RKE v0.2.x and below, the default versions of Kubernetes
-# are tied to specific versions of system images. Therefore,
-# your Kubernetes version should match the
-# version defined in the rancher/types defaults map:
-# https://github.com/rancher/types/blob/release/v2.2/apis/management.cattle.io/v3/k8s_defaults.go
-# 
-# For RKE v0.3.0 and above, you can configure
-# the Kubernetes version independently of the Rancher version.
-# If you change the Kubernetes version, you can supply the
-# corresponding system images yourself, according to the
-# mappings in this file:
+# The mapping of system images to the corresponding Kubernetes
+# versions has moved to this file:
 # https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_rke_system_images.go
 system_images:
     kubernetes: rancher/hyperkube:v1.10.3-rancher2

--- a/content/rke/latest/en/example-yamls/_index.md
+++ b/content/rke/latest/en/example-yamls/_index.md
@@ -86,20 +86,15 @@ bastion_host:
 cluster_name: mycluster
 
 
-# The Kubernetes version used.
+# The Kubernetes version used. The default versions of Kubernetes
+# are tied to specific versions of the system images.
 #
-# For RKE v0.2.x and below, the default versions of
-# Kubernetes are tied to specific versions of the system
-# images. Therefore, your Kubernetes version should match the
-# version defined in the `rancher/types` defaults map,
+# For RKE v0.2.x and below, the map of Kubernetes versions and their system images is
 # located here:
 # https://github.com/rancher/types/blob/release/v2.2/apis/management.cattle.io/v3/k8s_defaults.go
 #
-# For RKE v0.3.0 and above, the default Kubernetes versions
-# are no longer tied to specific versions of the system images.
-# If you change the Kubernetes version, you can supply the
-# corresponding system images yourself, according to the
-# mappings in this file:
+# For RKE v0.3.0 and above, the map of Kubernetes versions and their system images is
+# located here:
 # https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_rke_system_images.go
 #
 # In case the kubernetes_version and kubernetes image in
@@ -107,22 +102,18 @@ cluster_name: mycluster
 # will take precedence over kubernetes_version.
 kubernetes_version: v1.10.3-rancher2
 
-# System Image Tags are defaulted to a tag tied with specific
-# kubernetes Versions
+# System Images are defaulted to a tag that is mapped to a specific
+# Kubernetes Version and not required in a cluster.yml. 
+# Each individual system image can be specified if you want to use a different tag.
 #
-# For RKE v0.2.x and below, the default versions of
-# Kubernetes are tied to specific versions of the system
-# images. Therefore, your Kubernetes version should match the
-# version defined in the `rancher/types` defaults map,
+# For RKE v0.2.x and below, the map of Kubernetes versions and their system images is
 # located here:
 # https://github.com/rancher/types/blob/release/v2.2/apis/management.cattle.io/v3/k8s_defaults.go
 #
-# For RKE v0.3.0 and above, the default Kubernetes versions
-# are no longer tied to specific versions of the system images.
-# If you change the Kubernetes version, you can supply the
-# corresponding system images yourself, according to the
-# mappings in this file:
+# For RKE v0.3.0 and above, the map of Kubernetes versions and their system images is
+# located here:
 # https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_rke_system_images.go
+#
 system_images:
     kubernetes: rancher/hyperkube:v1.10.3-rancher2
     etcd: rancher/coreos-etcd:v3.1.12

--- a/content/rke/latest/en/example-yamls/_index.md
+++ b/content/rke/latest/en/example-yamls/_index.md
@@ -86,14 +86,20 @@ bastion_host:
 cluster_name: mycluster
 
 
-# The Kubernetes version used. For now, this should match the
-# version defined in the rancher/types defaults map.
+# The Kubernetes version used.
 #
-# For RKE v0.2.x and below, the default versions are defined at:
+# For RKE v0.2.x and below, the default versions of Kubernetes
+# are tied to specific versions of system images. Therefore,
+# your Kubernetes version should match the
+# version defined in the rancher/types defaults map:
 # https://github.com/rancher/types/blob/release/v2.2/apis/management.cattle.io/v3/k8s_defaults.go
 # 
-# For RKE v0.3.0 and above, the default versions are defined at:
-# https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_defaults.go
+# For RKE v0.3.0 and above, you can configure
+# the Kubernetes version independently of the Rancher version.
+# If you change the Kubernetes version, you can supply the
+# corresponding system images yourself, according to the
+# mappings in this file:
+# https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_rke_system_images.go
 #
 # In case the kubernetes_version and kubernetes image in
 # system_images are defined, the system_images configuration
@@ -103,11 +109,18 @@ kubernetes_version: v1.10.3-rancher2
 # System Image Tags are defaulted to a tag tied with specific
 # kubernetes Versions
 #
-# For RKE v0.2.x and below, the default versions are defined at:
+# For RKE v0.2.x and below, the default versions of Kubernetes
+# are tied to specific versions of system images. Therefore,
+# your Kubernetes version should match the
+# version defined in the rancher/types defaults map:
 # https://github.com/rancher/types/blob/release/v2.2/apis/management.cattle.io/v3/k8s_defaults.go
 # 
-# For RKE v0.3.0 and above, the default versions are defined at:
-# https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_defaults.go
+# For RKE v0.3.0 and above, you can configure
+# the Kubernetes version independently of the Rancher version.
+# If you change the Kubernetes version, you can supply the
+# corresponding system images yourself, according to the
+# mappings in this file:
+# https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_rke_system_images.go
 system_images:
     kubernetes: rancher/hyperkube:v1.10.3-rancher2
     etcd: rancher/coreos-etcd:v3.1.12

--- a/content/rke/latest/en/example-yamls/_index.md
+++ b/content/rke/latest/en/example-yamls/_index.md
@@ -49,7 +49,8 @@ nodes:
       labels:
         app: ingress
 
-# If set to true, RKE will not fail when unsupported Docker version are found
+# If set to true, RKE will not fail when unsupported Docker version
+# are found
 ignore_docker_version: false
 
 # Cluster level SSH private key
@@ -57,11 +58,13 @@ ignore_docker_version: false
 ssh_key_path: ~/.ssh/test
 
 # Enable use of SSH agent to use SSH private keys with passphrase
-# This requires the environment `SSH_AUTH_SOCK` configured pointing to your SSH agent which has the private key added
+# This requires the environment `SSH_AUTH_SOCK` configured pointing
+#to your SSH agent which has the private key added
 ssh_agent_auth: true
 
 # List of registry credentials
-# If you are using a Docker Hub registry, you can omit the `url` or set it to `docker.io`
+# If you are using a Docker Hub registry, you can omit the `url`
+# or set it to `docker.io`
 private_registries:
     - url: registry.com
       user: Username
@@ -83,12 +86,28 @@ bastion_host:
 cluster_name: mycluster
 
 
-# The kubernetes version used. For now, this should match the version defined in rancher/types defaults map: https://github.com/rancher/types/blob/master/apis/management.cattle.io/v3/k8s_defaults.go#L14
-# In case the kubernetes_version and kubernetes image in system_images are defined, the system_images configuration will take precedence over kubernetes_version.
+# The Kubernetes version used. For now, this should match the
+# version defined in the rancher/types defaults map.
+#
+# For RKE v0.2.x and below, the default versions are defined at:
+# https://github.com/rancher/types/blob/release/v2.2/apis/management.cattle.io/v3/k8s_defaults.go
+# 
+# For RKE v0.3.0 and above, the default versions are defined at:
+# https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_defaults.go
+#
+# In case the kubernetes_version and kubernetes image in
+# system_images are defined, the system_images configuration
+# will take precedence over kubernetes_version.
 kubernetes_version: v1.10.3-rancher2
 
-# System Image Tags are defaulted to a tag tied with specific kubernetes Versions
-# Default Tags: https://github.com/rancher/types/blob/master/apis/management.cattle.io/v3/k8s_defaults.go)
+# System Image Tags are defaulted to a tag tied with specific
+# kubernetes Versions
+#
+# For RKE v0.2.x and below, the default versions are defined at:
+# https://github.com/rancher/types/blob/release/v2.2/apis/management.cattle.io/v3/k8s_defaults.go
+# 
+# For RKE v0.3.0 and above, the default versions are defined at:
+# https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_defaults.go
 system_images:
     kubernetes: rancher/hyperkube:v1.10.3-rancher2
     etcd: rancher/coreos-etcd:v3.1.12
@@ -120,7 +139,10 @@ services:
       #   -----BEGIN PRIVATE KEY-----
       #   xxxxxxxxxx
       #   -----END PRIVATE KEY-----
-    # Note for Rancher 2 users: If you are configuring Cluster Options using a Config File when creating Rancher Launched Kubernetes, the names of services should contain underscores only: `kube_api`. This only applies to Rancher v2.0.5 and v2.0.6.
+    # Note for Rancher 2 users: If you are configuring Cluster
+    # Options using a Config File when creating Rancher Launched
+    # Kubernetes, the names of services should contain underscores
+    # only: `kube_api`. This only applies to Rancher v2.0.5 and v2.0.6.
     kube-api:
       # IP range for any services created on Kubernetes
       # This must match the service_cluster_ip_range in kube-controller
@@ -137,7 +159,10 @@ services:
         delete-collection-workers: 3
         # Set the level of log output to debug-level
         v: 4
-    # Note for Rancher 2 users: If you are configuring Cluster Options using a Config File when creating Rancher Launched Kubernetes, the names of services should contain underscores only: `kube_controller`. This only applies to Rancher v2.0.5 and v2.0.6.
+    # Note for Rancher 2 users: If you are configuring Cluster Options
+    # using a Config File when creating Rancher Launched Kubernetes,
+    # the names of services should contain underscores only:
+    # `kube_controller`. This only applies to Rancher v2.0.5 and v2.0.6.
     kube-controller:
       # CIDR pool used to assign IP addresses to pods in the cluster
       cluster_cidr: 10.42.0.0/16
@@ -157,19 +182,12 @@ services:
       # Optionally define additional volume binds to a service
       extra_binds:
         - "/usr/libexec/kubernetes/kubelet-plugins:/usr/libexec/kubernetes/kubelet-plugins"
-    scheduler:
-      extra_args:
-        # Set the level of log output to debug-level
-        v: 4
-    kubeproxy:
-      extra_args:
-        # Set the level of log output to debug-level
-        v: 4
 
 # Currently, only authentication strategy supported is x509.
-# You can optionally create additional SANs (hostnames or IPs) to add to
-#  the API server PKI certificate.
-# This is useful if you want to use a load balancer for the control plane servers.
+# You can optionally create additional SANs (hostnames or IPs) to
+# add to the API server PKI certificate.
+# This is useful if you want to use a load balancer for the
+# control plane servers.
 authentication:
     strategy: x509
     sans:
@@ -182,14 +200,17 @@ authentication:
 authorization:
     mode: rbac
 
-# If you want to set a Kubernetes cloud provider, you specify the name and configuration
+# If you want to set a Kubernetes cloud provider, you specify
+# the name and configuration
 cloud_provider:
     name: aws
 
-# Add-ons are deployed using kubernetes jobs. RKE will give up on trying to get the job status after this timeout in seconds..
+# Add-ons are deployed using kubernetes jobs. RKE will give
+# up on trying to get the job status after this timeout in seconds..
 addon_job_timeout: 30
 
-# There are several network plug-ins that work, but we default to canal      
+# There are several network plug-ins that work, but we default
+# to canal      
 network:
     plugin: canal
 


### PR DESCRIPTION
This PR addresses this issue: https://github.com/rancher/docs/issues/1633

It also shortens the comments in the example YAML so you don't have to horizontally scroll.