### PR TITLE
include file permissions in tar

### DIFF
--- a/content/rancher/v2.x/en/backups/backups/single-node-backups/_index.md
+++ b/content/rancher/v2.x/en/backups/backups/single-node-backups/_index.md
@@ -13,7 +13,7 @@ After completing your Docker installation of Rancher, we recommend creating back
 During the creation of your backup, you'll enter a series of commands, replacing placeholders with data from your environment. These placeholders are denoted with angled brackets and all capital letters (`<EXAMPLE>`). Here's an example of a command with a placeholder:
 
 ```
-docker run  --volumes-from rancher-data-<DATE> -v $PWD:/backup busybox tar zcvf /backup/rancher-data-backup-<RANCHER_VERSION>-<DATE>.tar.gz /var/lib/rancher
+docker run  --volumes-from rancher-data-<DATE> -v $PWD:/backup busybox tar pzcvf /backup/rancher-data-backup-<RANCHER_VERSION>-<DATE>.tar.gz /var/lib/rancher
 ```
 
 In this command, `<DATE>` is a placeholder for the date that the data container and backup were created. `9-27-18` for example.
@@ -54,7 +54,7 @@ This procedure creates a backup that you can restore if Rancher encounters a dis
 1. <a id="tarball"></a>From the data container that you just created (`rancher-data-<DATE>`), create a backup tarball (`rancher-data-backup-<RANCHER_VERSION>-<DATE>.tar.gz`). Use the following command, replacing each [placeholder](#before-you-start).
 
     ```
-    docker run  --volumes-from rancher-data-<DATE> -v $PWD:/backup:z busybox tar zcvf /backup/rancher-data-backup-<RANCHER_VERSION>-<DATE>.tar.gz /var/lib/rancher
+    docker run  --volumes-from rancher-data-<DATE> -v $PWD:/backup:z busybox tar pzcvf /backup/rancher-data-backup-<RANCHER_VERSION>-<DATE>.tar.gz /var/lib/rancher
     ```
 
     **Step Result:** A stream of commands runs on the screen.

--- a/content/rancher/v2.x/en/backups/restorations/single-node-restoration/_index.md
+++ b/content/rancher/v2.x/en/backups/restorations/single-node-restoration/_index.md
@@ -15,7 +15,7 @@ During restoration of your backup, you'll enter a series of commands, filling pl
 ```
 docker run  --volumes-from <RANCHER_CONTAINER_NAME> -v $PWD:/backup \
 busybox sh -c "rm /var/lib/rancher/* -rf  && \
-tar zxvf /backup/rancher-data-backup-<RANCHER_VERSION>-<DATE>"
+tar pzxvf /backup/rancher-data-backup-<RANCHER_VERSION>-<DATE>"
 ```
 
 In this command, `<RANCHER_CONTAINER_NAME>` and `<RANCHER_VERSION>-<DATE>` are environment variables for your Rancher deployment.
@@ -57,7 +57,7 @@ Using a [backup]({{< baseurl >}}/rancher/v2.x/en/backups/backups/single-node-bac
     ```
     docker run  --volumes-from <RANCHER_CONTAINER_NAME> -v $PWD:/backup \
     busybox sh -c "rm /var/lib/rancher/* -rf  && \
-    tar zxvf /backup/rancher-data-backup-<RANCHER_VERSION>-<DATE>.tar.gz"
+    tar pzxvf /backup/rancher-data-backup-<RANCHER_VERSION>-<DATE>.tar.gz"
     ```
 
     **Step Result:** A series of commands should run.


### PR DESCRIPTION
when making backups and restoring them with `tar`, it's helpful to use `-p` to maintain file permissions. this PR adds the `p` option to the `tar` commands.