### PR TITLE
fix typo

### DIFF
--- a/content/rancher/v2.x/en/cluster-admin/tools/istio/_index.md
+++ b/content/rancher/v2.x/en/cluster-admin/tools/istio/_index.md
@@ -60,7 +60,7 @@ With Istio enabled, you can:
 
 ## Leveraging Istio in Projects
 
-After you enable Istio, you can see traphic metrics and a traffic graph on the project level. You can see a traffic graph for all namespaces that have Istio sidecar injection enabled. For more information, refer to [How to Use Istio in Your Project]({{< baseurl >}}/rancher/v2.x/en/project-admin/istio/).
+After you enable Istio, you can see metrics and a traffic graph on the project level. You can see a traffic graph for all namespaces that have Istio sidecar injection enabled. For more information, refer to [How to Use Istio in Your Project]({{< baseurl >}}/rancher/v2.x/en/project-admin/istio/).
 
 ## Disabling Istio
 

--- a/content/rancher/v2.x/en/cluster-admin/tools/istio/_index.md
+++ b/content/rancher/v2.x/en/cluster-admin/tools/istio/_index.md
@@ -60,7 +60,7 @@ With Istio enabled, you can:
 
 ## Leveraging Istio in Projects
 
-After you enable Istio, you can see metrics and a traffic graph on the project level. You can see a traffic graph for all namespaces that have Istio sidecar injection enabled. For more information, refer to [How to Use Istio in Your Project]({{< baseurl >}}/rancher/v2.x/en/project-admin/istio/).
+After you enable Istio, you can see traffic metrics and a traffic graph on the project level. You can see a traffic graph for all namespaces that have Istio sidecar injection enabled. For more information, refer to [How to Use Istio in Your Project]({{< baseurl >}}/rancher/v2.x/en/project-admin/istio/).
 
 ## Disabling Istio
 


### PR DESCRIPTION
not sure if it should be "graphic metrics," which doesn't make sense, or "traffic metrics," but the reuse of "traffic" twice more on the same line leads me to think that it should just be removed. maybe "graphs of metrics?" i think it's sufficient to just see "metrics."