### PR TITLE
Add note about Helm 3 changes

### DIFF
--- a/content/rancher/v2.x/en/installation/ha/helm-init/_index.md
+++ b/content/rancher/v2.x/en/installation/ha/helm-init/_index.md
@@ -9,6 +9,8 @@ For systems without direct internet access, see [Helm - Air Gap]({{< baseurl >}}
 
 Refer to the [Helm version requirements]({{<baseurl>}}/rancher/v2.x/en/installation/helm-version) to choose a version of Helm to install Rancher.
 
+> **Note:** The installation instructions assume you are using Helm 2. The instructions will be updated for Helm 3 soon. In the meantime, if you want to use Helm 3, refer to [these instructions.](https://github.com/ibrokethecloud/rancher-helm3)
+
 ### Install Tiller on the Cluster
 
 > **Important:** Due to an issue with Helm v2.12.0 and cert-manager, please use Helm v2.12.1 or higher.

--- a/content/rancher/v2.x/en/installation/ha/helm-rancher/_index.md
+++ b/content/rancher/v2.x/en/installation/ha/helm-rancher/_index.md
@@ -9,6 +9,8 @@ For systems without direct internet access, see [Air Gap: High Availability Inst
 
 Refer to the [Helm version requirements]({{<baseurl>}}/rancher/v2.x/en/installation/helm-version) to choose a version of Helm to install Rancher.
 
+> **Note:** The installation instructions assume you are using Helm 2. The instructions will be updated for Helm 3 soon. In the meantime, if you want to use Helm 3, refer to [these instructions.](https://github.com/ibrokethecloud/rancher-helm3)
+
 ### Add the Helm Chart Repository
 
 Use `helm repo add` command to add the Helm chart repository that contains charts to install Rancher. For more information about the repository choices and which is best for your use case, see [Choosing a Version of Rancher]({{< baseurl >}}/rancher/v2.x/en/installation/server-tags/#helm-chart-repositories).

--- a/content/rancher/v2.x/en/installation/helm-version/_index.md
+++ b/content/rancher/v2.x/en/installation/helm-version/_index.md
@@ -5,6 +5,8 @@ weight: 400
 
 This section contains the requirements for Helm, which is the tool used to install Rancher on a high-availability Kubernetes cluster.
 
+> **Note:** The installation instructions assume you are using Helm 2. The instructions will be updated for Helm 3 soon. In the meantime, if you want to use Helm 3, refer to [these instructions.](https://github.com/ibrokethecloud/rancher-helm3)
+
 - Helm v2.15.1 or higher is required for Kubernetes v1.16. For the default Kubernetes version, refer to the [release notes](https://github.com/rancher/rke/releases) for the version of RKE that you are using.
 - Helm v2.15.0 should not be used, because of an issue with converting/comparing numbers.
 - Helm v2.12.0 should not be used, because of an issue with `cert-manager`.


### PR DESCRIPTION
This PR is in reference to this comment https://rancher.slack.com/archives/C6U4L2DS9/p1574827741151800 and this thread in Slack: https://rancher.slack.com/archives/C6U4L2DS9/p1574825644150200

Basically, this note is just to clarify that our HA installation instructions are for Helm 2, because it will take a little while to pull in the Helm 3 instructions.

https://github.com/rancher/docs/issues/2029