### PR TITLE
Add explicit reference to Traefik configuration

### DIFF
--- a/content/k3s/latest/en/configuration/_index.md
+++ b/content/k3s/latest/en/configuration/_index.md
@@ -161,7 +161,7 @@ If you don't install CoreDNS you will need to install a cluster DNS provider you
 Traefik
 -------
 
-Traefik is deployed by default when starting the server; to disable it, start the server with the `--no-deploy traefik` option.
+Traefik is deployed by default when starting the server; to disable it, start the server with the `--no-deploy traefik` option. The default config file is found in `/var/lib/rancher/k3s/server/manifests/traefik.yaml` and any changes made to this file will automatically be picked up  deployed to Kubernetes in a manner similar to `kubectl apply`.
 
 Service Load Balancer
 ---------------------

--- a/content/k3s/latest/en/configuration/_index.md
+++ b/content/k3s/latest/en/configuration/_index.md
@@ -161,7 +161,7 @@ If you don't install CoreDNS you will need to install a cluster DNS provider you
 Traefik
 -------
 
-Traefik is deployed by default when starting the server; to disable it, start the server with the `--no-deploy traefik` option. The default config file is found in `/var/lib/rancher/k3s/server/manifests/traefik.yaml` and any changes made to this file will automatically be picked up  deployed to Kubernetes in a manner similar to `kubectl apply`.
+Traefik is deployed by default when starting the server; to disable it, start the server with the `--no-deploy traefik` option. The default config file is found in `/var/lib/rancher/k3s/server/manifests/traefik.yaml` and any changes made to this file will automatically be deployed to Kubernetes in a manner similar to `kubectl apply`.
 
 Service Load Balancer
 ---------------------


### PR DESCRIPTION
- It is not obvious how to configure Traefik on in a default K3S install, add reference to the config file location.