### PR TITLE
Storage

### DIFF
--- a/content/k3s/latest/en/advanced/_index.md
+++ b/content/k3s/latest/en/advanced/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Advanced Options"
-weight: 3
+weight: 40
 aliases:
   - /k3s/latest/en/running/
 ---

--- a/content/k3s/latest/en/configuration/_index.md
+++ b/content/k3s/latest/en/configuration/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Configuration Info"
-weight: 4
+weight: 50
 ---
 
 This section contains information on using k3s with various configurations.

--- a/content/k3s/latest/en/faq/_index.md
+++ b/content/k3s/latest/en/faq/_index.md
@@ -1,6 +1,6 @@
 ---
 title: FAQ
-weight: 8000
+weight: 60
 ---
 
 The FAQ is updated periodically and designed to answer the questions our users most frequently ask about k3s.

--- a/content/k3s/latest/en/installation/_index.md
+++ b/content/k3s/latest/en/installation/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Installation Options"
-weight: 2
+weight: 20
 ---
 
 This section contains instructions for installing k3s in testing and production environments. Please ensure you have met the [Node Requirements]({{< baseurl >}}/k3s/latest/en/installation/node-requirements/) before you begin installing k3s.

--- a/content/k3s/latest/en/known-issues/_index.md
+++ b/content/k3s/latest/en/known-issues/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Known Issues
-weight: 9000
+weight: 70
 ---
 The Known Issues are updated periodically and designed to inform you about any issues that may not be immediately addressed in the next upcoming release.
 

--- a/content/k3s/latest/en/quick-start/_index.md
+++ b/content/k3s/latest/en/quick-start/_index.md
@@ -1,6 +1,6 @@
 ---
 title: "Quick-Start Guide"
-weight: 1
+weight: 10
 ---
 
 >**Note:** The intent of this guide is to quickly launch a cluster that you can use to evaluate k3s. This guide is not intended for production environments. Production environments should utilize a High-Availiability solution. The [installation options](../installation) section covers in greater detail how k3s can be setup.

--- a/content/k3s/latest/en/storage/_index.md
+++ b/content/k3s/latest/en/storage/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Volumes and Storage"
+weight: 30
+---
+
+Placeholder

--- a/content/k3s/latest/en/storage/_index.md
+++ b/content/k3s/latest/en/storage/_index.md
@@ -8,7 +8,7 @@ When deploying an application that needs to retain data, you’ll need to create
 # Local Storage Provider
 k3s comes with Rancher's Local Path Provisioner and this enables the ability to create persistent volume claims out of the box using local storage on the respective node. Below we cover a simple example. For more information please reference the official documentation [here](https://github.com/rancher/local-path-provisioner/blob/master/README.md#usage).
 
-Create a hostPath backed persistent volume and a pod to utilize it:
+Create a hostPath backed persistent volume claim and a pod to utilize it:
 
 ### pvc.yaml
 
@@ -53,7 +53,7 @@ spec:
 
 Apply the yaml `kubectl create -f pvc.yaml` and `kubectl create -f pod.yaml`
 
-Confirm the pv and pvc are created. `kubectl get pv` and `kubectl get pvc` The status should be Bound for each.
+Confirm the PV and PVC are created. `kubectl get pv` and `kubectl get pvc` The status should be Bound for each.
 
 # Longhorn
 
@@ -69,7 +69,7 @@ Apply the longhorn.yaml to install Longhorn.
 kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml
 ```
 
-Longhorn will be installed in the namespace `longhorn-system`
+Longhorn will be installed in the namespace `longhorn-system`.
 
 Before we create a PVC, we will create a storage class for longhorn with this yaml.
 
@@ -77,7 +77,7 @@ Before we create a PVC, we will create a storage class for longhorn with this ya
 kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/examples/storageclass.yaml
 ```
 
-Now, apply the following yaml to create the pvc and pod with `kubectl create -f pvc.yaml` and `kubectl create -f pod.yaml`
+Now, apply the following yaml to create the PVC and pod with `kubectl create -f pvc.yaml` and `kubectl create -f pod.yaml`
 
 ### pvc.yaml
 
