### PR TITLE
Tweaks to Traefik on Networking page

### DIFF
--- a/content/k3s/latest/en/installation/ha/_index.md
+++ b/content/k3s/latest/en/installation/ha/_index.md
@@ -141,7 +141,7 @@ Following the [Node Requirements]({{< baseurl >}}/k3s/latest/en/installation/nod
 Run the following command to join a worker node to the server nodes. We are leveraging the cluster-secret here. Since our server nodes were set up to use this, so too must any agent nodes.
 
 ```
-curl -sfL https://get.k3s.io | K3S_URL=https:/<server_node>:6443 K3S_CLUSTER_SECRET='mysecret' sh -
+curl -sfL https://get.k3s.io | K3S_URL=https://<server_node>:6443 K3S_CLUSTER_SECRET='mysecret' sh -
 ```
 
 Provide the IP or DNS in place of `<server_node>`. This can be any one server node. k3s automatically handles load balancing the server nodes.

--- a/content/k3s/latest/en/networking/_index.md
+++ b/content/k3s/latest/en/networking/_index.md
@@ -19,21 +19,28 @@ disables access to port 8472.
 Flannel
 -------
 
-Flannel is included by default, if you don't want flannel then run the agent with `--no-flannel` option.
+Flannel is included by default, if you don't want flannel then run each agent with `--no-flannel` option.
 
 In this setup you will still be required to install your own CNI driver.  More info [here](https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/#pod-network)
 
 CoreDNS
 -------
 
-CoreDNS is deployed on start of the agent, to disable run the server with the `--no-deploy coredns` option.
+CoreDNS is deployed on start of the agent, to disable run each server with the `--no-deploy coredns` option.
 
 If you don't install CoreDNS you will need to install a cluster DNS provider yourself.
 
-Traefik
--------
+Traefik Ingress Controller
+--------------------------
 
-Traefik is deployed by default when starting the server; to disable it, start the server with the `--no-deploy traefik` option. The default config file is found in `/var/lib/rancher/k3s/server/manifests/traefik.yaml` and any changes made to this file will automatically be deployed to Kubernetes in a manner similar to `kubectl apply`.
+Traefik is deployed by default when starting the server. For more information see [Auto Deploying Manifests]({{< baseurl >}}/k3s/latest/en/configuration/#auto-deploying-manifests). The default config file is found in `/var/lib/rancher/k3s/server/manifests/traefik.yaml` and any changes made to this file will automatically be deployed to Kubernetes in a manner similar to `kubectl apply`.
+
+The Traefik ingress controller will use ports 80, 443, and 8080 on the host (i.e. these will not be usable for HostPort or NodePort).
+
+You can tweak traefik to meet your needs by setting options in the traefik.yaml file.
+Reference the official [Traefik for Helm Configuration Parameters](https://github.com/helm/charts/tree/master/stable/traefik#configuration) readme for more information.
+
+To disable it, start each server with the `--no-deploy traefik` option.
 
 Service Load Balancer
 ---------------------


### PR DESCRIPTION
- Modify the Traefik section so it's clear it's the ingress controller
- Make it clear what ports are used on the host (so can't use for HostPort or a strange NodePort setting)
- Small misc tweaks

- Small typo fix to installation/ha/_index.md

Closes https://github.com/rancher/k3s/issues/1050
Is related to https://github.com/rancher/k3s/issues/985 but does not completely resolve it. We will want to improve this in 1.x so that issue was moved to that milestone.