### PR TITLE
Adding helm init

### DIFF
--- a/content/rancher/v2.x/en/installation/air-gap-high-availability/prepare-private-registry/_index.md
+++ b/content/rancher/v2.x/en/installation/air-gap-high-availability/prepare-private-registry/_index.md
@@ -52,6 +52,7 @@ Start by collecting all the images needed to install Rancher in an air gap envir
         > **Note:** Recent changes to cert-manager require an upgrade. If you are upgrading Rancher and using a version of cert-manager older than v0.9.1, please see our [upgrade documentation]({{< baseurl >}}/rancher/v2.x/en/installation/options/upgrading-cert-manager/).
         
         ```plain
+        helm init --client-only
         helm repo add jetstack https://charts.jetstack.io
         helm repo update
         helm fetch jetstack/cert-manager --version v0.9.1


### PR DESCRIPTION
Helm commands will not work if helm init has not been run first. For example:
$ helm repo add jetstack https://charts.jetstack.io
Error: Couldn't load repositories file (/home/rancher/.helm/repository/repositories.yaml).
You might need to run `helm init` (or `helm init --client-only` if tiller is already installed)

Also, it doesn't hurt to run "helm init" a second time if user has run it in the past.