### PR TITLE
Move metrics-server mention in configuration page to page for prior to v1.0.0

### DIFF
--- a/content/k3s/latest/en/configuration/_index.md
+++ b/content/k3s/latest/en/configuration/_index.md
@@ -162,14 +162,3 @@ k3s agents can be configured with options `--node-label` and `--node-taint` whic
      --node-taint key1=value1:NoExecute
 ```
 
-Metrics Server
---------------
-
-To add functionality for commands such as `k3s kubectl top nodes` metrics-server must be installed, 
-to install see the instructions located at https://github.com/kubernetes-incubator/metrics-server/.
-
-**NOTE** : By default the image used in `metrics-server-deployment.yaml` is valid only for **amd64** devices,
-this should be edited as appropriate for your architecture. As of this writing metrics-server provides
-the following images relevant to k3s: `amd64:v0.3.3`, `arm64:v0.3.2`, and `arm:v0.3.2`. Further information
-on the images provided through gcr.io can be found at https://console.cloud.google.com/gcr/images/google-containers/GLOBAL.
-

--- a/content/k3s/latest/en/configuration/_index.md
+++ b/content/k3s/latest/en/configuration/_index.md
@@ -162,3 +162,7 @@ k3s agents can be configured with options `--node-label` and `--node-taint` whic
      --node-taint key1=value1:NoExecute
 ```
 
+Metrics Server
+--------------
+
+>**Note:** v1.0.0 and newer includes the metrics-server by default. For older versions of k3s, please visit [Configuration Info Prior to v1.0.0]({{< baseurl >}}/k3s/latest/en/configuration/older-configuration/).

--- a/content/k3s/latest/en/configuration/older-configuration/_index.md
+++ b/content/k3s/latest/en/configuration/older-configuration/_index.md
@@ -1,0 +1,21 @@
+---
+title: "Configuration Info Prior to v1.0.0"
+weight: 10
+---
+
+>**Note:** Running k3s v1.0.0 or newer is recommended.
+
+This page outlines any configuration info that is relevant to versions older than v1.0.0 but was removed or no longer needed in v1.0.0 and newer.
+
+Metrics Server	
+--------------
+
+>**Note:** k3s v1.0.0 includes the metrics-server by default.
+
+To add functionality for commands such as `k3s kubectl top nodes` metrics-server must be installed, 
+to install see the instructions located at https://github.com/kubernetes-incubator/metrics-server/.	
+
+**NOTE** : By default the image used in `metrics-server-deployment.yaml` is valid only for **amd64** devices,	
+this should be edited as appropriate for your architecture. As of this writing metrics-server provides	
+the following images relevant to k3s: `amd64:v0.3.3`, `arm64:v0.3.2`, and `arm:v0.3.2`. Further information	
+on the images provided through gcr.io can be found at https://console.cloud.google.com/gcr/images/google-containers/GLOBAL.


### PR DESCRIPTION
- We now include our own metrics-server and thus standard `kubectl top nodes`, etc functionality works out of the box.
Since this works like standard k8s now with the top command, etc ~we don't need to document the custom-method to deploy metrics-server so we should simply remove this section.~ we should move this section to a child of the Configuration page for versions prior to v1.0.0

Closes https://github.com/rancher/k3s/issues/991