@@ -119,4 +119,4 @@ spec:
       claimName: longhorn-volv-pvc
 ```
 
-Confirm the pv and pvc are created. `kubectl get pv` and `kubectl get pvc` The status should be Bound for each.
+Confirm the PV and PVC are created. `kubectl get pv` and `kubectl get pvc` The status should be Bound for each.

--- a/content/k3s/latest/en/storage/_index.md
+++ b/content/k3s/latest/en/storage/_index.md
@@ -3,4 +3,120 @@ title: "Volumes and Storage"
 weight: 30
 ---
 
-Placeholder
+When deploying an application that needs to retain data, you’ll need to create persistent storage. Persistent storage allows you to store application data external from the pod running your application. This storage practice allows you to maintain application data, even if the application’s pod fails.
+
+# Local Storage Provider
+k3s comes with Rancher's Local Path Provisioner and this enables the ability to create persistent volume claims out of the box using local storage on the respective node. Below we cover a simple example. For more information please reference the official documentation [here](https://github.com/rancher/local-path-provisioner/blob/master/README.md#usage).
+
+Create a hostPath backed persistent volume and a pod to utilize it:
+
+### pvc.yaml
+
+```
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: local-path-pvc
+  namespace: default
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 2Gi
+```
+
+### pod.yaml
+
+```
+apiVersion: v1
+kind: Pod
+metadata:
+  name: volume-test
+  namespace: default
+spec:
+  containers:
+  - name: volume-test
+    image: nginx:stable-alpine
+    imagePullPolicy: IfNotPresent
+    volumeMounts:
+    - name: volv
+      mountPath: /data
+    ports:
+    - containerPort: 80
+  volumes:
+  - name: volv
+    persistentVolumeClaim:
+      claimName: local-path-pvc
+```
+
+Apply the yaml `kubectl create -f pvc.yaml` and `kubectl create -f pod.yaml`
+
+Confirm the pv and pvc are created. `kubectl get pv` and `kubectl get pvc` The status should be Bound for each.
+
+# Longhorn
+
+[comment]: <> (pending change - longhorn may support arm64 and armhf in the future.)
+
+> **Note:** At this time Longhorn only supports amd64.
+
+k3s supports [Longhorn](https://github.com/longhorn/longhorn). Below we cover a simple example. For more information please reference the official documentation [here](https://github.com/longhorn/longhorn/blob/master/README.md).
+
+Apply the longhorn.yaml to install Longhorn.
+
+```
+kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml
+```
+
+Longhorn will be installed in the namespace `longhorn-system`
+
+Before we create a PVC, we will create a storage class for longhorn with this yaml.
+
+```
+kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/examples/storageclass.yaml
+```
+
+Now, apply the following yaml to create the pvc and pod with `kubectl create -f pvc.yaml` and `kubectl create -f pod.yaml`
+
+### pvc.yaml
+
+```
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: longhorn-volv-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 2Gi
+```
+
+### pod.yaml
+
+```
+apiVersion: v1
+kind: Pod
+metadata:
+  name: volume-test
+  namespace: default
+spec:
+  containers:
+  - name: volume-test
+    image: nginx:stable-alpine
+    imagePullPolicy: IfNotPresent
+    volumeMounts:
+    - name: volv
+      mountPath: /data
+    ports:
+    - containerPort: 80
+  volumes:
+  - name: volv
+    persistentVolumeClaim:
+      claimName: longhorn-volv-pvc
+```
+
+Confirm the pv and pvc are created. `kubectl get pv` and `kubectl get pvc` The status should be Bound for each.


### PR DESCRIPTION
This PR adds a "Storage" page in the docs for k3s.

- Normalize page weights; order was not modified this just makes it easier to work with in the future.
- Add a storage page and content for the local path provisoner (built in to k3s) and longhorn.

Closes https://github.com/rancher/k3s/issues/863