### PR TITLE
Move "Upgrades" from Installation Options section to a new Upgrades section

### DIFF
--- a/content/k3s/latest/en/installation/_index.md
+++ b/content/k3s/latest/en/installation/_index.md
@@ -19,40 +19,6 @@ This section contains instructions for installing k3s in testing and production 
 
 	Install k3s in an air-gapped environment. High Availability is recommended for production environments.
 
-### Upgrading
-
->**Note:** When upgrading, upgrade server nodes first one at a time then any worker nodes.
-
-To upgrade k3s from an older version you can re-run the installation script using the same flags, for example:
-
-```sh
-curl -sfL https://get.k3s.io | sh -
-```
-
-If you want to upgrade to specific version you can run the following command:
-
-```sh
-curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=vX.Y.Z-rc1 sh -
-```
-
-Or to manually upgrade k3s:
-
-1. Download the desired version of k3s from [releases](https://github.com/rancher/k3s/releases/latest)
-2. Install to an appropriate location (normally `/usr/local/bin/k3s`)
-3. Stop the old version
-4. Start the new version
-
-Restarting k3s is supported by the installation script for systemd and openrc.
-To restart manually for systemd use:
-```sh
-sudo systemctl restart k3s
-```
-
-To restart manually for openrc use:
-```sh
-sudo service k3s restart
-```
-
 ### Uninstalling
 
 If you installed k3s with the help of the `install.sh` script an uninstall script is generated during installation, which will be created on your node at `/usr/local/bin/k3s-uninstall.sh` (or as `k3s-agent-uninstall.sh`).

--- a/content/k3s/latest/en/upgrades/_index.md
+++ b/content/k3s/latest/en/upgrades/_index.md
@@ -1,0 +1,36 @@
+---
+title: "Upgrades"
+weight: 25
+---
+
+>**Note:** When upgrading, upgrade server nodes first one at a time then any worker nodes.
+
+To upgrade k3s from an older version you can re-run the installation script using the same flags, for example:
+
+```sh
+curl -sfL https://get.k3s.io | sh -
+```
+
+If you want to upgrade to specific version you can run the following command:
+
+```sh
+curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=vX.Y.Z-rc1 sh -
+```
+
+Or to manually upgrade k3s:
+
+1. Download the desired version of k3s from [releases](https://github.com/rancher/k3s/releases/latest)
+2. Install to an appropriate location (normally `/usr/local/bin/k3s`)
+3. Stop the old version
+4. Start the new version
+
+Restarting k3s is supported by the installation script for systemd and openrc.
+To restart manually for systemd use:
+```sh
+sudo systemctl restart k3s
+```
+
+To restart manually for openrc use:
+```sh
+sudo service k3s restart
+```


### PR DESCRIPTION
Simply moves "Upgrading" section that was in "Instalaltion Options" to its own new "Upgrades" section just below "Installation Options".

Related to https://github.com/rancher/k3s/issues/859 it makes one last change for it.