### PR TITLE
Include both Helm 2 and Helm 3 commands for Rancher upgrades

### DIFF
--- a/content/rancher/v2.x/en/upgrades/upgrades/_index.md
+++ b/content/rancher/v2.x/en/upgrades/upgrades/_index.md
@@ -4,8 +4,8 @@ weight: 1005
 ---
 This section contains information about how to upgrade your Rancher server to a newer version. Regardless if you installed in an air gap environment or not, the upgrade steps mainly depend on whether you have a single node or high-availability installation of Rancher. Select from the following options:
 
-- [Upgrading a Single Node Install]({{< baseurl >}}/rancher/v2.x/en/upgrades/upgrades/single-node/)
-- [Upgrading an HA Install]({{< baseurl >}}/rancher/v2.x/en/upgrades/upgrades/ha/)
+- [Upgrading Rancher installed with Docker]({{<baseurl>}}/rancher/v2.x/en/upgrades/upgrades/single-node/)
+- [Upgrading Rancher installed on a Kubernetes cluster]({{<baseurl>}}/rancher/v2.x/en/upgrades/upgrades/ha/)
 
 ### Known Upgrade Issues
 

--- a/content/rancher/v2.x/en/upgrades/upgrades/ha/helm2/_index.md
+++ b/content/rancher/v2.x/en/upgrades/upgrades/ha/helm2/_index.md
@@ -1,13 +1,15 @@
 ---
-title: Upgrading Rancher Installed on Kubernetes
-weight: 1020
-aliases:
-  - /rancher/v2.x/en/upgrades/upgrades/ha-server-upgrade-helm
-  - /rancher/v2.x/en/upgrades/upgrades/ha-server-upgrade-helm-airgap
-  - /rancher/v2.x/en/upgrades/air-gap-upgrade/
+title: Upgrading Rancher Installed on Kubernetes with Helm 2
+weight: 1050
 ---
 
-The following instructions will guide you through using Helm to upgrade a Rancher server that was installed on a Kubernetes cluster.
+> After Helm 3 was released, the [instructions for upgrading Rancher on a Kubernetes cluster](./ha) were updated to use Helm 3.
+>
+> If you are using Helm 2, we recommend [migrating to Helm 3](https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/) because it is simpler to use and more secure than Helm 2.
+>
+> This section provides a copy of the older instructions for upgrading Rancher with Helm 2, and it is intended to be used if upgrading to Helm 3 is not feasible.
+
+The following instructions will guide you through using Helm to upgrade a high-availability (HA) Rancher server installation. 
 
 To upgrade the components in your Kubernetes cluster, or the definition of the [Kubernetes services]({{<baseurl>}}/rke/latest/en/config-options/services/) or [add-ons]({{< baseurl >}}/rke/latest/en/config-options/add-ons/), refer to the [upgrade documentation for RKE]({{<baseurl>}}/rke/latest/en/upgrades/), the Rancher Kubernetes Engine.
 
