### PR TITLE
Fix error in vSphere docs

### DIFF
--- a/content/rke/latest/en/config-options/cloud-providers/vsphere/_index.md
+++ b/content/rke/latest/en/config-options/cloud-providers/vsphere/_index.md
@@ -182,7 +182,7 @@ cloud_provider:
         datacenters: eu-west-1
     workspace:
       server: vc.example.com
-      folder: kubernetes
+      folder: vm/kubernetes
       default-datastore: ds-1
       datacenter: eu-west-1
 


### PR DESCRIPTION
This PR fixes an error in the vSphere docs. 

This fix worked for [someone in the Rancher forums](https://forums.rancher.com/t/vsphere-cloud-provider-password-not-saved/15772)  and for [someone in the Rancher Users Slack.](https://rancher-users.slack.com/archives/C3ASABBD1/p1573768059198700?thread_ts=1573766659.194800&cid=C3ASABBD1)