### PR TITLE
Add node_selector example to full cluster.yml

### DIFF
--- a/content/rke/latest/en/example-yamls/_index.md
+++ b/content/rke/latest/en/example-yamls/_index.md
@@ -226,10 +226,12 @@ dns:
 
 # Currently only nginx ingress provider is supported.
 # To disable ingress controller, set `provider: none`
-
+# `node_selector` controls ingress placement and is optional
 ingress:
     provider: nginx
-
+    node_selector:
+      app: ingress
+      
 # All add-on manifests MUST specify a namespace
 addons: |-
     ---


### PR DESCRIPTION
Fairly common to want to reduce the ingress controller deployments to a subset of nodes.
Helpful to find this in the 'full' example.