### PR TITLE
Support secure AWS Task IAM Roles

### DIFF
--- a/content/os/v1.x/en/installation/amazon-ecs/_index.md
+++ b/content/os/v1.x/en/installation/amazon-ecs/_index.md
@@ -28,7 +28,16 @@ rancher:
     ECS_AVAILABLE_LOGGING_DRIVERS: |-
       ["json-file","awslogs"]
 # If you have selected a RancherOS AMI that does not have ECS enabled by default,
-# you'll need to enable the system service for the ECS agent.
+# you'll need to enable the system service for the ECS agent, and configure the 
+# iptables rules.
+  sysctl:
+    net.ipv4.conf.all.route_localnet: 1
+  network:
+    post_cmds:
+      - iptables -t nat -A PREROUTING -p tcp -d 169.254.170.2 --dport 80 -j DNAT --to-destination 127.0.0.1:51679
+      - iptables -t nat -A OUTPUT -d 169.254.170.2 -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 51679
+      - iptables --insert DOCKER-USER 1 --in-interface docker+ --destination 169.254.169.254/32 --jump DROP
+      - iptables --insert DOCKER-USER 1 --in-interface docker-sys --destination 169.254.169.254/32 --jump ACCEPT
   services_include:
     amazon-ecs-agent: true
 ```
@@ -48,6 +57,14 @@ rancher:
     ECS_AGENT_VERSION: :v1.9.0
     # If you have selected a RancherOS AMI that does not have ECS enabled by default,
     # you'll need to enable the system service for the ECS agent.
+  sysctl:
+    net.ipv4.conf.all.route_localnet: 1
+  network:
+    post_cmds:
+      - iptables -t nat -A PREROUTING -p tcp -d 169.254.170.2 --dport 80 -j DNAT --to-destination 127.0.0.1:51679
+      - iptables -t nat -A OUTPUT -d 169.254.170.2 -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 51679
+      - iptables --insert DOCKER-USER 1 --in-interface docker+ --destination 169.254.169.254/32 --jump DROP
+      - iptables --insert DOCKER-USER 1 --in-interface docker-sys --destination 169.254.169.254/32 --jump ACCEPT
   services_include:
     amazon-ecs-agent: true
 ```


### PR DESCRIPTION
The Task IAM Rules were extracted verbatim from the Amazon documentation [steps 5, 6, and 7]( https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-install.html)

The latter two rules were adapted from [Amazon documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/instance_IAM_role.html) so that system-docker traffic retains access to the instance-metadata, while traffic from user-docker does not.

This documentation change is not sufficient to get Task IAM Roles to work, it requires a modification to the amazon-ecs-agent service, which will follow in a separate PR to the `os-services` repo.