### PR TITLE
[k3s] add flannel-backend

### DIFF
--- a/content/k3s/latest/en/installation/single-server/_index.md
+++ b/content/k3s/latest/en/installation/single-server/_index.md
@@ -211,6 +211,10 @@ The following information on server options is also available through `k3s serve
 
     (agent) Override default flannel interface
 
+* `--flannel-backend` _value_
+
+    (agent) Specify the flannel backend you would like to use: vxlan (default), ipsec, or wireguard
+
 * `--container-runtime-endpoint` _value_
 
     (agent) Disable embedded containerd and use alternative CRI implementation
@@ -279,6 +283,10 @@ The following information on agent options is also available through `k3s agent 
 * `--flannel-iface` _value_
 
     (agent) Override default flannel interface
+
+* `--flannel-backend` _value_
+
+    (agent) Specify the flannel backend you would like to use: vxlan (default), ipsec, or wireguard
 
 * `--node-name` _value_
 


### PR DESCRIPTION
Adds `--flannel-backend` flag to k3s docs with brief explanation.
Needed for adding ipsec and wireguard support (disabled by default; vxlan is default in v0.10.0 k3s release)