### PR TITLE
Fix merge conflict marks

### DIFF
--- a/content/rancher/v2.x/en/admin-settings/rbac/global-permissions/_index.md
+++ b/content/rancher/v2.x/en/admin-settings/rbac/global-permissions/_index.md
@@ -92,9 +92,6 @@ To change the default global permissions that are assigned to external users upo
 
 1. If you want to remove a default permission, edit the permission and select **No** from **New User Default**.
 
-<<<<<<< HEAD
-**Result:** The default global permissions are configured based on your changes. Permissions assigned to new users display a check in the **New User Default** column.
-=======
 **Result:** The default global permissions are configured based on your changes. Permissions assigned to new users display a check in the **New User Default** column.
 
 ### Configuring Global Permissions for Individual Users
@@ -112,5 +109,3 @@ To configure permission for a user,
 1. Click **Save.**
 
 > **Result:** The user's global permissions have been updated.
-
->>>>>>> Update and clarify docs on global and cluster permissions


### PR DESCRIPTION
Hi.

While reading the ranchers docs I stumbled upon that page.
https://rancher.com/docs/rancher/v2.x/en/admin-settings/rbac/global-permissions/
The bottom is a bit messed up, and it seems to be the result of git merge conflict marks, which had not been removed.