### PR TITLE
Minor changes to vSphere docs

### DIFF
--- a/content/rancher/v2.x/en/cluster-provisioning/rke-clusters/node-pools/vsphere/_index.md
+++ b/content/rancher/v2.x/en/cluster-provisioning/rke-clusters/node-pools/vsphere/_index.md
@@ -34,10 +34,12 @@ For the fields to be populated, your setup needs to fulfill the [prerequisites.]
 
 ### More Supported Operating Systems
 
-As of Rancher v2.3.3+, you can provision VMs with any operating system that supports cloud init.
+In Rancher v2.3.3+, you can provision VMs with any operating system that supports `cloud-init`. Only YAML format is supported for the [cloud config.](https://cloudinit.readthedocs.io/en/latest/topics/examples.html)
 
 In Rancher prior to v2.3.3, the vSphere node driver included in Rancher only supported the provisioning of VMs with [RancherOS]({{<baseurl>}}/os/v1.x/en/) as the guest operating system.
 
 # Video Walkthrough of v2.3.3 Node Template Features
 
-In [this YouTube video,](https://www.youtube.com/watch?v=dPIwg6x1AlU) we demonstrate how to set up a node template with the new features designed to help you bring cloud operations to on-premises clusters.
+In this YouTube video, we demonstrate how to set up a node template with the new features designed to help you bring cloud operations to on-premises clusters.
+
+{{< youtube id="dPIwg6x1AlU">}}

--- a/content/rancher/v2.x/en/cluster-provisioning/rke-clusters/node-pools/vsphere/provisioning-vsphere-clusters/_index.md
+++ b/content/rancher/v2.x/en/cluster-provisioning/rke-clusters/node-pools/vsphere/provisioning-vsphere-clusters/_index.md
@@ -215,11 +215,11 @@ In the custom attributes, Rancher will let you select all the custom attributes 
 {{% /tab %}}
 {{% /tabs %}}
 
-### G. Optional: Configure Cloud Init
+### G. Optional: Configure cloud-init
 
 [Cloud-init](https://cloud-init.io/) is a tool that applies user data to your nodes when they boot for the first time.
 
-The configuration file for `cloud-init` is named `cloud-config.yml.` In the **Cloud Init** field, it is optional to enter a file name or URL pointing to a `cloud-config.yml` file.
+The configuration file for `cloud-init` is named `cloud-config.yml.` In the **Cloud Init** field, it is optional to enter a file name or URL pointing to a `cloud-config.yml` file. Only YAML format is supported for the cloud config.
 
 You can use `cloud-init` to automate tasks that should happen when the instance boots, such as creating users, running shell commands, adding a load balancer, or preinstalling Kubernetes on the VM.
 


### PR DESCRIPTION
This PR clarifies that for vSphere node templates, the operating system must support cloud-init, and only YAML format is supported for the cloud config. It addresses this issue https://github.com/rancher/docs/issues/2038

I've also embedded the vSphere webinar/meetup YouTube video so you don't have to leave the docs.