### PR TITLE
Clarified location of configuration

### DIFF
--- a/content/rke/latest/en/config-options/bastion-host/_index.md
+++ b/content/rke/latest/en/config-options/bastion-host/_index.md
@@ -3,7 +3,7 @@ title: Bastion/Jump Host Configuration
 weight: 220
 ---
 
-Since RKE uses `ssh` to connect to [nodes]({{< baseurl >}}/rke/latest/en/config-options/nodes/), you can configure to use a bastion host. Keep in mind that the [port requirements]({{< baseurl >}}/rke/latest/en/os/#ports) for the RKE node move to the configured bastion host.
+Since RKE uses `ssh` to connect to [nodes]({{< baseurl >}}/rke/latest/en/config-options/nodes/), you can configure the `cluster.yml` so RKE will use a bastion host. Keep in mind that the [port requirements]({{< baseurl >}}/rke/latest/en/os/#ports) for the RKE node move to the configured bastion host.
 
 ```yaml
 bastion_host:


### PR DESCRIPTION
If you are working through the docs in order it makes sense that the addons are in the cluster.yml but this is not evident if you land on the page from a search.