### PR TITLE
add comment for additional network plug-ins

### DIFF
--- a/content/rke/latest/en/example-yamls/_index.md
+++ b/content/rke/latest/en/example-yamls/_index.md
@@ -215,8 +215,7 @@ cloud_provider:
 # up on trying to get the job status after this timeout in seconds..
 addon_job_timeout: 30
 
-# There are several network plug-ins that work, but we default
-# to canal      
+# Specify network plugin-in (canal, calico, flannel, weave, or none)
 network:
     plugin: canal
 


### PR DESCRIPTION
Update network plug-in comment to include options in addition to "canal." Follows the same format as the following comment for DNS provider.