### PR TITLE
Updated info about using kubeconfig

### DIFF
--- a/content/k3s/latest/en/configuration/_index.md
+++ b/content/k3s/latest/en/configuration/_index.md
@@ -90,7 +90,7 @@ Accessing Cluster from Outside
 -----------------------------
 
 Copy `/etc/rancher/k3s/k3s.yaml` on your machine located outside the cluster as `~/.kube/config`. Then replace
-"localhost" with the IP or name of your K3s server. `kubectl` can now manage your K3s cluster.
+"127.0.0.1" with the IP or name of your K3s server. `kubectl` can now manage your K3s cluster.
 
 Node Registration
 -----------------


### PR DESCRIPTION
K3S no longer puts "localhost" in kubeconfig but "127.0.0.1" instead. Therefore - updated instructions.