### PR TITLE
Fix a small typo

### DIFF
--- a/content/k3s/latest/en/installation/private-registry/_index.md
+++ b/content/k3s/latest/en/installation/private-registry/_index.md
@@ -8,7 +8,7 @@ Containerd can be configured to connect to private registries and use them to pu
 
 Upon startup, K3s will check to see if a `registries.yaml` file exists at `/etc/rancher/k3s/` and instruct containerd to use any registries defined in the file. If you wish to use a private registry, then you will need to create this file as root on each node that will be using the registry.
 
-Note that server nodes are schedulable by default. If you have not tainted the server nodes and will be running workloads on them, please ensure you also create the registires.yaml file on each server as well.
+Note that server nodes are schedulable by default. If you have not tainted the server nodes and will be running workloads on them, please ensure you also create the `registries.yaml` file on each server as well.
 
 Configuration in containerd can be used to connect to a private registry with a TLS connection and with registries that enable authentication as well. The following section will explain the `registries.yaml` file and give different examples of using private registry configuration in K3s.
 


### PR DESCRIPTION
Also marked it as inline code to be the same as the other definitions of registries.yaml.