### PR TITLE
Small change to quick-start

### DIFF
--- a/content/k3s/latest/en/quick-start/_index.md
+++ b/content/k3s/latest/en/quick-start/_index.md
@@ -3,7 +3,9 @@ title: "Quick-Start Guide"
 weight: 1
 ---
 
->**Note:** The intent of this guide is to quickly launch a cluster that you can use to evaluate k3s. This guide is not intended for production environments. Production environments should utilize a High-Availability solution. The [installation options](../installation) section covers in greater detail how k3s can be setup.
+>**Note:** The intent of this guide is to quickly launch a cluster that you can use to evaluate k3s. This guide is not intended for production environments. Production environments should utilize a High-Availiability solution. The [installation options](../installation) section covers in greater detail how k3s can be setup.
+
+> New to Kubernetes? The official Kubernetes docs already have some great tutorials outlining the basics [here](https://kubernetes.io/docs/tutorials/kubernetes-basics/).
 
 Install Script
 --------------


### PR DESCRIPTION
This tweaks the big NOTE at the top of the quick-start guide to point to kubernetes tutorials for any k8s newbies.
These tutorials are actually pretty great and explain how to create a deployment and get this exposed to the outside world.

We will look into adding docs around Traefik separately.

Partially resolves https://github.com/rancher/k3s/issues/795