@@ -17,11 +19,11 @@ If you installed Rancher using the RKE Add-on yaml, follow the directions to [mi
 > 
 > - [Let's Encrypt will be blocking cert-manager instances older than 0.8.0 starting November 1st 2019.](https://community.letsencrypt.org/t/blocking-old-cert-manager-versions/98753) Upgrade cert-manager to the latest version by following [these instructions.]({{<baseurl>}}/rancher/v2.x/en/installation/options/upgrading-cert-manager)
 > - If you are upgrading Rancher from v2.x to v2.3+, and you are using external TLS termination, you will need to edit the cluster.yml to [enable using forwarded host headers.]({{<baseurl>}}/rancher/v2.x/en/installation/ha/helm-rancher/chart-options/#configuring-ingress-for-external-tls-when-using-nginx-v0-25)
-> - The upgrade instructions assume you are using Helm 3. For migration of installs started with Helm 2, refer to the official [Helm 2 to 3 migration docs.](https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/) This [section]({{<baseurl>}}/rancher/v2.x/en/upgrades/upgrades/ha/helm2) provides a copy of the older upgrade instructions that used Helm 2, and it is intended to be used if upgrading to Helm 3 is not feasible.
+> - The upgrade instructions assume you are using Helm 3. For migration of installs started with Helm 2, refer to the official [Helm 2 to 3 migration docs.](https://helm.sh/blog/migrate-from-helm-v2-to-helm-v3/) This [section]({{<baseurl>}}/rancher/v2.x/en/upgrades/helm2) provides a copy of the older upgrade instructions that used Helm 2, and it is intended to be used if upgrading to Helm 3 is not feasible.
 
 # Prerequisites
 
-- **Review the [Known Upgrade Issues]({{<baseurl>}}/rancher/v2.x/en/upgrades/upgrades/#known-upgrade-issues) and [Caveats]({{<baseurl>}}/rancher/v2.x/en/upgrades/upgrades/#caveats)**
+- **Review the [Known Upgrade Issues]({{< baseurl >}}/rancher/v2.x/en/upgrades/upgrades/#known-upgrade-issues) and [Caveats]({{< baseurl >}}/rancher/v2.x/en/upgrades/upgrades/#caveats)**
 
 - **[Air Gap Installs Only:]({{< baseurl >}}/rancher/v2.x/en/installation/other-installation-methods/air-gap) Collect and Populate Images for the new Rancher server version**
 
@@ -97,16 +99,14 @@ If you are also upgrading cert-manager to the latest version from a version olde
 
 Upgrade Rancher to the latest version with all your settings.
 
-Take all the values from the previous step and append them to the command using `--set key=value`:
+Take all the values from the previous step and append them to the command using `--set key=value`. Note: There will be many more options from the previous step that need to be appended.
 
 ```
-helm upgrade rancher rancher-<CHART_REPO>/rancher \
+helm upgrade rancher-<CHART_REPO>/rancher \
+  --name rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org
 ```
-
-> **Note:** There will be many more options from the previous step that need to be appended.
-
 {{% /accordion %}}
 
 {{% accordion label="Option B: Reinstalling Rancher chart" %}}
@@ -124,7 +124,8 @@ Please refer the [Upgrading Cert-Manager]({{< baseurl >}}/rancher/v2.x/en/instal
 2. Reinstall Rancher to the latest version with all your settings. Take all the values from the previous step and append them to the command using `--set key=value`. Note: There will be many more options from the previous step that need to be appended.
 
     ```
-    helm install rancher rancher-<CHART_REPO>/rancher \
+    helm install rancher-<CHART_REPO>/rancher \
+    --name rancher \
     --namespace cattle-system \
     --set hostname=rancher.my.org
     ```

--- a/content/rancher/v2.x/en/upgrades/upgrades/namespace-migration/_index.md
+++ b/content/rancher/v2.x/en/upgrades/upgrades/namespace-migration/_index.md
@@ -1,7 +1,6 @@
 ---
 title: Upgrading to v2.0.7+ — Namespace Migration
-weight:
-aliases:
+weight: 1040
 ---
 >This section applies only to Rancher upgrades from v2.0.6 or earlier to v2.0.7 or later. Upgrades from v2.0.7 to later version are unaffected.
 

--- a/content/rancher/v2.x/en/upgrades/upgrades/single-node/_index.md
+++ b/content/rancher/v2.x/en/upgrades/upgrades/single-node/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Single Node Upgrade
+title: Upgrading Rancher Installed with Docker
 weight: 1010
 aliases:
   - /rancher/v2.x/en/upgrades/single-node-upgrade/
@@ -7,7 +7,7 @@ aliases:
   - /rancher/v2.x/en/upgrades/upgrades/single-node-air-gap-upgrade
 ---
 
-The following instructions will guide you through upgrading a high-availability Rancher server installation.
+The following instructions will guide you through upgrading a Rancher server that was installed with Docker.
 
 ## Prerequisites
 


### PR DESCRIPTION
In this PR I have done several things:

- Addressed this issue https://github.com/rancher/docs/issues/2144 by adding `--namespace cattle-system` to the `helm install` and `helm upgrade` commands
- Updated the upgrade docs to describe the two main Rancher installation options as Docker install and Kubernetes install, instead of single node and HA install (this is to align with changes that will soon be made to our installation docs)
- Added a note to the upgrade docs that the Helm commands have been updated for Helm 3
- Added a new page for upgrade docs that still have Helm 2 commands, for people who don't want to migrate to Helm 3

@rawmind0 , I have changed the commands in the upgrade docks so that they align with the Helm 2 and Helm 3 commands in our installation docs. Can you please validate that these commands are correct?

1. The command to install Rancher with Helm 2

```
helm install rancher-<CHART_REPO>/rancher \
    --name rancher \
    --namespace cattle-system \
    --set hostname=rancher.my.org
```


2. The command to upgrade Rancher with Helm 2

```
helm upgrade rancher-<CHART_REPO>/rancher \
  --name rancher \
  --namespace cattle-system \
  --set hostname=rancher.my.org
```


3. The command to install Rancher with Helm 3

```
helm install rancher rancher-<CHART_REPO>/rancher \
    --namespace cattle-system \
    --set hostname=rancher.my.org
```

4. The command to upgrade Rancher with Helm 3

```
helm upgrade rancher rancher-<CHART_REPO>/rancher \
  --namespace cattle-system \
  --set hostname=rancher.my.org
```

