### PR TITLE
Change Rancher version in quickstart to 2.x

### DIFF
--- a/content/rancher/v2.x/en/quick-start-guide/deployment/quickstart-manual-setup/_index.md
+++ b/content/rancher/v2.x/en/quick-start-guide/deployment/quickstart-manual-setup/_index.md
@@ -4,7 +4,7 @@ weight: 300
 ---
 Howdy Partner! This tutorial walks you through:
     
-- Installation of {{< product >}} {{< version >}}
+- Installation of {{< product >}} 2.x
 - Creation of your first cluster
 - Deployment of an application, Nginx
 


### PR DESCRIPTION
The version on this page was 2.0, which is now outdated. The shortcode for the version only appeared once in the docs, so I've changed it to 2.x.

This PR is in reference to this comment https://rancher.slack.com/archives/C6U4L2DS9/p1571928092057900