### PR TITLE
remove copy/paste cruft from k8s upgrade page

### DIFF
--- a/content/rancher/v2.x/en/upgrades/upgrades/single-node/_index.md
+++ b/content/rancher/v2.x/en/upgrades/upgrades/single-node/_index.md
@@ -46,7 +46,6 @@ During upgrade, you create a copy of the data from your current Rancher containe
 
 - A. Create a copy of the data from your Rancher server container
 - B. Create a backup tarball
-Get the options set from your current Rancher install
 - C. Upgrade Rancher
 - D. Verify the Upgrade
 - E. Clean up your old Rancher server container


### PR DESCRIPTION
the text that i removed only applies to the k8s/helm upgrade procedure. it looks like it was leftover from a copy/paste when the page was built