### PR TITLE
Add new network-options page to Install section

### DIFF
--- a/content/k3s/latest/en/installation/network-options/_index.md
+++ b/content/k3s/latest/en/installation/network-options/_index.md
@@ -1,0 +1,54 @@
+---
+title: "Network Options"
+weight: 25
+---
+
+> **Note:** Please reference the [Networking]({<< baseurl >>}/k3s/latest/en/networking) page for information about CoreDNS, Traefik, and the Service LB.
+
+By default, K3s will run with flannel as the CNI, using VXLAN as the default backend. To change the CNI, refer to the section on configuring a custom CNI. To change the flannel backend, refer to the flannel options section.
+
+### Flannel Options
+
+The default backend for flannel is VXLAN. If you would like to use a different backend with flannel, use one of the options in the table below.
+
+If you wish to use WireGuard as your flannel backend it may require additional kernel modules. Please see the [WireGuard Install Guide](https://www.wireguard.com/install/) for details. The WireGuard install steps will ensure the appropriate kernel modules are installed for your operating system. You need to install WireGuard on every node, both server and agents before attempting to leverage the WireGuard flannel backend option.
+
+  CLI Flag and Value | Description
+  -------------------|------------
+ <span style="white-space: nowrap">`--flannel-backend=vxlan`</span> | (Default) Uses the VXLAN backend. |
+ <span style="white-space: nowrap">`--flannel-backend=ipsec`</span> | Uses the IPSEC backend which encrypts network traffic. |
+ <span style="white-space: nowrap">`--flannel-backend=wireguard`</span> | Uses the WireGuard backend which encrypts network traffic. May require additional kernel modules and configuration. |
+
+### Custom CNI
+
+Run K3s with `--flannel-backend=none` and install your CNI of choice. IP Forwarding should be enabled for Canal and Calico. Please reference the steps below.
+
+{{% tabs %}}
+{{% tab "Canal" %}}
+
+Visit the [Project Calico Docs](https://docs.projectcalico.org/) website. Follow the steps to install Canal. Modify the Canal YAML so that IP forwarding is allowed in the container_settings section, for example:
+
+```
+"container_settings": {
+              "allow_ip_forwarding": true
+          }
+```
+
+Applyl the Canal YAML.
+
+{{% /tab %}}
+{{% tab "Calico" %}}
+
+Follow the [Calico CNI Plugins Guide](https://docs.projectcalico.org/master/reference/cni-plugin/configuration). Modify the Calico YAML so that IP forwarding is allowed in the container_settings section, for example:
+
+```
+"container_settings": {
+              "allow_ip_forwarding": true
+          }
+```
+
+Apply the Calico YAML.
+
+{{% /tab %}}
+{{% /tabs %}}
+

--- a/content/k3s/latest/en/installation/network-options/_index.md
+++ b/content/k3s/latest/en/installation/network-options/_index.md
@@ -36,6 +36,14 @@ Visit the [Project Calico Docs](https://docs.projectcalico.org/) website. Follow
 
 Applyl the Canal YAML.
 
+Ensure the settings were applied by running the following command on the host:
+
+```
+cat /etc/cni/net.d/10-calico.conflist
+```
+
+You should see that ip forwarding is set to true.
+
 {{% /tab %}}
 {{% tab "Calico" %}}
 
@@ -48,6 +56,15 @@ Follow the [Calico CNI Plugins Guide](https://docs.projectcalico.org/master/refe
 ```
 
 Apply the Calico YAML.
+
+Ensure the settings were applied by running the following command on the host:
+
+```
+cat /etc/cni/net.d/10-canal.conflist
+```
+
+You should see that ip forwarding is set to true.
+
 
 {{% /tab %}}
 {{% /tabs %}}

--- a/content/k3s/latest/en/installation/network-options/_index.md
+++ b/content/k3s/latest/en/installation/network-options/_index.md
@@ -5,11 +5,11 @@ weight: 25
 
 > **Note:** Please reference the [Networking]({<< baseurl >>}/k3s/latest/en/networking) page for information about CoreDNS, Traefik, and the Service LB.
 
-By default, K3s will run with flannel as the CNI, using VXLAN as the default backend. To change the CNI, refer to the section on configuring a custom CNI. To change the flannel backend, refer to the flannel options section.
+By default, K3s will run with flannel as the CNI, using VXLAN as the default backend. To change the CNI, refer to the section on configuring a [custom CNI](#custom-cni). To change the flannel backend, refer to the flannel options section.
 
 ### Flannel Options
 
-The default backend for flannel is VXLAN. If you would like to use a different backend with flannel, use one of the options in the table below.
+The default backend for flannel is VXLAN. To enable encryption, pass the IPSec (Internet Protocol Security) or WireGuard options below.
 
 If you wish to use WireGuard as your flannel backend it may require additional kernel modules. Please see the [WireGuard Install Guide](https://www.wireguard.com/install/) for details. The WireGuard install steps will ensure the appropriate kernel modules are installed for your operating system. You need to install WireGuard on every node, both server and agents before attempting to leverage the WireGuard flannel backend option.
 
@@ -42,7 +42,7 @@ Ensure the settings were applied by running the following command on the host:
 cat /etc/cni/net.d/10-calico.conflist
 ```
 
-You should see that ip forwarding is set to true.
+You should see that IP forwarding is set to true.
 
 {{% /tab %}}
 {{% tab "Calico" %}}
@@ -63,7 +63,7 @@ Ensure the settings were applied by running the following command on the host:
 cat /etc/cni/net.d/10-canal.conflist
 ```
 
-You should see that ip forwarding is set to true.
+You should see that IP forwarding is set to true.
 
 
 {{% /tab %}}

--- a/content/k3s/latest/en/networking/_index.md
+++ b/content/k3s/latest/en/networking/_index.md
@@ -3,16 +3,11 @@ title: "Networking"
 weight: 35
 ---
 
+>**Note:** CNI options are covered in detail on the [Installation Network Options]({{< baseurl >}}/k3s/latest/en/installation/network-options/) page. Please reference that page for details on Flannel and the various flannel backend options or how to set up your own CNI.
+
 Open Ports
 ----------
 Please reference the [Node Requirements]({{< baseurl >}}/k3s/latest/en/installation/node-requirements/#networking) page for port information.
-
-Flannel
--------
-
-Flannel is included by default, if you don't want flannel then run each agent with `--no-flannel` option.
-
-In this setup you will still be required to install your own CNI driver.  More info [here](https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/#pod-network)
 
 CoreDNS
 -------


### PR DESCRIPTION
- Adds this new page describing the flannel backend options and how to set up your own CNI
- Tweaks the existing Networking page
- Adds hyperlinks linking the two pages together.

Note: Intent is that the main Networking page is for CoreDNS, Traefik, ServiceLB, and in the future other general high level networking discussions. Whereas the new "network-options" page under the Installation section is for specific things that should be considered at install-time for K3s such as the flannel backend or other CNIs.