### PR TITLE
Document enabling forward host headers for NGINX 0.25.0

### DIFF
--- a/content/rancher/v2.x/en/installation/ha/helm-rancher/chart-options/_index.md
+++ b/content/rancher/v2.x/en/installation/ha/helm-rancher/chart-options/_index.md
@@ -156,9 +156,9 @@ You may terminate the SSL/TLS on a L7 load balancer external to the Rancher clus
 
 Your load balancer must support long lived websocket connections and will need to insert proxy headers so Rancher can route links correctly.
 
-#### Enabling Forward Host Headers for NGINX v0.25.0
+#### Configuring Ingress for External TLS when Using NGINX v0.25
 
-If you are using an NGINX v0.25.0 ingress controller, you must edit the `cluster.yml` to enable the `use-forwarded-headers` option for ingress:
+Rancher v2.3.0 shipped with NGINX v0.25.1. In this version, the behavior of NGINX has [changed](https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0220) regarding forwarding headers and external TLS termination. Therefore, in the scenario that you are using external TLS termination configuration with NGINX 0.25, you must edit the `cluster.yml` to enable the `use-forwarded-headers` option for ingress:
 
 ```yaml
 ingress:
@@ -166,9 +166,6 @@ ingress:
   options:
     use-forwarded-headers: "true"
 ```
-Version 0.22 of `ingress-nginx` had a [breaking change](https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0220) in which the IP addreses for forwarded headers are not trusted by default. Rancher v2.2.x used `ingress-nginx` 0.21, while Rancher v2.3.x uses `ingress-nginx` 0.25.
-
-This change allows `ingress-nginx` to trust any client to extract true IP addresses from forwarded headers.
 
 #### Required Headers
 

--- a/content/rancher/v2.x/en/installation/ha/helm-rancher/chart-options/_index.md
+++ b/content/rancher/v2.x/en/installation/ha/helm-rancher/chart-options/_index.md
@@ -156,6 +156,22 @@ You may terminate the SSL/TLS on a L7 load balancer external to the Rancher clus
 
 Your load balancer must support long lived websocket connections and will need to insert proxy headers so Rancher can route links correctly.
 
+#### Enabling Forward Host Headers
+
+_For Rancher v2.3.0+, which uses NGINX 0.25.0_
+
+If you are using an NGINX ingress controller, you must edit the `cluster.yml` to enable the `use-forwarded-headers` option for ingress:
+
+```yaml
+ingress:
+  provider: nginx
+  options:
+    use-forwarded-headers: "true"
+```
+Version 0.22 of `ingress-nginx` had a [breaking change](https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0220) in which the IP addreses for forwarded headers are not trusted by default. Rancher v2.2.x used `ingress-nginx` 0.21, while Rancher v2.3.x uses `ingress-nginx` 0.25.
+
+This change allows `ingress-nginx` to trust any client to extract true IP addresses from forwarded headers.
+
 #### Required Headers
 
 * `Host`

--- a/content/rancher/v2.x/en/installation/ha/helm-rancher/chart-options/_index.md
+++ b/content/rancher/v2.x/en/installation/ha/helm-rancher/chart-options/_index.md
@@ -158,7 +158,7 @@ Your load balancer must support long lived websocket connections and will need t
 
 #### Configuring Ingress for External TLS when Using NGINX v0.25
 
-Rancher v2.3.0 shipped with NGINX v0.25.1. In this version, the behavior of NGINX has [changed](https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0220) regarding forwarding headers and external TLS termination. Therefore, in the scenario that you are using external TLS termination configuration with NGINX 0.25, you must edit the `cluster.yml` to enable the `use-forwarded-headers` option for ingress:
+In NGINX v0.25, the behavior of NGINX has [changed](https://github.com/kubernetes/ingress-nginx/blob/master/Changelog.md#0220) regarding forwarding headers and external TLS termination. Therefore, in the scenario that you are using external TLS termination configuration with NGINX v0.25, you must edit the `cluster.yml` to enable the `use-forwarded-headers` option for ingress:
 
 ```yaml
 ingress:

--- a/content/rancher/v2.x/en/installation/ha/helm-rancher/chart-options/_index.md
+++ b/content/rancher/v2.x/en/installation/ha/helm-rancher/chart-options/_index.md
@@ -156,11 +156,9 @@ You may terminate the SSL/TLS on a L7 load balancer external to the Rancher clus
 
 Your load balancer must support long lived websocket connections and will need to insert proxy headers so Rancher can route links correctly.
 
-#### Enabling Forward Host Headers
+#### Enabling Forward Host Headers for NGINX v0.25.0
 
-_For Rancher v2.3.0+, which uses NGINX 0.25.0_
-
-If you are using an NGINX ingress controller, you must edit the `cluster.yml` to enable the `use-forwarded-headers` option for ingress:
+If you are using an NGINX v0.25.0 ingress controller, you must edit the `cluster.yml` to enable the `use-forwarded-headers` option for ingress:
 
 ```yaml
 ingress:


### PR DESCRIPTION
This PR addresses this issue https://github.com/rancher/docs/issues/1835