### PR TITLE
Revert TOC, which is in this commit: "https://github.com/rancherlabs/…

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -34,7 +34,7 @@
         <!-- </div> -->
       </div>
       <div class="
-        col-xl-6
+        col-xl-9
         col-lg-8
         col-md-8
         col-sm-12
@@ -137,19 +137,6 @@
           {{ end }} -->
         </div>
       </div>
-
-      <!--toc-->
-      <aside class="
-        col-xl-3
-        col-lg-4
-        col-md-4
-        col-sm-12
-        col-xs-12
-        col-12
-        docs-toc">
-        <h4 class="m-a-0">Table of Contents</h4>
-        {{ .TableOfContents }}
-    </aside>
     </div>
   </section>
 

--- a/layouts/shortcodes/accordion.html
+++ b/layouts/shortcodes/accordion.html
@@ -1,4 +1,4 @@
-<div class="accordion" id="{{ .Get "id" }}">
+<div class="accordion">
   <input id="{{ .Get "id" }}" type="checkbox" name="accordion">
   <label for="{{ .Get "id" }}">{{ .Get "label" }}</label>
   <div class="accordion-content">


### PR DESCRIPTION
…website/issues/1615 add id on div"

This reverts commit 439afaa3e3e8531a9f6ae3881784763fb575efe6.

This change reverts an experimental feature - a table of contents in a third column in the documentation - which will be worked on in the feature branch `docs-ui-changes`