### PR TITLE
Remove load balancer step for ha install

### DIFF
--- a/content/k3s/latest/en/installation/ha/_index.md
+++ b/content/k3s/latest/en/installation/ha/_index.md
@@ -43,8 +43,8 @@ Following the [Node Requirements]({{< baseurl >}}/k3s/latest/en/installation/nod
 Run the following command to join a worker node to the master nodes. You can get the node-token from any of the servers at `/var/lib/rancher/k3s/server/node-token`
 
 ```
-curl -sfL https://get.k3s.io | K3S_URL=https:/<Master_node>:6443 K3S_TOKEN=XXX sh-
+curl -sfL https://get.k3s.io | K3S_URL=https:/<master_node>:6443 K3S_TOKEN=XXX sh-
 ```
 
-Provide the IP or DNS in place of `<Master_node>` this can be any one master node. k3s automatically handles load balancing the master nodes. The K3S_URL you provide will actually be the last used in a fail-over scenario.
+Provide the IP or DNS in place of `<master_node>` this can be any one master node. k3s automatically handles load balancing the master nodes.
 

--- a/content/k3s/latest/en/installation/ha/_index.md
+++ b/content/k3s/latest/en/installation/ha/_index.md
@@ -3,7 +3,7 @@ title: "High Availability (HA) Install (Experimental)"
 weight: 30
 ---
 
->**Important:** High-Availability (HA) was introduced in the v0.10.0 release of k3s and is _experimental_. Our next release plans to support HA in production environments. HA should currently only be used for testing purposes in non-production environments.
+>**Important:** High-Availability (HA) was introduced in the v0.10.0 release of k3s and is _experimental_. Our v1.0 release plans to support HA in production environments. HA should currently only be used for testing purposes in non-production environments.
 >**Note:** k3s does not utilize etcd by default so only a 2-node cluster is needed for HA at a minimum. The following will guide you through setting up a 2-node cluster with PostgreSQL. You could optionally add one or more nodes for additional redundancy. In the future we plan to add support for additional database providers.
 
 For production environments, we recommend installing k3s in a high-availability configuration so that you can always access your cluster. This procedure walks you through setting up a 2-node cluster with k3s with an external PostgreSQL database. As of v0.10.0 release (Experimental HA) we are supporting PostgreSQL 10.7-R1 thru 11.5-R1
@@ -12,8 +12,7 @@ Installation Outline
 --------------------
 1. Create backend database (PostgreSQL)
 2. Create master nodes
-3. Create a load balancer for the master nodes
-4. Join worker nodes
+3. Join worker nodes
 
 ### Create Database
 The first step for setting up High Availability (HA) is to create the database for the backend. As of v0.10.0 release (Experimental HA) we are currently supporting PostgreSQL 10.7-R1 thru 11.5-R1
@@ -36,10 +35,7 @@ On the second machine, run the following command. Since we ran the first node wi
 curl -fL https://get.k3s.io | sh -s - server --storage-endpoint='postgres://username:password@hostname:5432/dbname'
 ```
 
-Ensure that both of the nodes in a Ready state such as with `k3s kubectl get nodes`
-
-### Create the Load Balancer
-You should create a TCP Load Balancer for the master nodes. This will allow worker nodes to address any master node should one of them fail. The Load Balancer should point to each of the master nodes on port 6443 (Default port for the server).
+Ensure that both of the nodes are in a Ready state such as with `k3s kubectl get nodes`
 
 ### Join Worker Nodes
 Following the [Node Requirements]({{< baseurl >}}/k3s/latest/en/installation/node-requirements/) page, provision one or more machines to fill the role of the worker node(s).
@@ -47,8 +43,8 @@ Following the [Node Requirements]({{< baseurl >}}/k3s/latest/en/installation/nod
 Run the following command to join a worker node to the master nodes. You can get the node-token from any of the servers at `/var/lib/rancher/k3s/server/node-token`
 
 ```
-curl -sfL https://get.k3s.io | K3S_URL=https:/<FQDN_of_LB>:6443 K3S_TOKEN=XXX sh-
+curl -sfL https://get.k3s.io | K3S_URL=https:/<Master_node>:6443 K3S_TOKEN=XXX sh-
 ```
 
-Provide the FQDN of the Load Balancer for the master nodes.
+Provide the IP or DNS in place of `<Master_node>` this can be any one master node. k3s automatically handles load balancing the master nodes. The K3S_URL you provide will actually be the last used in a fail-over scenario.
 


### PR DESCRIPTION
- Fix a couple of minor things in the ha installation _index.md
- Remove the "Create a load balancer..." step
- Remove the "Create a load balancer..." section
- Modify the "Join Worker Nodes" section accordingly