### PR TITLE
Fixed typo in Pen Test Links

### DIFF
--- a/content/rancher/v2.x/en/security/_index.md
+++ b/content/rancher/v2.x/en/security/_index.md
@@ -45,8 +45,8 @@ Rancher periodically hires third parties to perform security audits and penetrat
 
 Results:
 
-- [Cure53 Pen Test - 7/2019](https://relesases.rancher.com/documents/security/pen-tests/2019/RAN-01-cure53-report.final.pdf)
-- [Untamed Theory Pen Test- 3/2019](https://relesases.rancher.com/documents/security/pen-tests/2019/UntamedTheory-Rancher_SecurityAssessment-20190712_v5.pdf)
+- [Cure53 Pen Test - 7/2019](https://releases.rancher.com/documents/security/pen-tests/2019/RAN-01-cure53-report.final.pdf)
+- [Untamed Theory Pen Test- 3/2019](https://releases.rancher.com/documents/security/pen-tests/2019/UntamedTheory-Rancher_SecurityAssessment-20190712_v5.pdf)
 
 ### Rancher CVEs and Resolutions
 


### PR DESCRIPTION
Pen Test links had `relesases` instead of `releases`. With the typo fixed both links now work.