### PR TITLE
Missing a L3 Header for General Linux

### DIFF
--- a/content/rke/latest/en/os/_index.md
+++ b/content/rke/latest/en/os/_index.md
@@ -9,7 +9,7 @@ aliases:
 <!-- TOC -->
 
 - [Operating System](#operating-system)
-
+    - [General Linux Requirements](#general-linux-requirements)
     - [Red Hat Enterprise Linux (RHEL) / Oracle Enterprise Linux (OEL) / CentOS](#red-hat-enterprise-linux-rhel-oracle-enterprise-linux-oel-centos)
 
         - [Using upstream Docker](#using-upstream-docker)
@@ -28,6 +28,8 @@ aliases:
 <!-- /TOC -->
 
 ## Operating System
+
+### General Linux Requirements
 
 RKE runs on almost any Linux OS with Docker installed. Most of the development and testing of RKE occurred on Ubuntu 16.04. However, some OS's have restrictions and specific requirements.
 


### PR DESCRIPTION
The current TOC structure is missing a General category which makes it read like CentOS/RHEL is the recommended distro..
Adding a General Linux Recommendations better highlights that the RHEL stuff is additional information for those distros.