### PR TITLE
Update k3s main page

### DIFF
--- a/content/k3s/latest/en/_index.md
+++ b/content/k3s/latest/en/_index.md
@@ -20,14 +20,12 @@ What is this?
 
 k3s is intended to be a fully compliant Kubernetes distribution with the following changes:
 
-1. Removed legacy and non-default features. You lilkely won't notice the
-   stuff that has been removed.
-2. Removed most in-tree plugins (cloud providers and storage plugins) which can be replaced
+1. Removed most in-tree plugins (cloud providers and storage plugins) which can be replaced
    with out of tree addons.
-3. Added sqlite3 as the default storage mechanism and support for other external SQL databases such as PostgreSQL and MySQL. etcd3 is also supported as an external database.
-4. Added local storage provider, service load balancer, helm-controller, and traefik ingress controller.
-5. Wrapped in simple launcher that handles a lot of the complexity of TLS and options.
-6. Minimal to no OS dependencies (just a sane kernel and cgroup mounts needed). k3s packages required dependencies
+2. Added sqlite3 as the default storage mechanism and support for other external SQL databases such as PostgreSQL and MySQL. etcd3 is also supported as an external database.
+3. Added local storage provider, service load balancer, helm-controller, and traefik ingress controller.
+4. Wrapped in simple launcher that handles a lot of the complexity of TLS and options.
+5. Minimal to no OS dependencies (just a sane kernel and cgroup mounts needed). k3s packages required dependencies
     * containerd
     * Flannel
     * CoreDNS

--- a/content/k3s/latest/en/_index.md
+++ b/content/k3s/latest/en/_index.md
@@ -20,14 +20,14 @@ What is this?
 
 k3s is intended to be a fully compliant Kubernetes distribution with the following changes:
 
-1. Legacy, alpha, non-default features are removed. Hopefully, you shouldn't notice the
+1. Removed legacy and non-default features. You lilkely won't notice the
    stuff that has been removed.
 2. Removed most in-tree plugins (cloud providers and storage plugins) which can be replaced
    with out of tree addons.
-3. Add sqlite3 as the default storage mechanism. etcd3 is still available, but not the default.
-4. Wrapped in simple launcher that handles a lot of the complexity of TLS and options.
-5. Minimal to no OS dependencies (just a sane kernel and cgroup mounts needed). k3s packages required
-   dependencies
+3. Added sqlite3 as the default storage mechanism and support for other external SQL databases such as PostgreSQL and MySQL. etcd3 is also supported as an external database.
+4. Added local storage provider, service load balancer, helm-controller, and traefik ingress controller.
+5. Wrapped in simple launcher that handles a lot of the complexity of TLS and options.
+6. Minimal to no OS dependencies (just a sane kernel and cgroup mounts needed). k3s packages required dependencies
     * containerd
     * Flannel
     * CoreDNS


### PR DESCRIPTION
Update the main page for #1017 and #1018
This tweaks the main page to update the description of what we remove and add to k3s that sets us apart from k8s.

Closes https://github.com/rancher/k3s/issues/1017 and closes https://github.com/rancher/k3s/issues/1018