### PR TITLE
Typo fix. Cert manager chart

### DIFF
--- a/content/rancher/v2.x/en/installation/other-installation-methods/air-gap/install-rancher/_index.md
+++ b/content/rancher/v2.x/en/installation/other-installation-methods/air-gap/install-rancher/_index.md
@@ -97,8 +97,8 @@ By default, Rancher generates a CA and uses cert-manager to issue the certificat
    ```plain
    helm template cert-manager ./cert-manager-v0.12.0.tgz --output-dir . \
        --namespace cert-manager \
-       --set image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-controller
-       --set webhook.image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-webhook
+       --set image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-controller \
+       --set webhook.image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-webhook \
        --set cainjector.image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-cainjector
    ```
 


### PR DESCRIPTION
The cert manager template command was missing several trailing '\' slashes, making it hard to copy and paste the command into a terminal.