### PR TITLE
Clarified and attempted to improve flow

### DIFF
--- a/content/rke/latest/en/config-options/add-ons/_index.md
+++ b/content/rke/latest/en/config-options/add-ons/_index.md
@@ -3,22 +3,20 @@ title: Add-Ons
 weight: 260
 ---
 
-RKE supports pluggable add-ons. Add-ons are used to deploy several cluster components including:
+RKE supports configuring pluggable add-ons in the cluster YML. Add-ons are used to deploy several cluster components including:
 
 * [Network plug-ins]({{< baseurl >}}/rke/latest/en/config-options/add-ons/network-plugins/)
 * [Ingress controller]({{< baseurl >}}/rke/latest/en/config-options/add-ons/ingress-controllers/)
 * [DNS provider]({{< baseurl >}}/rke/latest/en/config-options/add-ons/dns/)
 * [Metrics Server]({{< baseurl >}}/rke/latest/en/config-options/add-ons/metrics-server/)
 
-The images used for these add-ons under the [`system_images` directive]({{< baseurl >}}/rke/latest/en/config-options/system-images/). For each Kubernetes version, there are default images associated with each add-on, but these can be overridden by changing the image tag in `system_images`.
+These add-ons require images that can be found under the [`system_images` directive]({{< baseurl >}}/rke/latest/en/config-options/system-images/). For each Kubernetes version, there are default images associated with each add-on, but these can be overridden by changing the image tag in `system_images`.
 
-In addition to these pluggable add-ons, you can specify an add-on that you want deployed after the cluster deployment is complete.
-
-RKE only adds additional add-ons when using `rke up` multiple times. RKE does **not** support removing of cluster add-ons when doing `rke up` with a different list of add-ons.
-
-As of v0.1.8, RKE will update an add-on if it is the same name.
-
-Prior to v0.1.8, update any add-ons by using `kubectl edit`.
+There are a few things worth noting:
+* In addition to these pluggable add-ons, you can specify an add-on that you want deployed after the cluster deployment is complete.
+* RKE only adds additional add-ons when using `rke up` multiple times. RKE does **not** support removing of cluster add-ons when doing `rke up` with a different list of add-ons.
+* As of v0.1.8, RKE will update an add-on if it is the same name.
+* Prior to v0.1.8, update any add-ons by using `kubectl edit`.
 
 
 ## Critical and Non-Critical Add-ons


### PR DESCRIPTION
Explicit > Implicit
The page felt very disjointed and as with the others, if you landed on the page from a search it wasn't clear how to add add-ons so I attempted to clarify this and improve the flow of the page.
Turned the portion that read like un-bulleted bullet points into bullet points, but this is still lacking an explanation on best practice for removing an addon and those bullets could use some elucidation.