### PR TITLE
Title of k8s-in-rancher section reflects contents

### DIFF
--- a/content/rancher/v2.x/en/k8s-in-rancher/_index.md
+++ b/content/rancher/v2.x/en/k8s-in-rancher/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Working in Projects
+title: Kubernetes Resources, Registries and Pipelines
 weight: 3000
 aliases:
   - /rancher/v2.x/en/concepts/


### PR DESCRIPTION
My concern with the title "Working in Projects" is that projects are a Rancher concept, while the section covers almost entirely how to work with Kubernetes resources. When I first started at Rancher I remember being confused by this section because I thought those were features of Rancher projects, and the more I think about it, the more I think the title could mislead people into believing that projects are more important than they really are. So I have changed the title to try to more closely reflect the contents of the section.