### PR TITLE
Change wording for node labels and taints

### DIFF
--- a/content/k3s/latest/en/configuration/_index.md
+++ b/content/k3s/latest/en/configuration/_index.md
@@ -155,7 +155,7 @@ mount namespace.
 Node Labels and Taints
 ----------------------
 
-K3s agents can be configured with options `--node-label` and `--node-taint` which adds set of Labels and Taints to kubelet, the two options only adds labels/taints at registration time, so they can only be added once and not changed after that, an example of options to add new label is:
+K3s agents can be configured with the options `--node-label` and `--node-taint` which adds a label and taint to the kubelet. The two options only add labels and/or taints at registration time, so they can only be added once and not changed after that again by running K3s again. If you want to change node labels and taints after node registration you should use `kubectl`. Below is an example showing how to add labels and a taint:
 ```
      --node-label foo=bar \
      --node-label hello=world \

--- a/content/k3s/latest/en/configuration/_index.md
+++ b/content/k3s/latest/en/configuration/_index.md
@@ -155,7 +155,7 @@ mount namespace.
 Node Labels and Taints
 ----------------------
 
-K3s agents can be configured with the options `--node-label` and `--node-taint` which adds a label and taint to the kubelet. The two options only add labels and/or taints at registration time, so they can only be added once and not changed after that again by running K3s again. If you want to change node labels and taints after node registration you should use `kubectl`. Below is an example showing how to add labels and a taint:
+K3s agents can be configured with the options `--node-label` and `--node-taint` which adds a label and taint to the kubelet. The two options only add labels and/or taints at registration time, so they can only be added once and not changed after that again by running K3s. If you want to change node labels and taints after node registration you should use `kubectl`. Below is an example showing how to add labels and a taint:
 ```
      --node-label foo=bar \
      --node-label hello=world \


### PR DESCRIPTION
- Make it more clear that you can still modify / add / remove labels and taints, just not with k3s after node registration
You can still change these with the kubectl client, so the wording was changed to make this more clear to avoid confusion.