### PR TITLE
Add note on issue with Helm v2.15.0

### DIFF
--- a/content/rancher/v2.x/en/installation/ha/_index.md
+++ b/content/rancher/v2.x/en/installation/ha/_index.md
@@ -30,7 +30,8 @@ The following CLI tools are required for this install. Please make sure these to
 * [rke]({{< baseurl >}}/rke/latest/en/installation/) - Rancher Kubernetes Engine, cli for building Kubernetes clusters.
 * [helm](https://docs.helm.sh/using_helm/#installing-helm) - Package management for Kubernetes.
 
-> **Important:** Due to an issue with Helm v2.12.0 and cert-manager, please use Helm v2.12.1 or higher.
+> **Known issues:**
+> Do not use Helm v2.15.0 (issue with converting/comparing numbers)
 
 ## Installation Outline
 


### PR DESCRIPTION
See https://github.com/rancher/rancher/issues/23516

Although a fix is in the making and will probably be released as v2.15.1, this version will probably pop up in some channels and be used.

Also removed the v2.12.0 reference as that version is almost 1 year old.