### PR TITLE
Added clarity for objectClass fields in LDAP providers

### DIFF
--- a/content/rancher/v2.x/en/admin-settings/authentication/ad/_index.md
+++ b/content/rancher/v2.x/en/admin-settings/authentication/ad/_index.md
@@ -74,7 +74,7 @@ The table below details the parameters for the user schema section configuration
 
 | Parameter | Description |
 |:--|:--|
-| Object Class | The name of the object class used for user objects in your domain. |
+| Object Class | The name of the object class used for user objects in your domain. If defined, only specify the name of the object class - *don't* include it in an LDAP wrapper such as &(objectClass=xxxx) |
 | Username Attribute | The user attribute whose value is suitable as a display name. |
 | Login Attribute | The attribute whose value matches the username part of credentials entered by your users when logging in to Rancher. If your users authenticate with their UPN (e.g. "jdoe@acme.com") as username then this field must normally be set to `userPrincipalName`. Otherwise for the old, NetBIOS-style logon names (e.g. "jdoe") it's usually `sAMAccountName`. |
 | User Member Attribute | The attribute containing the groups that a user is a member of. |
@@ -93,7 +93,7 @@ The table below details the parameters for the group schema configuration.
 
 | Parameter | Description |
 |:--|:--|
-| Object Class | The name of the object class used for group objects in your domain. |
+| Object Class | The name of the object class used for group objects in your domain. If defined, only specify the name of the object class - *don't* include it in an LDAP wrapper such as &(objectClass=xxxx)  |
 | Name Attribute | The group attribute whose value is suitable for a display name. |
 | Group Member User Attribute | The name of the **user attribute** whose format matches the group members in the `Group Member Mapping Attribute`. |
 | Group Member Mapping Attribute | The name of the group attribute containing the members of a group. |

--- a/content/rancher/v2.x/en/admin-settings/authentication/openldap/_index.md
+++ b/content/rancher/v2.x/en/admin-settings/authentication/openldap/_index.md
@@ -75,7 +75,7 @@ The table below details the parameters for the user schema configuration.
 
 | Parameter | Description |
 |:--|:--|
-| Object Class | The name of the object class used for user objects in your domain. |
+| Object Class | The name of the object class used for user objects in your domain. If defined, only specify the name of the object class - *don't* include it in an LDAP wrapper such as &(objectClass=xxxx) |
 | Username Attribute | The user attribute whose value is suitable as a display name. |
 | Login Attribute | The attribute whose value matches the username part of credentials entered by your users when logging in to Rancher. This is typically `uid`. |
 | User Member Attribute | The user attribute containing the Distinguished Name of groups a user is member of. Usually this is one of `memberOf` or `isMemberOf`. |
@@ -93,7 +93,7 @@ The table below details the parameters for the group schema configuration.
 
 | Parameter | Description |
 |:--|:--|
-| Object Class | The name of the object class used for group entries in your domain. |
+| Object Class | The name of the object class used for group entries in your domain. If defined, only specify the name of the object class - *don't* include it in an LDAP wrapper such as &(objectClass=xxxx) |
 | Name Attribute | The group attribute whose value is suitable for a display name. |
 | Group Member User Attribute | The name of the **user attribute** whose format matches the group members in the `Group Member Mapping Attribute`. |
 | Group Member Mapping Attribute | The name of the group attribute containing the members of a group. |


### PR DESCRIPTION
This PR clarifies that the objectClass fields in LDAP providers (AD, OpenLDAP) do not need the LDAP wrappings like &(objectClass=xxxx). Those fields should only specify the name of the object class.