### PR TITLE
Update _index.md

### DIFF
--- a/content/rancher/v2.x/en/cluster-provisioning/rke-clusters/options/_index.md
+++ b/content/rancher/v2.x/en/cluster-provisioning/rke-clusters/options/_index.md
@@ -77,7 +77,7 @@ Authorized Cluster Endpoint can be used to directly access the Kubernetes API se
 
 This is enabled by default in Rancher-launched Kubernetes clusters, using the IP of the node with the `controlplane` role and the default Kubernetes self signed certificates.
 
-For more detail on how an authorized cluster endpoint works and why it is used, refer to the [architecture section.]({{<baseurl>}}/rancher/v2.x/en/overview/architecture/4-authorized-cluster-endpoint)
+For more detail on how an authorized cluster endpoint works and why it is used, refer to the [architecture section.]({{<baseurl>}}/rancher/v2.x/en/overview/architecture/#4-authorized-cluster-endpoint)
 
 We recommend using a load balancer with the authorized cluster endpoint. For details, refer to the [recommended architecture section.]({{<baseurl>}}/rancher/v2.x/en/overview/architecture-recommendations/#architecture-for-an-authorized-cluster-endpoint)
 


### PR DESCRIPTION
Fix broken link for [architecture section] in the link "For more detail on how an authorized cluster endpoint works and why it is used, refer to the [architecture section.]"