### PR TITLE
Fix broken hyperlink on networking-options page

### DIFF
--- a/content/k3s/latest/en/installation/network-options/_index.md
+++ b/content/k3s/latest/en/installation/network-options/_index.md
@@ -3,7 +3,7 @@ title: "Network Options"
 weight: 25
 ---
 
-> **Note:** Please reference the [Networking]({<< baseurl >>}/k3s/latest/en/networking) page for information about CoreDNS, Traefik, and the Service LB.
+> **Note:** Please reference the [Networking]({{< baseurl >}}/k3s/latest/en/networking) page for information about CoreDNS, Traefik, and the Service LB.
 
 By default, K3s will run with flannel as the CNI, using VXLAN as the default backend. To change the CNI, refer to the section on configuring a [custom CNI](#custom-cni). To change the flannel backend, refer to the flannel options section.
 


### PR DESCRIPTION
Fixes bad hyperlink from https://github.com/rancher/docs/pull/2063/files#diff-21dbbc32348fca9505741f0371c9e7c8R6