### PR TITLE
Clarified where possible

### DIFF
--- a/content/rancher/v2.x/en/cluster-admin/tools/istio/setup/set-up-traffic-management/_index.md
+++ b/content/rancher/v2.x/en/cluster-admin/tools/istio/setup/set-up-traffic-management/_index.md
@@ -3,9 +3,9 @@ title: 6. Set up Istio's Components for Traffic Management
 weight: 6
 ---
 
-A central advantage of  traffic management in Istio is that it allows dynamic request routing, which is useful for canary deployments or blue/green deployments. The two key resources in Istio traffic management are virtual services and destination rules.
+A central advantage of  traffic management in Istio is that it allows dynamic request routing, (which is useful for canary deployments or blue/green deployments). The two key resources in Istio traffic management are *virtual services* and *destination rules*.
 
-- [Virtual services](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/)intercept and direct traffic to your Kubernetes services, allowing you to divide percentages of traffic from a request to different services. You can use them to define a set of routing rules to apply when a host is addressed.
+- [Virtual services](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/) intercept and direct traffic to your Kubernetes services, allowing you to divide percentages of traffic from a request to different services. You can use them to define a set of routing rules to apply when a host is addressed.
 - [Destination rules](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/) serve as the single source of truth about which service versions are available to receive traffic from virtual services. You can use these resources to define policies that apply to traffic that is intended for a service after routing has occurred.
 
 This section describes how to add an example virtual service that corresponds to the `reviews` microservice in the sample BookInfo app. The purpose of this service is to divide traffic between two versions of the `reviews` service.
@@ -16,11 +16,10 @@ After this virtual service is deployed, we will generate traffic and see from th
 
 To deploy the virtual service and destination rules for the `reviews` service,
 
-1. Go to the cluster view and click **Import YAML.**
+1. Go to the project view and click **Import YAML.**
 1. Copy resources below into the form.
 1.  Click **Import.**
 
-**Result:** When you generate traffic to this service (for example, by refreshing the ingress gateway URL), the Kiali traffic graph will reflect that traffic to the `reviews` service is divided evenly between `v1` and `v3`.
 ```
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
@@ -57,5 +56,6 @@ spec:
     labels:
       version: v3
 ```
+**Result:** When you generate traffic to this service (for example, by refreshing the ingress gateway URL), the Kiali traffic graph will reflect that traffic to the `reviews` service is divided evenly between `v1` and `v3`.
 
 ### [Next: Generate and View Traffic]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/tools/istio/setup/view-traffic)

--- a/content/rancher/v2.x/en/cluster-admin/tools/istio/setup/set-up-traffic-management/_index.md
+++ b/content/rancher/v2.x/en/cluster-admin/tools/istio/setup/set-up-traffic-management/_index.md
@@ -3,7 +3,7 @@ title: 6. Set up Istio's Components for Traffic Management
 weight: 6
 ---
 
-A central advantage of  traffic management in Istio is that it allows dynamic request routing, (which is useful for canary deployments or blue/green deployments). The two key resources in Istio traffic management are *virtual services* and *destination rules*.
+A central advantage of traffic management in Istio is that it allows dynamic request routing. Some common applications for dynamic request routing include canary deployments and blue/green deployments. The two key resources in Istio traffic management are *virtual services* and *destination rules*.
 
 - [Virtual services](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/) intercept and direct traffic to your Kubernetes services, allowing you to divide percentages of traffic from a request to different services. You can use them to define a set of routing rules to apply when a host is addressed.
 - [Destination rules](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule/) serve as the single source of truth about which service versions are available to receive traffic from virtual services. You can use these resources to define policies that apply to traffic that is intended for a service after routing has occurred.


### PR DESCRIPTION
Clarified and added a space, moved the result to the end of the instructions to match prior pages and intuitive format, and swapped 'cluster' for 'project' as there is no import yaml option in the cluster view.  This last one could do with some investigation as I'm not sure if it was maybe saying to go to the project, import the yaml, and choose the Cluster 'Import Mode' (Options are Cluster, Project, and Namespace).  I'm not sure which should be chosen and it might be worth clarifying on all YAML import steps.