### PR TITLE
Add details on addon and agent placement

### DIFF
--- a/content/rancher/v2.x/en/cluster-provisioning/rancher-agents/_index.md
+++ b/content/rancher/v2.x/en/cluster-provisioning/rancher-agents/_index.md
@@ -1,0 +1,30 @@
+---
+title: Rancher agents
+weight: 2400
+---
+
+There are two types of agent resources deployed on Rancher managed clusters:
+
+- Deployment `cattle-cluster-agent`: Used to interact with the cluster, it is the agent that Rancher uses to talk to the Kubernetes API server in the cluster.
+- DaemonSet `cattle-node-agent`: Used to be able to interact with the nodes in a cluster, this only applies to [Rancher Launched Kubernetes]({{< baseurl >}}/rancher/v2.x/en/cluster-provisioning/rke-clusters/) as these are the clusters where Rancher needs to connect to the node to make changes. This agent is also used when using `Execute Shell` in the Rancher UI.
+
+The last resource deployed to Rancher managed clusters is the DaemonSet `kube-api-auth`. This DaemonSet is only deployed to nodes with the `controlplane` role and is needed for the [Authorized Cluster Endpoint]({{< baseurl >}}/rancher/v2.x/en/cluster-admin/kubeconfig/_index.md) feature.
+
+### Placement
+
+_Applies to v2.3.0 and higher_
+
+| Component            | nodeAffinity nodeSelectorTerms             | nodeSelector | Tolerations                                                                    |
+| -------------------- | ------------------------------------------ | ------------ | ------------------------------------------------------------------------------ |
+| cattle-cluster-agent | `beta.kubernetes.io/os:NotIn:windows`      | none         | `operator:Exists`                                                              |
+| cattle-node-agent    | `beta.kubernetes.io/os:NotIn:windows`      | none         | `operator:Exists`                                                              |
+| kube-api-auth        | - `beta.kubernetes.io/os:NotIn:windows`<br/>- `node-role.kubernetes.io/controlplane:In:"true"` | none         | `operator:Exists`          |
+
+> **Note:** In Rancher v2.2.4 and lower, the `cattle-node-agent` pods did not tolerate all taints, causing Kubernetes upgrades to fail on these nodes. The fix for this has been included in Rancher v2.2.5 and higher.
+
+The `cattle-cluster-agent` has preferred scheduling rules using `requiredDuringSchedulingIgnoredDuringExecution` and is configured as follows:
+
+| Weight | Expression                                       |
+| ------ | ------------------------------------------------ |
+| 100    | `node-role.kubernetes.io/controlplane:In:"true"` |
+| 1      | `node-role.kubernetes.io/etcd:In:"true"`         |

--- a/content/rke/latest/en/config-options/add-ons/_index.md
+++ b/content/rke/latest/en/config-options/add-ons/_index.md
@@ -20,7 +20,6 @@ As of v0.1.8, RKE will update an add-on if it is the same name.
 
 Prior to v0.1.8, update any add-ons by using `kubectl edit`.
 
-
 ## Critical and Non-Critical Add-ons
 
 As of version v0.1.7, add-ons are split into two categories:
@@ -37,3 +36,18 @@ RKE uses Kubernetes jobs to deploy add-ons. In some cases, add-ons deployment ta
 ```yaml
 addon_job_timeout: 30
 ```
+
+## Add-on placement
+
+_Applies to v0.2.3 and higher_
+
+| Component          | nodeAffinity nodeSelectorTerms             | nodeSelector | Tolerations |
+| ------------------ | ------------------------------------------ | ------------ | ----------- |
+| Calico             | `beta.kubernetes.io/os:NotIn:windows`  | none | - `NoSchedule:Exists`<br/>- `NoExecute:Exists`<br/>- `CriticalAddonsOnly:Exists` |
+| Flannel            | `beta.kubernetes.io/os:NotIn:windows`  | none | - `operator:Exists` |
+| Canal              | `beta.kubernetes.io/os:NotIn:windows`  | none         | - `NoSchedule:Exists`<br/>- `NoExecute:Exists`<br/>- `CriticalAddonsOnly:Exists` |
+| Weave              | `beta.kubernetes.io/os:NotIn:windows`  | none | - `NoSchedule:Exists`<br/>- `NoExecute:Exists` |
+| CoreDNS            | `node-role.kubernetes.io/worker:Exists` | `beta.kubernetes.io/os:linux` | - `NoSchedule:Exists`<br/>- `NoExecute:Exists`<br/>- `CriticalAddonsOnly:Exists` |
+| kube-dns           | - `beta.kubernetes.io/os:NotIn:windows`<br/>- `node-role.kubernetes.io/worker` `Exists` | none  | - `NoSchedule:Exists`<br/>- `NoExecute:Exists`<br/>- `CriticalAddonsOnly:Exists` |
+| nginx-ingress      | - `beta.kubernetes.io/os:NotIn:windows`<br/>- `node-role.kubernetes.io/worker` `Exists` | none | - `NoSchedule:Exists`<br/>- `NoExecute:Exists` |
+| metrics-server     | - `beta.kubernetes.io/os:NotIn:windows`<br/>- `node-role.kubernetes.io/worker` `Exists` | none | - `NoSchedule:Exists`<br/>- `NoExecute:Exists` |


### PR DESCRIPTION
I need some help on where to put the Rancher part.

- It's called Rancher Agents because people look for agent info, other option is "Rancher deployed resources" or something
- I also include `kube-api-auth` but its not an agent, I could possibly move this to Authorized Cluster Endpoint section?