### PR TITLE
Say how to avoid creating unusable namespaces with kubectl

### DIFF
--- a/content/rancher/v2.x/en/cluster-admin/projects-and-namespaces/_index.md
+++ b/content/rancher/v2.x/en/cluster-admin/projects-and-namespaces/_index.md
@@ -48,7 +48,9 @@ You can assign the following resources directly to namespaces:
 - [Registries]({{<baseurl>}}/rancher/v2.x/en/k8s-in-rancher/registries/)
 - [Secrets]({{<baseurl>}}/rancher/v2.x/en/k8s-in-rancher/secrets/)
 
->**Note:** Although you can assign role-based access to namespaces in the base version of Kubernetes, you cannot assign roles to namespaces in Rancher. Instead, assign role-based access at the project level.
+To manage permissions in a vanilla Kubernetes cluster, cluster admins configure role-based access policies for each namespace. With Rancher user permissions are assigned on the project level instead and automatically inherited by any namespace owned by the particular project.
+
+> **Note:** If you create a namespace with `kubectl`, it may be unusable because `kubectl` doesn't require your new namespace to be scoped within a project that you have access to. If your permissions are restricted to the project level, it is better to [create a namespace through Rancher]({{<baseurl>}}/rancher/v2.x/en/project-admin/namespaces/#creating-namespaces) to ensure that you will have permission to access the namespace.
 
 For more information on creating and moving namespaces, see [Namespaces]({{<baseurl>}}/rancher/v2.x/en/project-admin/namespaces/).
 
