### PR TITLE
Capitalize k3s and small fixes

### DIFF
--- a/content/k3s/latest/en/_index.md
+++ b/content/k3s/latest/en/_index.md
@@ -18,14 +18,14 @@ Great for:
 What is this?
 ---
 
-k3s is intended to be a fully compliant Kubernetes distribution with the following changes:
+K3s is intended to be a fully compliant Kubernetes distribution with the following changes:
 
 1. Removed most in-tree plugins (cloud providers and storage plugins) which can be replaced
    with out of tree addons.
 2. Added sqlite3 as the default storage mechanism and support for other external SQL databases such as PostgreSQL and MySQL. etcd3 is also supported as an external database.
 3. Added local storage provider, service load balancer, helm-controller, and traefik ingress controller.
 4. Wrapped in simple launcher that handles a lot of the complexity of TLS and options.
-5. Minimal to no OS dependencies (just a sane kernel and cgroup mounts needed). k3s packages required dependencies
+5. Minimal to no OS dependencies (just a sane kernel and cgroup mounts needed). K3s packages required dependencies
     * containerd
     * Flannel
     * CoreDNS

--- a/content/k3s/latest/en/advanced/_index.md
+++ b/content/k3s/latest/en/advanced/_index.md
@@ -5,7 +5,7 @@ aliases:
   - /k3s/latest/en/running/
 ---
 
-This section contains advanced information describing the different ways you can run and manage k3s.
+This section contains advanced information describing the different ways you can run and manage K3s.
 
 Starting the Server
 ------------------
@@ -81,10 +81,10 @@ After rebooting:
 Running in Docker (and docker-compose)
 -----------------
 
