### PR TITLE
Document service defaults/admission plugins location

### DIFF
--- a/content/rke/latest/en/config-options/_index.md
+++ b/content/rke/latest/en/config-options/_index.md
@@ -69,7 +69,7 @@ In case both `kubernetes_version` and [system images]({{< baseurl >}}/rke/latest
 
 > **Note:** In RKE, `kubernetes_version` is used to map the version of Kubernetes to the default services, parameters, and options:
 > - For RKE v0.3.0+, the service defaults are located [here](https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_service_options.go).
-> - For RKE prior to v0.3.0, the service defaults are located [here](https://github.com/rancher/types/blob/release/v2.2/apis/management.cattle.io/v3/k8s_defaults.go).
+> - For RKE prior to v0.3.0, the service defaults are located [here](https://github.com/rancher/types/blob/release/v2.2/apis/management.cattle.io/v3/k8s_defaults.go). Note: The version in the path of the service defaults file corresponds to a Rancher version. Therefore, for Rancher v2.1.x, [this file](https://github.com/rancher/types/blob/release/v2.1/apis/management.cattle.io/v3/k8s_defaults.go) should be used.
 
 #### Listing Supported Kubernetes Versions
 

--- a/content/rke/latest/en/config-options/_index.md
+++ b/content/rke/latest/en/config-options/_index.md
@@ -67,6 +67,10 @@ kubernetes_version: "v1.11.6-rancher1-1"
 
 In case both `kubernetes_version` and [system images]({{< baseurl >}}/rke/latest/en/config-options/system-images/) are defined, the system images configuration will take precedence over `kubernetes_version`.
 
+> **Note:** In RKE, `kubernetes_version` is used to map the version of Kubernetes to the default services, parameters, and options:
+> - For RKE v0.3.0+, the service defaults are located here: https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_service_options.go
+> - For RKE prior to v0.3.0, the service defaults are located here: https://github.com/rancher/types/blob/release/v2.2/apis/management.cattle.io/v3/k8s_defaults.go
+
 #### Listing Supported Kubernetes Versions
 
 Please refer to the [release notes](https://github.com/rancher/rke/releases) of the RKE version that you are running, to find the list of supported Kubernetes versions as well as the default Kubernetes version.

--- a/content/rke/latest/en/config-options/_index.md
+++ b/content/rke/latest/en/config-options/_index.md
@@ -68,7 +68,6 @@ kubernetes_version: "v1.11.6-rancher1-1"
 In case both `kubernetes_version` and [system images]({{< baseurl >}}/rke/latest/en/config-options/system-images/) are defined, the system images configuration will take precedence over `kubernetes_version`.
 
 > **Note:** In RKE, `kubernetes_version` is used to map the version of Kubernetes to the default services, parameters, and options:
-
 > - For RKE v0.3.0+, the service defaults are located [here](https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_service_options.go).
 > - For RKE prior to v0.3.0, the service defaults are located [here](https://github.com/rancher/types/blob/release/v2.2/apis/management.cattle.io/v3/k8s_defaults.go).
 

--- a/content/rke/latest/en/config-options/_index.md
+++ b/content/rke/latest/en/config-options/_index.md
@@ -68,8 +68,9 @@ kubernetes_version: "v1.11.6-rancher1-1"
 In case both `kubernetes_version` and [system images]({{< baseurl >}}/rke/latest/en/config-options/system-images/) are defined, the system images configuration will take precedence over `kubernetes_version`.
 
 > **Note:** In RKE, `kubernetes_version` is used to map the version of Kubernetes to the default services, parameters, and options:
-> - For RKE v0.3.0+, the service defaults are located here: https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_service_options.go
-> - For RKE prior to v0.3.0, the service defaults are located here: https://github.com/rancher/types/blob/release/v2.2/apis/management.cattle.io/v3/k8s_defaults.go
+
+> - For RKE v0.3.0+, the service defaults are located [here](https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_service_options.go).
+> - For RKE prior to v0.3.0, the service defaults are located [here](https://github.com/rancher/types/blob/release/v2.2/apis/management.cattle.io/v3/k8s_defaults.go).
 
 #### Listing Supported Kubernetes Versions
 

--- a/content/rke/latest/en/config-options/services/services-extras/_index.md
+++ b/content/rke/latest/en/config-options/services/services-extras/_index.md
@@ -15,10 +15,9 @@ Prior to `v0.1.3`, using `extra_args` would only add new arguments to the list a
 
 All service defaults and parameters are defined per [`kubernetes_version`]({{<baseurl>}}/rke/latest/en/config-options/#kubernetes-version):
 
-- For RKE v0.3.0+, the service defaults are located here: https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_service_options.go
-- For RKE prior to v0.3.0, the service defaults are located here: https://github.com/rancher/types/blob/release/v2.2/apis/management.cattle.io/v3/k8s_defaults.go
+- For RKE v0.3.0+, the service defaults and parameters are defined per [`kubernetes_version`]({{<baseurl>}}/rke/latest/en/config-options/#kubernetes-version). The service defaults are located [here](https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_service_options.go). The default list of admissions plugins is the same for all Kubernetes versions and is located [here](https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_service_options.go#L11).
 
-The default list of admission plugins for RKE v0.3.0+ is defined [here](https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_service_options.go#L11). The list is sometimes changed per Kubernetes version. The exact list per version is defined in the same file. The admission plugins for RKE prior to v0.3.0 is defined [here](https://github.com/rancher/types/blob/release/v2.2/apis/management.cattle.io/v3/k8s_defaults.go). 
+- For RKE prior to v0.3.0, the service defaults and admission plugins are defined per [`kubernetes_version`]({{<baseurl>}}/rke/latest/en/config-options/#kubernetes-version) and located [here](https://github.com/rancher/types/blob/release/v2.2/apis/management.cattle.io/v3/k8s_defaults.go). 
 
 ```yaml
 services:

--- a/content/rke/latest/en/config-options/services/services-extras/_index.md
+++ b/content/rke/latest/en/config-options/services/services-extras/_index.md
@@ -9,9 +9,16 @@ RKE supports additional service arguments, volume binds and environment variable
 
 For any of the Kubernetes services, you can update the `extra_args` to change the existing defaults.
 
-As of `v0.1.3`, using `extra_args` will add new arguments and **override** any existing defaults. For example, if you need to modify the default admission controllers list, you need to include the default list and edit it with your changes so all changes are included.
+As of `v0.1.3`, using `extra_args` will add new arguments and **override** any existing defaults. For example, if you need to modify the default admission plugins list, you need to include the default list and edit it with your changes so all changes are included.
 
 Prior to `v0.1.3`, using `extra_args` would only add new arguments to the list and there was no ability to change the default list.
+
+All service defaults and parameters are defined per [`kubernetes_version`]({{<baseurl>}}/rke/latest/en/config-options/#kubernetes-version):
+
+- For RKE v0.3.0+, the service defaults are located here: https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_service_options.go
+- For RKE prior to v0.3.0, the service defaults are located here: https://github.com/rancher/types/blob/release/v2.2/apis/management.cattle.io/v3/k8s_defaults.go
+
+The default list of admission plugins for RKE v0.3.0+ is defined [here](https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_service_options.go#L11). The list is sometimes changed per Kubernetes version. The exact list per version is defined in the same file. The admission plugins for RKE prior to v0.3.0 is defined [here](https://github.com/rancher/types/blob/release/v2.2/apis/management.cattle.io/v3/k8s_defaults.go). 
 
 ```yaml
 services:


### PR DESCRIPTION
This PR continues the work done here: https://github.com/rancher/docs/pull/1771
It addresses the same issue https://github.com/rancher/rke/issues/1265 as the above PR.