### PR TITLE
Add list of ports required for combination etcd/controlplane/worker nodes

### DIFF
--- a/content/rancher/v2.x/en/installation/requirements/_index.md
+++ b/content/rancher/v2.x/en/installation/requirements/_index.md
@@ -2,7 +2,6 @@
 title: Installation Requirements
 weight: 1
 aliases:
-  - /rancher/v2.x/en/hosts/amazon/#required-ports-for-rancher-to-work/
   - /rancher/v2.x/en/installation/references
 ---
 
@@ -92,15 +91,20 @@ Each node used should have a static IP configured, regardless of whether you are
 
 This section describes the port requirements for nodes running the `rancher/rancher` container.
 
-The port requirements are different depending on whether you are installing Rancher on a single node or on a high-availability Kubernetes cluster. For a single node, you only need to open the [ports required to enable Rancher to communicate with user clusters.](#port-requirements-for-enabling-rancher-to-communicate-with-user-clusters) For a high-availability installation, the same ports need to be opened, as well as additional [ports required to set up the Kubernetes cluster](#additional-port-requirements-for-nodes-in-high-availability-rancher-installations) that Rancher is installed on.
+The port requirements are different depending on whether you are installing Rancher on a single node or on a high-availability Kubernetes cluster.
 
-### Port Requirements for Enabling Rancher to Communicate with User Clusters
+- **For a single-node installation,** you only need to open the ports required to enable Rancher to communicate with downstream user clusters.
+- **For a high-availability installation,** the same ports need to be opened, as well as additional ports required to set up the Kubernetes cluster that Rancher is installed on.
 
-For a single-node installation, you only need to open the ports for the Rancher management plane. These ports are opened to allow the Rancher server to communicate with the Kubernetes clusters that will run your apps and services.
+{{% tabs %}}
+{{% tab "HA Install Port Requirements" %}}
+### Ports for Communication with Downstream Clusters
 
-For a high-availability installation, these rules apply as well as the [port requirements to set up the Kubernetes cluster](#additional-port-requirements-for-nodes-in-high-availability-rancher-installations) that Rancher is installed on.
+To communicate with downstream clusters, Rancher requires different ports to be open depending on the infrastructure you are using.
 
-The port requirements are different based the infrastructure you are using. For example, if you are deploying Rancher on nodes hosted by an infrastructure provider, port `22` must be open for SSH. The following diagram depicts the ports that are opened for each [cluster type]({{<baseurl>}}/rancher/v2.x/en/cluster-provisioning).
+For example, if you are deploying Rancher on nodes hosted by an infrastructure provider, port `22` must be open for SSH.
+
+The following diagram depicts the ports that are opened for each [cluster type]({{<baseurl>}}/rancher/v2.x/en/cluster-provisioning).
 
 <figcaption>Port Requirements for the Rancher Management Plane</figcaption>
 
@@ -126,8 +130,78 @@ The following tables break down the port requirements for inbound and outbound t
 
 **Note** Rancher nodes may also require additional outbound access for any external [authentication provider]({{< baseurl >}}/rancher/v2.x/en/admin-settings/authentication/) which is configured (LDAP for example).
 
-### Additional Port Requirements for Nodes in High-Availability Rancher Installations
+### Additional Port Requirements for Nodes in an HA/Kubernetes Cluster
 
 You will need to open additional ports to the launch the Kubernetes cluster that is required for a high-availability installation of Rancher.
 
-The ports that need to be opened for each node depend on the node's Kubernetes role: etcd, controlplane, or worker. For a breakdown of the port requirements for each role, refer to the [port requirements for the Rancher Kubernetes Engine.]({{<baseurl>}}/rke/latest/en/os/#ports)
+If you follow the Rancher installation documentation for setting up a Kubernetes cluster using RKE, you will set up a cluster in which all three nodes have all three roles: etcd, controlplane, and worker. In that case, you can refer to this list of requirements for each node with all three roles:
+
+<figcaption>Inbound Rules for Nodes with All Three Roles: etcd, Controlplane, and Worker</figcaption>
+
+Protocol | Port | Source | Description
+-----------|------|----------|--------------
+TCP | 22 | Linux worker nodes only, and any network that you want to be able to remotely access this node from. | Remote access over SSH
+TCP | 80 | Any source that consumes Ingress services | Ingress controller (HTTP)
+TCP | 443 | Any source that consumes Ingress services | Ingress controller (HTTPS)
+TCP | 2376 | Rancher nodes | Docker daemon TLS port used by Docker Machine (only needed when using Node Driver/Templates)
+TCP | 2379 | etcd nodes and controlplane nodes | etcd client requests
+TCP | 2380 | etcd nodes and controlplane nodes | etcd peer communication
+TCP | 3389 | Windows worker nodes only, and any network that you want to be able to remotely access this node from. | Remote access over RDP
+TCP | 6443 | etcd nodes, controlplane nodes, and worker nodes | Kubernetes apiserver
+UDP | 8472 | etcd nodes, controlplane nodes, and worker nodes | Canal/Flannel VXLAN overlay networking
+TCP | 9099 | the node itself (local traffic, not across nodes) | Canal/Flannel livenessProbe/readinessProbe
+TCP | 10250 | controlplane nodes | kubelet
+TCP | 10254 | the node itself (local traffic, not across nodes) | Ingress controller livenessProbe/readinessProbe
+TCP/UDP | 30000-32767 | Any source that consumes NodePort services | NodePort port range
+
+<figcaption>Outbound Rules for Nodes with All Three Roles: etcd, Controlplane, and Worker</figcaption>
+
+Protocol | Port | Source | Destination | Description
+-----------|------|----------|---------------|--------------
+TCP | 22 | RKE node | Any node configured in Cluster Configuration File | SSH provisioning of node by RKE
+TCP | 443 | Rancher nodes | Rancher agent | 
+TCP | 2379 | etcd nodes | etcd client requests | 
+TCP | 2380 | etcd nodes | etcd peer communication | 
+TCP | 6443 | RKE node | controlplane nodes | Kubernetes API server
+TCP | 6443 | controlplane nodes | Kubernetes API server | 
+UDP | 8472 | etcd nodes, controlplane nodes, and worker nodes | Canal/Flannel VXLAN overlay networking | 
+TCP | 9099 | the node itself (local traffic, not across nodes) | Canal/Flannel livenessProbe/readinessProbe | 
+TCP | 10250 | etcd nodes, controlplane nodes, and worker nodes | kubelet | 
+TCP | 10254 | the node itself (local traffic, not across nodes) | Ingress controller livenessProbe/readinessProbe
+
+The ports that need to be opened for each node depend on the node's Kubernetes role: etcd, controlplane, or worker. If you installed Rancher on a Kubernetes cluster that doesn't have all three roles on each node, refer to the [port requirements for the Rancher Kubernetes Engine (RKE).]({{<baseurl>}}/rke/latest/en/os/#ports) The RKE docs show a breakdown of the port requirements for each role.
+{{% /tab %}}
+{{% tab "Single Node Port Requirements" %}}
+### Ports for Communication with Downstream Clusters
+
+To communicate with downstream clusters, Rancher requires different ports to be open depending on the infrastructure you are using.
+
+For example, if you are deploying Rancher on nodes hosted by an infrastructure provider, port `22` must be open for SSH.
+
+The following diagram depicts the ports that are opened for each [cluster type]({{<baseurl>}}/rancher/v2.x/en/cluster-provisioning).
+
+<figcaption>Port Requirements for the Rancher Management Plane</figcaption>
+
+![Basic Port Requirements]({{<baseurl>}}/img/rancher/port-communications.svg)
+
+The following tables break down the port requirements for inbound and outbound traffic:
+
+<figcaption>Inbound Rules for Rancher Nodes</figcaption>
+
+| Protocol | Port | Source                                                                                                                                                                                | Description                                          |
+| -------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| TCP      | 80   | Load balancer/proxy that does external SSL termination                                                                                                                                | Rancher UI/API when external SSL termination is used |
+| TCP      | 443  | <ul><li>etcd nodes</li><li>controlplane nodes</li><li>worker nodes</li><li>hosted/imported Kubernetes</li><li>any source that needs to be able to use the Rancher UI or API</li></ul> | Rancher agent, Rancher UI/API, kubectl               |
+
+<figcaption>Outbound Rules for Rancher Nodes</figcaption>
+
+| Protocol | Port | Source                                                   | Description                                   |
+| -------- | ---- | -------------------------------------------------------- | --------------------------------------------- |
+| TCP      | 22   | Any node IP from a node created using Node Driver        | SSH provisioning of nodes using Node Driver   |
+| TCP      | 443  | `35.160.43.145/32`, `35.167.242.46/32`, `52.33.59.17/32` | git.rancher.io (catalogs)                     |
+| TCP      | 2376 | Any node IP from a node created using Node driver        | Docker daemon TLS port used by Docker Machine |
+| TCP      | 6443 | Hosted/Imported Kubernetes API                           | Kubernetes API server                         |
+
+**Note** Rancher nodes may also require additional outbound access for any external [authentication provider]({{< baseurl >}}/rancher/v2.x/en/admin-settings/authentication/) which is configured (LDAP for example).
+{{% /tab %}}
+{{% /tabs %}}

--- a/layouts/partials/page-edit.html
+++ b/layouts/partials/page-edit.html
@@ -1,3 +1,4 @@
+{{ if not .Lastmod.IsZero }}Last updated on {{ .Lastmod.Format "Jan 2, 2006" }}{{ end }}
 <div class="buttons-container">
     <a href="{{.Site.Params.ghdocsrepo}}/edit/master/content/{{.File.Path}}" class="btn bg-link">
         <button class="button has-icon-right">


### PR DESCRIPTION
@Tejeev said customers are looking for a simple list of inbound and outbound port requirements for people who have done an HA rancher cluster exactly according to the installation documents.

The information was there, in the matrix that shows the inbound and outbound requirements of each role. But I figured, it's a little overcomplicated to tell people to refer to the specific breakdown of requirements for etcd, controlplane, and worker nodes, when the docs told people that we are using all the same roles for each node. So all the Kubernetes cluster nodes should be able to have the same inbound and outbound ports.

I made this list by looking at the inbound ports for etcd, controlplane, and worker nodes in the RKE docs, and deduping the list so that what remains is what you need for a node with all three roles. I did the same for deduping the outbound ports. Then I made tabs in the port requirements section and put all this Kubernetes port information on the default tab for HA install port requirements.

In this PR I have also tried to do a better job of making it clear that extra ports must be open for HA installs.