### PR TITLE
Add Docker installation scripts to docs

### DIFF
--- a/content/rancher/v2.x/en/installation/requirements/_index.md
+++ b/content/rancher/v2.x/en/installation/requirements/_index.md
@@ -35,7 +35,9 @@ All supported operating systems are 64-bit x86.
 
 If you plan to run Rancher on ARM64, see [Running on ARM64 (Experimental).]({{<baseurl>}}/rancher/v2.x/en/installation/options/arm64-platform/)
 
-For information on how to install Docker, refer to the offical [Docker documentation.](https://docs.docker.com/)
+### Installing Docker
+
+Docker can be installed by following the steps in the offical [Docker documentation.](https://docs.docker.com/) Rancher also provides [scripts]({{<baseurl>}}/rancher/v2.x/en/installation/requirements/installing-docker) to install Docker with one command.
 
 # Hardware Requirements
 

--- a/content/rancher/v2.x/en/installation/requirements/installing-docker/_index.md
+++ b/content/rancher/v2.x/en/installation/requirements/installing-docker/_index.md
@@ -1,0 +1,18 @@
+---
+title: Installing Docker
+weight: 1
+---
+
+Docker is required to be installed on any node that runs the Rancher server.
+
+There are a couple of options for installing Docker. One option is to refer to the [official Docker documentation](https://docs.docker.com/install/) about how to install Docker on Linux. The steps will vary based on the Linux distribution.
+
+Another option is to use one of Rancher's Docker installation scripts, which are available for most recent versions of Docker.
+
+For example, this command could be used to install Docker 18.09 on Ubuntu:
+
+```
+curl https://releases.rancher.com/install-docker/18.09.sh | sh
+```
+
+To find out whether a script is available for installing a certain Docker version, refer to this [GitHub repository,](https://github.com/rancher/install-docker) which contains all of Rancher's Docker installation scripts.


### PR DESCRIPTION
@Tejeev said some customers need more guidance on installing Docker, so I thought it might help if we link to Rancher's convenient Docker installation scripts in the docs.