-[k3d](https://github.com/rancher/k3d) is a utility designed to easily run k3s in Docker. It can be installed via the [brew](https://brew.sh/) utility for MacOS.
+[k3d](https://github.com/rancher/k3d) is a utility designed to easily run K3s in Docker. It can be installed via the [brew](https://brew.sh/) utility for MacOS.
 
-`rancher/k3s` images are also available to run k3s server and agent from Docker.  A `docker-compose.yml` is in the root of the k3s repo that
-serves as an example of how to run k3s from Docker.  To run from `docker-compose` from this repo run:
+`rancher/k3s` images are also available to run K3s server and agent from Docker.  A `docker-compose.yml` is in the root of the K3s repo that
+serves as an example of how to run K3s from Docker.  To run from `docker-compose` from this repo run:
 
     docker-compose up --scale node=3
     # kubeconfig is written to current dir

--- a/content/k3s/latest/en/configuration/_index.md
+++ b/content/k3s/latest/en/configuration/_index.md
@@ -3,7 +3,7 @@ title: "Configuration Info"
 weight: 50
 ---
 
-This section contains information on using k3s with various configurations.
+This section contains information on using K3s with various configurations.
 
 
 Auto-Deploying Manifests
@@ -12,7 +12,7 @@ Auto-Deploying Manifests
 Any file found in `/var/lib/rancher/k3s/server/manifests` will automatically be deployed to
 Kubernetes in a manner similar to `kubectl apply`.
 
-It is also possible to deploy Helm charts. k3s supports a CRD controller for installing charts. A YAML file specification can look as following (example taken from `/var/lib/rancher/k3s/server/manifests/traefik.yaml`):
+It is also possible to deploy Helm charts. K3s supports a CRD controller for installing charts. A YAML file specification can look as following (example taken from `/var/lib/rancher/k3s/server/manifests/traefik.yaml`):
 
 ```yaml
 apiVersion: helm.cattle.io/v1
@@ -27,7 +27,7 @@ spec:
     ssl.enabled: "true"
 ```
 
-Keep in mind that `namespace` in your HelmChart resource metadata section should always be `kube-system`, because k3s deploy controller is configured to watch this namespace for new HelmChart resources. If you want to specify the namespace for the actual helm release, you can do that using `targetNamespace` key in the spec section:
+Keep in mind that `namespace` in your HelmChart resource metadata section should always be `kube-system`, because the K3s deploy controller is configured to watch this namespace for new HelmChart resources. If you want to specify the namespace for the actual helm release, you can do that using `targetNamespace` key in the spec section:
 
 ```
 apiVersion: helm.cattle.io/v1
@@ -53,7 +53,7 @@ spec:
 
 Also note that besides `set` you can use `valuesContent` in the spec section. And it's okay to use both of them.
 
-k3s versions `<= v0.5.0` used `k3s.cattle.io` for the api group of helmcharts, this has been changed to `helm.cattle.io` for later versions.
+K3s versions `<= v0.5.0` used `k3s.cattle.io` for the api group of helmcharts, this has been changed to `helm.cattle.io` for later versions.
 
 Using the helm CRD
 ---------------------
@@ -90,7 +90,7 @@ Accessing Cluster from Outside
 -----------------------------
 
 Copy `/etc/rancher/k3s/k3s.yaml` on your machine located outside the cluster as `~/.kube/config`. Then replace
-"localhost" with the IP or name of your k3s server. `kubectl` can now manage your k3s cluster.
+"localhost" with the IP or name of your K3s server. `kubectl` can now manage your K3s cluster.
 
 Node Registration
 -----------------
@@ -104,9 +104,9 @@ password file should be recreated for the agent, or the entry removed from the s
 Containerd and Docker
 ----------
 
-k3s includes and defaults to containerd. If you want to use Docker instead of containerd then you simply need to run the agent with the `--docker` flag.
+K3s includes and defaults to containerd. If you want to use Docker instead of containerd then you simply need to run the agent with the `--docker` flag.
 
-k3s will generate config.toml for containerd in `/var/lib/rancher/k3s/agent/etc/containerd/config.toml`, for advanced customization for this file you can create another file called `config.toml.tmpl` in the same directory and it will be used instead.
+K3s will generate config.toml for containerd in `/var/lib/rancher/k3s/agent/etc/containerd/config.toml`, for advanced customization for this file you can create another file called `config.toml.tmpl` in the same directory and it will be used instead.
 
 The `config.toml.tmpl` will be treated as a Golang template file, and the `config.Node` structure is being passed to the template, the following is an example on how to use the structure to customize the configuration file https://github.com/rancher/k3s/blob/master/pkg/agent/templates/templates.go#L16-L32
 
@@ -126,9 +126,9 @@ In short, latest Ubuntu is your best bet for this to work.
 
 * **Ports**
 
-    When running rootless a new network namespace is created.  This means that k3s instance is running with networking
-    fairly detached from the host.  The only way to access services run in k3s from the host is to setup port forwards
-    to the k3s network namespace.  We have a controller that will automatically bind 6443 and service port below 1024 to the host with an offset of 10000. 
+    When running rootless a new network namespace is created.  This means that K3s instance is running with networking
+    fairly detached from the host.  The only way to access services run in K3s from the host is to setup port forwards
+    to the K3s network namespace.  We have a controller that will automatically bind 6443 and service port below 1024 to the host with an offset of 10000. 
 
     That means service port 80 will become 10080 on the host, but 8080 will become 8080 without any offset.
 
@@ -136,7 +136,7 @@ In short, latest Ubuntu is your best bet for this to work.
 
 * **Daemon lifecycle**
 
-    Once you kill k3s and then start a new instance of k3s it will create a new network namespace, but it doesn't kill the old pods.  So you are left
+    Once you kill K3s and then start a new instance of K3s it will create a new network namespace, but it doesn't kill the old pods.  So you are left
     with a fairly broken setup.  This is the main issue at the moment, how to deal with the network namespace.
 
     The issue is tracked in https://github.com/rootless-containers/rootlesskit/issues/65
@@ -149,13 +149,13 @@ In short, latest Ubuntu is your best bet for this to work.
 
 Just add `--rootless` flag to either server or agent.  So run `k3s server --rootless` and then look for the message
 `Wrote kubeconfig [SOME PATH]` for where your kubeconfig to access you cluster is.  Be careful, if you use `-o` to write
-the kubeconfig to a different directory it will probably not work.  This is because the k3s instance in running in a different
+the kubeconfig to a different directory it will probably not work.  This is because the K3s instance in running in a different
 mount namespace.
 
 Node Labels and Taints
 ----------------------
 
-k3s agents can be configured with options `--node-label` and `--node-taint` which adds set of Labels and Taints to kubelet, the two options only adds labels/taints at registration time, so they can only be added once and not changed after that, an example of options to add new label is:
+K3s agents can be configured with options `--node-label` and `--node-taint` which adds set of Labels and Taints to kubelet, the two options only adds labels/taints at registration time, so they can only be added once and not changed after that, an example of options to add new label is:
 ```
      --node-label foo=bar \
      --node-label hello=world \

--- a/content/k3s/latest/en/faq/_index.md
+++ b/content/k3s/latest/en/faq/_index.md
@@ -19,4 +19,4 @@ At this time k3s does not natively support Windows, however we are open to the i
 
 **How can I build from source?**
 
-Please reference the k3s [README.md](https://github.com/rancher/k3s/blob/master/README.md) with instructions.
+Please reference the k3s [BUILDING.md](https://github.com/rancher/k3s/blob/master/BUILDING.md) with instructions.

--- a/content/k3s/latest/en/faq/_index.md
+++ b/content/k3s/latest/en/faq/_index.md
@@ -3,20 +3,20 @@ title: FAQ
 weight: 60
 ---
 
-The FAQ is updated periodically and designed to answer the questions our users most frequently ask about k3s.
+The FAQ is updated periodically and designed to answer the questions our users most frequently ask about K3s.
 
-**Is k3s a suitable replacement for k8s?**
+**Is K3s a suitable replacement for k8s?**
 
-k3s is capable of nearly everything k8s can do. It is just a more lightweight version. See the [main]({{<baseurl>}}/k3s/latest/en/) docs page for more details.
+K3s is capable of nearly everything k8s can do. It is just a more lightweight version. See the [main]({{<baseurl>}}/k3s/latest/en/) docs page for more details.
 
 **How can I use my own Ingress instead of Traefik?**
 
-Simply start k3s server with `--no-deploy=traefik` and deploy your ingress.
+Simply start K3s server with `--no-deploy=traefik` and deploy your ingress.
 
-**Does k3s support Windows?**
+**Does K3s support Windows?**
 
-At this time k3s does not natively support Windows, however we are open to the idea in the future.
+At this time K3s does not natively support Windows, however we are open to the idea in the future.
 
 **How can I build from source?**
 
-Please reference the k3s [BUILDING.md](https://github.com/rancher/k3s/blob/master/BUILDING.md) with instructions.
+Please reference the K3s [BUILDING.md](https://github.com/rancher/k3s/blob/master/BUILDING.md) with instructions.

--- a/content/k3s/latest/en/installation/_index.md
+++ b/content/k3s/latest/en/installation/_index.md
@@ -3,22 +3,22 @@ title: "Installation"
 weight: 20
 ---
 
-This section contains instructions for installing k3s in various environments. Please ensure you have met the [Node Requirements]({{< baseurl >}}/k3s/latest/en/installation/node-requirements/) before you begin installing k3s.
+This section contains instructions for installing K3s in various environments. Please ensure you have met the [Node Requirements]({{< baseurl >}}/k3s/latest/en/installation/node-requirements/) before you begin installing K3s.
 
 ### Installation Options
 
 *   [Single Server Installation]({{< baseurl >}}/k3s/latest/en/installation/single-server/)
 
-	Install k3s on a single Linux host. Single server installs are recommended for development, test, or production environments where the cluster doesn't have to be readily available for a user-base and some downtime is acceptible.
+	Install K3s on a single Linux host. Single server installs are recommended for development, test, or production environments where the cluster doesn't have to be readily available for a user-base and some downtime is acceptible.
 
 *   [High Availability (HA) Installation]({{< baseurl >}}/k3s/latest/en/installation/ha/)
 
-	Install k3s on two or more Linux hosts. High Availability installs are recommended for production environments that cannot tolerate any downtime.
+	Install K3s on two or more Linux hosts. High Availability installs are recommended for production environments that cannot tolerate any downtime.
 
 *   [Air-Gap Installation]({{< baseurl >}}/k3s/latest/en/installation/airgap/)
 
-	Install k3s in an air-gapped environment. High Availability is recommended for production environments that cannot tolerate any downtime.
+	Install K3s in an air-gapped environment. High Availability is recommended for production environments that cannot tolerate any downtime.
 
 ### Uninstalling
 
-If you installed k3s with the help of the `install.sh` script an uninstall script is generated during installation, which will be created on your node at `/usr/local/bin/k3s-uninstall.sh` (or as `k3s-agent-uninstall.sh`).
+If you installed K3s with the help of the `install.sh` script an uninstall script is generated during installation, which will be created on your node at `/usr/local/bin/k3s-uninstall.sh` (or as `k3s-agent-uninstall.sh`).

--- a/content/k3s/latest/en/installation/node-requirements/_index.md
+++ b/content/k3s/latest/en/installation/node-requirements/_index.md
@@ -34,3 +34,5 @@ k3s performance depends on the performance of the database. To ensure optimal sp
 The k3s server needs port 6443 to be accessible by the nodes. The nodes need to be able to reach other nodes over UDP port 8472 (Flannel VXLAN). If you do not use flannel and provide your own custom CNI, then port 8472 is not needed by k3s. The node should not listen on any other port. k3s uses reverse tunneling such that the nodes make outbound connections to the server and all kubelet traffic runs through that tunnel.
 
 IMPORTANT: The VXLAN port on nodes should not be exposed to the world as it opens up your cluster network to be accessed by anyone. Run your nodes behind a firewall/security group that disabled access to port 8472.
+
+If you wish to utilize the metrics server, you will need to open port 10250 on each node.

--- a/content/k3s/latest/en/installation/node-requirements/_index.md
+++ b/content/k3s/latest/en/installation/node-requirements/_index.md
@@ -3,16 +3,16 @@ title: Node Requirements
 weight: 1
 ---
 
-k3s is very lightweight, but has some minimum requirements as outlined below.
+K3s is very lightweight, but has some minimum requirements as outlined below.
 
-Whether you're configuring a k3s cluster to run in a single-node or high-availability (HA) setup, each node running k3s should meet the following minimum requirements. You may need more resources to fit your needs.
+Whether you're configuring a K3s cluster to run in a single-node or high-availability (HA) setup, each node running K3s should meet the following minimum requirements. You may need more resources to fit your needs.
 
 ## Prerequisites
 *    Two nodes cannot have the same hostname. If all your nodes have the same hostname, pass `--node-name` or set `$K3S_NODE_NAME` with a unique name for each node you add to the cluster.
 
 ## Operating Systems
 
-k3s should run on just about any flavor of Linux. However, k3s is tested on the following operating systems and their subsequent non-major releases.
+K3s should run on just about any flavor of Linux. However, K3s is tested on the following operating systems and their subsequent non-major releases.
 
 *    Ubuntu 16.04 (amd64)
 *    Ubuntu 18.04 (amd64)
@@ -27,11 +27,11 @@ Hardware requirements scale based on the size of your deployments. Minimum recom
 
 #### Disks
 
-k3s performance depends on the performance of the database. To ensure optimal speed, we recommend using an SSD when possible. Disk performance will vary on ARM devices utilizing an SD card or eMMC.
+K3s performance depends on the performance of the database. To ensure optimal speed, we recommend using an SSD when possible. Disk performance will vary on ARM devices utilizing an SD card or eMMC.
 
 ## Networking
 
-The k3s server needs port 6443 to be accessible by the nodes. The nodes need to be able to reach other nodes over UDP port 8472 (Flannel VXLAN). If you do not use flannel and provide your own custom CNI, then port 8472 is not needed by k3s. The node should not listen on any other port. k3s uses reverse tunneling such that the nodes make outbound connections to the server and all kubelet traffic runs through that tunnel.
+The K3s server needs port 6443 to be accessible by the nodes. The nodes need to be able to reach other nodes over UDP port 8472 (Flannel VXLAN). If you do not use flannel and provide your own custom CNI, then port 8472 is not needed by K3s. The node should not listen on any other port. K3s uses reverse tunneling such that the nodes make outbound connections to the server and all kubelet traffic runs through that tunnel.
 
 IMPORTANT: The VXLAN port on nodes should not be exposed to the world as it opens up your cluster network to be accessed by anyone. Run your nodes behind a firewall/security group that disabled access to port 8472.
 

--- a/content/k3s/latest/en/installation/single-server/_index.md
+++ b/content/k3s/latest/en/installation/single-server/_index.md
@@ -3,12 +3,12 @@ title: "Single Server Install"
 weight: 20
 ---
 
->**Note:** This section contains information on flags and environment variables used for starting a single-server (non-HA) k3s cluster. A High-Availability (HA) k3s cluster is recommended for production environments that cannot tolerate down time.
+>**Note:** This section contains information on flags and environment variables used for starting a single-server (non-HA) K3s cluster. A High-Availability (HA) K3s cluster is recommended for production environments that cannot tolerate down time.
 
 Installation
 ------------
 
-k3s is easy to install. To install the latest version, simply run:
+K3s is easy to install. To install the latest version, simply run:
 
 ```sh
 curl -sfL https://get.k3s.io | sh -
@@ -47,7 +47,7 @@ The full help text for the install script environment variables are as follows:
 
    - `INSTALL_K3S_SKIP_DOWNLOAD`
 
-     If set to true will not download k3s hash or binary.
+     If set to true will not download K3s hash or binary.
      
    - `INSTALL_K3S_SYMLINK`
 
@@ -56,12 +56,12 @@ The full help text for the install script environment variables are as follows:
 
    - `INSTALL_K3S_VERSION`
 
-     Version of k3s to download from github. Will attempt to download the
+     Version of K3s to download from github. Will attempt to download the
      latest version if not specified.
 
    - `INSTALL_K3S_BIN_DIR`
 
-     Directory to install k3s binary, links, and uninstall script to, or use
+     Directory to install K3s binary, links, and uninstall script to, or use
      /usr/local/bin as the default
 
    - `INSTALL_K3S_SYSTEMD_DIR`
@@ -71,7 +71,7 @@ The full help text for the install script environment variables are as follows:
 
    - `INSTALL_K3S_EXEC` or script arguments
 
-     Command with flags to use for launching k3s in the systemd service, if
+     Command with flags to use for launching K3s in the systemd service, if
      the command is not specified will default to "agent" if `K3S_URL` is set
      or "server" if not. The final systemd command resolves to a combination
      of EXEC and script args ($@).
@@ -87,11 +87,11 @@ The full help text for the install script environment variables are as follows:
 
    - `INSTALL_K3S_NAME`
 
-     Name of systemd service to create, will default from the k3s exec command
+     Name of systemd service to create, will default from the K3s exec command
      if not specified. If specified the name will be prefixed with 'k3s-'.
 
    - `INSTALL_K3S_TYPE`
 
-     Type of systemd service to create, will default from the k3s exec command
+     Type of systemd service to create, will default from the K3s exec command
      if not specified.
 

--- a/content/k3s/latest/en/known-issues/_index.md
+++ b/content/k3s/latest/en/known-issues/_index.md
@@ -6,7 +6,7 @@ The Known Issues are updated periodically and designed to inform you about any i
 
 **Snap Docker**
 
-If you plan to use k3s with docker, Docker installed via a snap package is not recommended as it has been known to cause issues running k3s.
+If you plan to use K3s with docker, Docker installed via a snap package is not recommended as it has been known to cause issues running K3s.
 
 **Iptables**
 

--- a/content/k3s/latest/en/networking/_index.md
+++ b/content/k3s/latest/en/networking/_index.md
@@ -3,18 +3,9 @@ title: "Networking"
 weight: 35
 ---
 
-Open Ports / Network Security
----------------------------
-
-The server needs port 6443 to be accessible by the nodes.  The nodes need to be able to reach
-other nodes over UDP port 8472.  The nodes also need to be able to reach the server on UDP port 8472.  This is used for flannel VXLAN.  If you don't use flannel
-and provide your own custom CNI, then 8472 is not needed by k3s. The node should not listen
-on any other port.  k3s uses reverse tunneling such that the nodes make outbound connections
-to the server and all kubelet traffic runs through that tunnel.
-
-IMPORTANT. The VXLAN port on nodes should not be exposed to the world, it opens up your
-cluster network to accessed by anyone.  Run your nodes behind a firewall/security group that
-disables access to port 8472.
+Open Ports
+----------
+Please reference the [Node Requirements]({{< baseurl >}}/k3s/latest/en/installation/node-requirements/#networking) page for port information.
 
 Flannel
 -------

--- a/content/k3s/latest/en/networking/_index.md
+++ b/content/k3s/latest/en/networking/_index.md
@@ -36,7 +36,7 @@ To disable it, start each server with the `--no-deploy traefik` option.
 Service Load Balancer
 ---------------------
 
-k3s includes a basic service load balancer that uses available host ports.  If you try to create
+K3s includes a basic service load balancer that uses available host ports.  If you try to create
 a load balancer that listens on port 80, for example, it will try to find a free host in the cluster
 for port 80.  If no port is available the load balancer will stay in Pending.
 

--- a/content/k3s/latest/en/quick-start/_index.md
+++ b/content/k3s/latest/en/quick-start/_index.md
@@ -4,20 +4,20 @@ weight: 10
 ---
 
 >**Note:** The intent of this guide is to quickly launch a cluster with default options. It is suitable for production environments if you can accept some downtime in production (e.g. on the Edge). A High-Availiability solution should be utilized if down time is not acceptible.
-The [installation options](../installation) section covers in greater detail how k3s can be set up.
+The [installation options](../installation) section covers in greater detail how K3s can be set up.
 
 > New to Kubernetes? The official Kubernetes docs already have some great tutorials outlining the basics [here](https://kubernetes.io/docs/tutorials/kubernetes-basics/).
 
 Install Script
 --------------
-The k3s `install.sh` script provides a convenient way for installing to systemd or openrc,
-to install k3s as a service just run:
+The K3s `install.sh` script provides a convenient way for installing to systemd or openrc,
+to install K3s as a service just run:
 ```bash
 curl -sfL https://get.k3s.io | sh -
 ```
 
 A kubeconfig file is written to `/etc/rancher/k3s/k3s.yaml` and the service is automatically started or restarted.
-The install script will install k3s and additional utilities, such as `kubectl`, `crictl`, `ctr`, `k3s-killall.sh`, and `k3s-uninstall.sh`.
+The install script will install K3s and additional utilities, such as `kubectl`, `crictl`, `ctr`, `k3s-killall.sh`, and `k3s-uninstall.sh`.
 
 To install on worker nodes and add them to the cluster, we should pass `K3S_URL` along with the `K3S_TOKEN` environment variable. `K3S_TOKEN` is created at `/var/lib/rancher/k3s/server/node-token` on your server. Here is an example showing how to join a node:
 

--- a/content/k3s/latest/en/storage/_index.md
+++ b/content/k3s/latest/en/storage/_index.md
@@ -6,7 +6,7 @@ weight: 30
 When deploying an application that needs to retain data, you’ll need to create persistent storage. Persistent storage allows you to store application data external from the pod running your application. This storage practice allows you to maintain application data, even if the application’s pod fails.
 
 # Local Storage Provider
-k3s comes with Rancher's Local Path Provisioner and this enables the ability to create persistent volume claims out of the box using local storage on the respective node. Below we cover a simple example. For more information please reference the official documentation [here](https://github.com/rancher/local-path-provisioner/blob/master/README.md#usage).
+K3s comes with Rancher's Local Path Provisioner and this enables the ability to create persistent volume claims out of the box using local storage on the respective node. Below we cover a simple example. For more information please reference the official documentation [here](https://github.com/rancher/local-path-provisioner/blob/master/README.md#usage).
 
 Create a hostPath backed persistent volume claim and a pod to utilize it:
 
@@ -61,7 +61,7 @@ Confirm the PV and PVC are created. `kubectl get pv` and `kubectl get pvc` The s
 
 > **Note:** At this time Longhorn only supports amd64.
 
-k3s supports [Longhorn](https://github.com/longhorn/longhorn). Below we cover a simple example. For more information please reference the official documentation [here](https://github.com/longhorn/longhorn/blob/master/README.md).
+K3s supports [Longhorn](https://github.com/longhorn/longhorn). Below we cover a simple example. For more information please reference the official documentation [here](https://github.com/longhorn/longhorn/blob/master/README.md).
 
 Apply the longhorn.yaml to install Longhorn.
 

--- a/content/k3s/latest/en/upgrades/_index.md
+++ b/content/k3s/latest/en/upgrades/_index.md
@@ -5,7 +5,7 @@ weight: 25
 
 >**Note:** When upgrading, upgrade server nodes first one at a time then any worker nodes.
 
-To upgrade k3s from an older version you can re-run the installation script using the same flags, for example:
+To upgrade K3s from an older version you can re-run the installation script using the same flags, for example:
 
 ```sh
 curl -sfL https://get.k3s.io | sh -
@@ -17,14 +17,14 @@ If you want to upgrade to specific version you can run the following command:
 curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=vX.Y.Z-rc1 sh -
 ```
 
-Or to manually upgrade k3s:
+Or to manually upgrade K3s:
 
-1. Download the desired version of k3s from [releases](https://github.com/rancher/k3s/releases/latest)
+1. Download the desired version of K3s from [releases](https://github.com/rancher/k3s/releases/latest)
 2. Install to an appropriate location (normally `/usr/local/bin/k3s`)
 3. Stop the old version
 4. Start the new version
 
-Restarting k3s is supported by the installation script for systemd and openrc.
+Restarting K3s is supported by the installation script for systemd and openrc.
 To restart manually for systemd use:
 ```sh
 sudo systemctl restart k3s


### PR DESCRIPTION
Capitalize k3s > K3s in all areas (except for /installation/ha/_index.md as Craig is handling this in a separate PR)

Small fixes
- faq question fix url for BUILDING.md
- fix node req page to mention port 10250 needed if want to utilize metrics-server

Closes https://github.com/rancher/k3s/issues/1073