@@ -57,6 +59,20 @@ For more information on creating and moving namespaces, see [Namespaces]({{<base
 Within Rancher, a project can contain multiple namespaces and access control policies, making it possible to organize and isolate resources within the project.
 
 A project is a concept introduced by Rancher that allows you manage multiple namespaces as a group and perform Kubernetes operations in them. The Rancher UI provides features for [project administration]({{<baseurl>}}/rancher/v2.x/en/project-admin/) and for [managing applications within projects.]({{<baseurl>}}/rancher/v2.x/en/k8s-in-rancher/)
+
+This section covers the following topics:
+
+- [Projects](#projects)
+  - [Default project](#default-project)
+  - [System project](#system-project)
+  - [Authorization](#authorization)
+  - [Pod security policies](#pod-security-policies)
+  - [Creating projects](#creating-projects)
+- [Switching between clusters and projects](#switching-between-clusters-and-projects)
+- [Namespaces](#namespaces)
+
+
+# Projects
 
 In terms of hierarchy:
 

--- a/content/rancher/v2.x/en/cluster-admin/projects-and-namespaces/_index.md
+++ b/content/rancher/v2.x/en/cluster-admin/projects-and-namespaces/_index.md
@@ -48,31 +48,13 @@ You can assign the following resources directly to namespaces:
 - [Registries]({{<baseurl>}}/rancher/v2.x/en/k8s-in-rancher/registries/)
 - [Secrets]({{<baseurl>}}/rancher/v2.x/en/k8s-in-rancher/secrets/)
 
-To manage permissions in a vanilla Kubernetes cluster, cluster admins configure role-based access policies for each namespace. With Rancher user permissions are assigned on the project level instead and automatically inherited by any namespace owned by the particular project.
+To manage permissions in a vanilla Kubernetes cluster, cluster admins configure role-based access policies for each namespace. With Rancher, user permissions are assigned on the project level instead, and permissions are automatically inherited by any namespace owned by the particular project.
 
 > **Note:** If you create a namespace with `kubectl`, it may be unusable because `kubectl` doesn't require your new namespace to be scoped within a project that you have access to. If your permissions are restricted to the project level, it is better to [create a namespace through Rancher]({{<baseurl>}}/rancher/v2.x/en/project-admin/namespaces/#creating-namespaces) to ensure that you will have permission to access the namespace.
 
 For more information on creating and moving namespaces, see [Namespaces]({{<baseurl>}}/rancher/v2.x/en/project-admin/namespaces/).
 
 # About Projects
-
-Within Rancher, a project can contain multiple namespaces and access control policies, making it possible to organize and isolate resources within the project.
-
-A project is a concept introduced by Rancher that allows you manage multiple namespaces as a group and perform Kubernetes operations in them. The Rancher UI provides features for [project administration]({{<baseurl>}}/rancher/v2.x/en/project-admin/) and for [managing applications within projects.]({{<baseurl>}}/rancher/v2.x/en/k8s-in-rancher/)
-
-This section covers the following topics:
-
-- [Projects](#projects)
-  - [Default project](#default-project)
-  - [System project](#system-project)
-  - [Authorization](#authorization)
-  - [Pod security policies](#pod-security-policies)
-  - [Creating projects](#creating-projects)
-- [Switching between clusters and projects](#switching-between-clusters-and-projects)
-- [Namespaces](#namespaces)
-
-
-# Projects
 
 In terms of hierarchy:
 
@@ -83,9 +65,9 @@ You can use projects to support multi-tenancy, so that a team can access a proje
 
 In the base version of Kubernetes, features like role-based access rights or cluster resources are assigned to individual namespaces. A project allows you to save time by giving an individual or a team access to multiple namespaces simultaneously.
 
-You can use projects to perform actions like:
+You can use projects to perform actions such as:
 
-- Assign users access to a group of namespaces (i.e., [project membership]({{<baseurl>}}/rancher/v2.x/en/k8s-in-rancher/projects-and-namespaces/project-members)).
+- Assign users to a group of namespaces (i.e., [project membership]({{<baseurl>}}/rancher/v2.x/en/k8s-in-rancher/projects-and-namespaces/project-members)).
 - Assign users specific roles in a project. A role can be owner, member, read-only, or [custom]({{<baseurl>}}/rancher/v2.x/en/admin-settings/rbac/default-custom-roles/).
 - Assign resources to the project.
 - Assign Pod Security Policies.

--- a/content/rancher/v2.x/en/project-admin/namespaces/_index.md
+++ b/content/rancher/v2.x/en/project-admin/namespaces/_index.md
@@ -18,9 +18,10 @@ Resources that you can assign directly to namespaces include:
 - [Registries]({{< baseurl >}}/rancher/v2.x/en/k8s-in-rancher/registries/)
 - [Secrets]({{< baseurl >}}/rancher/v2.x/en/k8s-in-rancher/secrets/)
 
-Although you can assign role-based access to namespaces in the base version of Kubernetes, you cannot assign roles to namespaces in Rancher. Instead, assign role-based access at the project level.
+To manage permissions in a vanilla Kubernetes cluster, cluster admins configure role-based access policies for each namespace. With Rancher, user permissions are assigned on the project level instead, and permissions are automatically inherited by any namespace owned by the particular project.
 
-> **Note:** If you create a namespace with `kubectl`, it may be unusable because `kubectl` doesn't require your new namespace to be scoped within a project that you have access to. If your permissions are restricted to the project level, it is better to [create a namespace through Rancher](#creating-namespaces) to ensure that you will have permission to access the namespace.
+> **Note:** If you create a namespace with `kubectl`, it may be unusable because `kubectl` doesn't require your new namespace to be scoped within a project that you have access to. If your permissions are restricted to the project level, it is better to [create a namespace through Rancher]({{<baseurl>}}/rancher/v2.x/en/project-admin/namespaces/#creating-namespaces) to ensure that you will have permission to access the namespace.
+
 
 ### Creating Namespaces
 

--- a/content/rancher/v2.x/en/project-admin/namespaces/_index.md
+++ b/content/rancher/v2.x/en/project-admin/namespaces/_index.md
@@ -18,13 +18,15 @@ Resources that you can assign directly to namespaces include:
 - [Registries]({{< baseurl >}}/rancher/v2.x/en/k8s-in-rancher/registries/)
 - [Secrets]({{< baseurl >}}/rancher/v2.x/en/k8s-in-rancher/secrets/)
 
->**Note:** Although you can assign role-based access to namespaces in the base version of Kubernetes, you cannot assign roles to namespaces in Rancher. Instead, assign role-based access at the project level.
+Although you can assign role-based access to namespaces in the base version of Kubernetes, you cannot assign roles to namespaces in Rancher. Instead, assign role-based access at the project level.
+
+> **Note:** If you create a namespace with `kubectl`, it may be unusable because `kubectl` doesn't require your new namespace to be scoped within a project that you have access to. If your permissions are restricted to the project level, it is better to [create a namespace through Rancher](#creating-namespaces) to ensure that you will have permission to access the namespace.
 
 ### Creating Namespaces
 
 Create a new namespace to isolate apps and resources in a project.
 
->**Tip:** When working with project resources that you can assign to a namespace (i.e., [workloads]({{< baseurl >}}/rancher/v2.x/en/k8s-in-rancher/workloads/deploy-workloads/), [certificates]({{< baseurl >}}/rancher/v2.x/en/k8s-in-rancher/certificates/), [ConfigMaps]({{< baseurl >}}/rancher/v2.x/en/k8s-in-rancher/configmaps), etc.) you can create a namespace on the fly.
+When working with project resources that you can assign to a namespace (i.e., [workloads]({{< baseurl >}}/rancher/v2.x/en/k8s-in-rancher/workloads/deploy-workloads/), [certificates]({{< baseurl >}}/rancher/v2.x/en/k8s-in-rancher/certificates/), [ConfigMaps]({{< baseurl >}}/rancher/v2.x/en/k8s-in-rancher/configmaps), etc.) you can create a namespace on the fly.
 
 1. From the **Global** view, open the project where you want to create a namespace.
 


### PR DESCRIPTION
This PR is intended to address this issue https://github.com/rancher/docs/issues/1304

@jambajaar and @janeczku , does this note convey the problem and how to avoid it?

> **Note:** If you create a namespace with `kubectl`, it may be unusable because `kubectl` doesn't require your new namespace to be scoped within a project that you have access to. If your permissions are restricted to the project level, it is better to [create a namespace through Rancher]({{<baseurl>}}/rancher/v2.x/en/project-admin/namespaces/#creating-namespaces) to ensure that you will have permission to access the namespace.