### PR TITLE
Say that Windows Server 1809 also works with Docker 19.03

### DIFF
--- a/content/rancher/v2.x/en/cluster-provisioning/rke-clusters/windows-clusters/_index.md
+++ b/content/rancher/v2.x/en/cluster-provisioning/rke-clusters/windows-clusters/_index.md
@@ -42,16 +42,10 @@ For a custom cluster, the general node requirements for networking, operating sy
 
 ### OS and Docker Requirements
 
-In order to add Windows worker nodes to a cluster, the node must be running one of the following Windows Server versions and the corresponding version of Docker:
+In order to add Windows worker nodes to a cluster, the node must be running one of the following Windows Server versions and the corresponding version of Docker Engine - Enterprise Edition (EE):
 
-- Windows Server core version 1809 and Docker 18.09
-- Windows server core version 1903 and Docker 19.03
-
-The nodes must run Docker Engine - Enterprise Edition (EE).
-
-Nodes with Windows Server core version 1809 should use Docker EE-basic 18.09.
-
-Nodes with Windows Server core version 1903 should use Docker EE-basic 19.03.
+- Nodes with Windows Server core version 1809 should use Docker EE-basic 18.09 or Docker EE-basic 19.03.
+- Nodes with Windows Server core version 1903 should use Docker EE-basic 19.03.
 
 > **Notes:**
 >

--- a/content/rancher/v2.x/en/installation/requirements/_index.md
+++ b/content/rancher/v2.x/en/installation/requirements/_index.md
@@ -39,7 +39,7 @@ Windows Server 2019 (64-bit x86) | Requires Docker Engine - Enterprise Edition (
 
 \* Some distributions of Linux derived from RHEL, including Oracle Linux, may have default firewall rules that block communication with Helm. This [how-to guide]({{<baseurl>}}/rancher/v2.x/en/installation/options/firewall) shows how to check the default firewall rules and how to open the ports with `firewalld` if necessary.
 
-\** Nodes with Windows Server core version 1809 should use Docker EE-basic 18.09. Nodes with Windows Server core version 1903 should use Docker EE-basic 19.03. Supported for worker nodes only. See [Configuring Custom Clusters for Windows]({{< baseurl >}}/rancher/v2.x/en/cluster-provisioning/rke-clusters/windows-clusters/)
+\** Nodes with Windows Server core version 1809 should use Docker EE-basic 18.09 or Docker EE-basic 19.03. Nodes with Windows Server core version 1903 should use Docker EE-basic 19.03. Supported for worker nodes only. See [Configuring Custom Clusters for Windows]({{<baseurl>}}/rancher/v2.x/en/cluster-provisioning/rke-clusters/windows-clusters/)
 
 If you plan to run Rancher on ARM64, see [Running on ARM64 (Experimental)]({{<baseurl>}}/rancher/v2.x/en/installation/arm64-platform/) 
 


### PR DESCRIPTION
Sowmya had a question about this and I confirmed it with Logan. Docker 19.03 is fine to use with Windows Server 1809, so I have updated the Windows requirements to reflect this.