### PR TITLE
Update steps prepare-private-registry HA steps

### DIFF
--- a/content/rancher/v2.x/en/installation/air-gap-high-availability/prepare-private-registry/_index.md
+++ b/content/rancher/v2.x/en/installation/air-gap-high-availability/prepare-private-registry/_index.md
@@ -39,12 +39,6 @@ Start by collecting all the images needed to install Rancher in an air gap envir
     chmod +x rancher-save-images.sh
     ```
 
-
-1. From the directory that contains the RKE binary, add RKE's images to `rancher-images.txt`, which is a list of all the files needed to install Rancher.
-
-    ```
-    rke config --system-images >> ./rancher-images.txt
-    ```
 1. **Default Rancher Generated Self-Signed Certificate Users Only:** If you elect to use the Rancher default self-signed TLS certificates, you must add the [`cert-manager`](https://github.com/helm/charts/tree/master/stable/cert-manager) image to `rancher-images.txt` as well. You may skip this step if you are using you using your own certificates.
 
     1.  Fetch the latest `cert-manager` Helm chart and parse the template for image details.


### PR DESCRIPTION
The rke images are included in the rancher-images.txt list.
We don't need to get them separately

https://github.com/rancher/docs/issues/1758