### PR TITLE
change limiting language

### DIFF
--- a/content/rancher/v2.x/en/k8s-in-rancher/workloads/deploy-workloads/_index.md
+++ b/content/rancher/v2.x/en/k8s-in-rancher/workloads/deploy-workloads/_index.md
@@ -15,7 +15,7 @@ Deploy a workload to run an application in one or more containers.
 
 1. Select a [workload type]({{< baseurl >}}/rancher/v2.x/en/k8s-in-rancher/workloads/). The workload defaults to a scalable deployment, by can change the workload type by clicking **More options.**
 
-1. From the **Docker Image** field, enter the name of the Docker image that you want to deploy to the project. During deployment, Rancher pulls this image from [Docker Hub](https://hub.docker.com/explore/). Enter the name exactly as it appears on Docker Hub.
+1. From the **Docker Image** field, enter the name of the Docker image that you want to deploy to the project, optionally prefacing it with the registry host (e.g. `quay.io`, `registry.gitlab.com`, etc.). During deployment, Rancher pulls this image from the specified public or private registry. If no registry host is provided, Rancher will pull the image from [Docker Hub](https://hub.docker.com/explore/). Enter the name exactly as it appears in the registry server, including any required path, and optionally including the desired tag (e.g. `registry.gitlab.com/user/path/image:tag`). If no tag is provided, the `latest` tag will be automatically used.
 
 1. Either select an existing [namespace]({{< baseurl >}}/rancher/v2.x/en/k8s-in-rancher/projects-and-namespaces/#namespaces), or click **Add to a new namespace** and enter a new namespace.
 


### PR DESCRIPTION
As written the instructions sound like we only pull from Docker Hub. This change opens that up to alternative public and private registries and adds additional language for defaults, such as registry and tag.