### PR TITLE
Remove dash from suggested HA db name

### DIFF
--- a/content/k3s/latest/en/_index.md
+++ b/content/k3s/latest/en/_index.md
@@ -1,7 +1,6 @@
 ---
 title: "K3s - 5 less than K8s"
 shortTitle: K3s
-date: 2019-02-05T09:52:46-07:00
 name: "menu"
 ---
 

--- a/content/k3s/latest/en/installation/datastore/_index.md
+++ b/content/k3s/latest/en/installation/datastore/_index.md
@@ -80,14 +80,14 @@ The above assumes a typical three node etcd cluster. The parameter can accept on
 {{% /tab %}}
 {{% /tabs %}}
 
-<br/>Based on the above, the following example command could be used to launch a server instance that connects to a PostgresSQL database named k3s-db:
+<br/>Based on the above, the following example command could be used to launch a server instance that connects to a PostgresSQL database named k3s:
 ```
-K3S_DATASTORE_ENDPOINT='postgres://username:password@hostname:5432/k3s-db' k3s server
+K3S_DATASTORE_ENDPOINT='postgres://username:password@hostname:5432/k3s' k3s server
 ```
 
 And the following example could be used to connect to a MySQL database using client certificate authentication:
 ```
-K3S_DATASTORE_ENDPOINT='mysql://username:password@tcp(hostname:3306)/k3s-db' \
+K3S_DATASTORE_ENDPOINT='mysql://username:password@tcp(hostname:3306)/k3s' \
 K3S_DATASTORE_CERTFILE='/path/to/client.crt' \
 K3S_DATASTORE_KEYFILE='/path/to/client.key' \
 k3s server


### PR DESCRIPTION
Remove the dash from the suggested HA dbname because this will cause issues if not escaped properly. Since escaping it would make things more complicated we just don't mention a dbname with a dash in it now. The docs reference where to get DSN details for the various DB providers -- users should reference that material if they are using special chars and I think most people would know to check this.

Remove date from main _index.md page
- Most contributors won't know to always update this date
- If we actually  want to keep this date (which is rendered on the website) we need to ensure all contributors always update the date...

Remove "k3s-db" and replace with "k3s" for dbname
- PostgreSQL/MySQL already have links to docs for DSN that users could reference to escape special chars
- Make suggested command work out of the box (won't run into an issue with unescaped dash in db name any more)

Closes https://github.com/rancher/k3s/issues/1136