### PR TITLE
Clarified location for configuration

### DIFF
--- a/content/rke/latest/en/config-options/private-registries/_index.md
+++ b/content/rke/latest/en/config-options/private-registries/_index.md
@@ -3,7 +3,7 @@ title: Private Registries
 weight: 215
 ---
 
-RKE supports the ability to configure multiple private Docker registries. By passing in your registry and credentials, it allows the nodes to pull images from these private registries.  
+RKE supports the ability to configure multiple private Docker registries in the `cluster.yml`. By passing in your registry and credentials, it allows the nodes to pull images from these private registries.  
 
 ```yaml
 private_registries:


### PR DESCRIPTION
If you are working through the docs in order it makes sense that the addons are in the cluster.yml but this is not evident if you land on the page from a search.