### PR TITLE
Respond to feedback on RKE template docs

### DIFF
--- a/content/rancher/v2.x/en/admin-settings/rke-templates/_index.md
+++ b/content/rancher/v2.x/en/admin-settings/rke-templates/_index.md
@@ -13,7 +13,7 @@ With Kubernetes increasing in popularity, there is a trend toward managing a lar
 
 RKE templates help standardize these configurations. Regardless of whether clusters are created with the Rancher UI, the Rancher API, or an automated process, Rancher will guarantee that every cluster it provisions from an RKE template is uniform and consistent in the way it is produced.
 
-Admins control which cluster options can be changed by end users. RKE templates can also be shared with specific users, so that admins can create different RKE templates for different sets of users.
+Admins control which cluster options can be changed by end users. RKE templates can also be shared with specific users and groups, so that admins can create different RKE templates for different sets of users.
 
 If a cluster was created with an RKE template, you can't change it to a different RKE template. You can only update the cluster to a new revision of the same template.
 
@@ -21,7 +21,7 @@ To summarize, RKE templates allow DevOps and security teams to:
 
 - Standardize cluster configuration and ensure that Rancher-provisioned clusters are created following best practices
 - Prevent less technical users from making uninformed choices when provisioning clusters
-- Share different templates with different sets of users
+- Share different templates with different sets of users and groups
 - Delegate ownership of templates to users who are trusted to make changes to them
 - Control which users can create templates
 - Require users to create clusters from a template

--- a/content/rancher/v2.x/en/admin-settings/rke-templates/enforcement/_index.md
+++ b/content/rancher/v2.x/en/admin-settings/rke-templates/enforcement/_index.md
@@ -5,9 +5,11 @@ weight: 32
 
 This section describes how template administrators can enforce templates in Rancher, restricting the ability of users to create clusters without a template.
 
-This section also describes how template owners can define which settings in a template can be edited by end users.
+By default, any standard user in Rancher can create clusters. But when RKE template enforcement is turned on,
 
-By default, any standard user in Rancher can create clusters, but you can change the default so that only an administrator has the ability to create clusters without a template. When you turn on temmplate enforcement, all standard users must use an RKE template when creating a cluster.
+- Only an administrator has the ability to create clusters without a template.
+- All standard users must use an RKE template to create a new cluster.
+- Standard users cannot create a cluster without using a template.
 
 Users can only create new templates if the administrator [gives them permission.]({{<baseurl>}}/rancher/v2.x/en/admin-settings/rke-templates/creator-permissions/#allowing-a-user-to-create-templates)
 

--- a/content/rancher/v2.x/en/admin-settings/rke-templates/example-scenarios/_index.md
+++ b/content/rancher/v2.x/en/admin-settings/rke-templates/example-scenarios/_index.md
@@ -16,9 +16,14 @@ These example scenarios describe how an organization could use templates to stan
 Let's say there is an organization in which the administrators decide that all new clusters should be created with Kubernetes version 1.14.
 
 1. First, an administrator creates a template which specifies the Kubernetes version as 1.14 and marks all other settings as **Allow User Override**. 
-1. Then the administrator makes the template public and turns on template enforcement.
+1. The administrator makes the template public.
+1. The administrator turns on template enforcement.
 
-**Result:** All Rancher users in the organization have access to the template. All new clusters created by [standard users]({{<baseurl>}}/rancher/v2.x/en/admin-settings/rbac/global-permissions/) use Kubernetes 1.14 and they are unable to use a different Kubernetes version.
+**Results:** 
+
+- All Rancher users in the organization have access to the template.
+- All new clusters created by [standard users]({{<baseurl>}}/rancher/v2.x/en/admin-settings/rbac/global-permissions/) with this template will use Kubernetes 1.14 and they are unable to use a different Kubernetes version. By default, standard users don't have permission to create templates, so this template will be the only template they can use unless more templates are shared with them.
+- All standard users must use a cluster template to create a new cluster. They cannot create a cluster without using a template.
 
 In this way, the administrators enforce the Kubernetes version across the organization, while still allowing end users to configure everything else.
 

--- a/content/rancher/v2.x/en/admin-settings/rke-templates/template-access-and-sharing/_index.md
+++ b/content/rancher/v2.x/en/admin-settings/rke-templates/template-access-and-sharing/_index.md
@@ -3,11 +3,11 @@ title: Access and Sharing
 weight: 31
 ---
 
-If you are an RKE template owner, you can share it with users, who can then use it to create clusters.
+If you are an RKE template owner, you can share it with users or groups of users, who can then use the template to create clusters.
 
-Since RKE templates are specifically shared with users, owners can share different RKE templates with different sets of users.
+Since RKE templates are specifically shared with users and groups, owners can share different RKE templates with different sets of users.
 
-When you share a template with a user, each user can have one of two access levels:
+When you share a template, each user can have one of two access levels:
 
 - **Owner:** This user can update, delete, and share the templates that they own. The owner can also share the template with other users.
 - **User:** These users can create clusters using the template. They can also upgrade those clusters to new revisions of the same template. When you share a template as **Make Public (read-only),** all users in your Rancher setup have the User access level for the template.
@@ -23,9 +23,9 @@ There are several ways to share templates:
 - Make the RKE template public, sharing it with all users in the Rancher setup
 - Share template ownership with users who are trusted to modify the template
 
-### Sharing Templates with Specific Users
+### Sharing Templates with Specific Users or Groups
 
-To allow other users to create clusters using your template, you can give them the basic **User** access level for the template.
+To allow users or groups to create clusters using your template, you can give them the basic **User** access level for the template.
 
 1. From the **Global** view, click **Tools > RKE Templates.**
 1. Go to the template that you want to share and click the **Vertical Ellipsis (...) > Edit.**
@@ -46,11 +46,11 @@ To allow other users to create clusters using your template, you can give them t
 
 ### Sharing Ownership of Templates
 
-If you are the creator of a template, you might want to delegate responsibility for maintaining and updating a template to another user.
+If you are the creator of a template, you might want to delegate responsibility for maintaining and updating a template to another user or group.
 
 In that case, you can give users the Owner access type, which allows another user to update your template, delete it, or share access to it with other users.
 
-To give a user Owner access to a template,
+To give Owner access to a user or group,
 
 1. From the **Global** view, click **Tools > RKE Templates.**
 1. Go to the RKE template that you want to share and click the **Vertical Ellipsis (...) > Edit.**
@@ -58,4 +58,4 @@ To give a user Owner access to a template,
 1. In the **Access Type** field, click **Owner.**
 1. Click **Save.**
 
-**Result:** The user has the Owner access type, and can modify, share, or delete the template.
+**Result:** The user or group has the Owner access type, and can modify, share, or delete the template.


### PR DESCRIPTION
Making two main changes here:
- When we describe Enforcement, in this example https://staging.rancher.com/docs/rancher/v2.x/en/admin-settings/rke-templates/example-scenarios/#enforcing-a-template-setting-for-everyone emphasize that all users must use a cluster template to create new cluster, they cannot create one without using a template
- Sharing the templates, can mention that templates can be shared with groups of users too.
So we should mention, you can search for specific users or specific groups of users https://staging.rancher.com/docs/rancher/v2.x/en/admin-settings/rke-templates/