### PR TITLE
Clarified location of configuration

### DIFF
--- a/content/rke/latest/en/config-options/authorization/_index.md
+++ b/content/rke/latest/en/config-options/authorization/_index.md
@@ -5,7 +5,7 @@ weight: 240
 
 Kubernetes supports multiple [Authorization Modules](https://kubernetes.io/docs/reference/access-authn-authz/authorization/#authorization-modules). Currently, RKE only supports the [RBAC module](https://kubernetes.io/docs/reference/access-authn-authz/rbac/).
 
-By default, RBAC is already enabled. If you wanted to turn off RBAC support, **which isn't recommended**, you set the authorization mode to `none`.
+By default, RBAC is already enabled. If you wanted to turn off RBAC support, **which isn't recommended**, you set the authorization mode to `none` in your `cluster.yml`.
 
 ```yaml
 authorization:


### PR DESCRIPTION
Explicit > Implicit
If you are working through the docs in order it makes sense that the addons are in the cluster.yml but this is not evident if you land on the page from a search so I attempted to clarify this on this page. 