### PR TITLE
Brings some missing information in the documenation

### DIFF
--- a/content/rke/latest/en/installation/certs/_index.md
+++ b/content/rke/latest/en/installation/certs/_index.md
@@ -42,7 +42,8 @@ The following certificates must exist in the certificate directory.
 | Kube Api Request Header CA | kube-apiserver-requestheader-ca.pem* | kube-apiserver-requestheader-ca-key.pem** |
 |    Service Account Token   |                  -                  |    kube-service-account-token-key.pem   |
 
-\* Is the same as kube-ca.pem 
+\* Is the same as kube-ca.pem
+
 \** Is the same as kube-ca-key
 
 ## Generating Certificate Signing Requests (CSRs) and Keys

--- a/content/rke/latest/en/installation/certs/_index.md
+++ b/content/rke/latest/en/installation/certs/_index.md
@@ -41,8 +41,10 @@ The following certificates must exist in the certificate directory.
 |         Etcd Nodes         |        kube-etcd-x-x-x-x.pem        |        kube-etcd-x-x-x-x-key.pem        |
 | Kube Api Request Header CA | kube-apiserver-requestheader-ca.pem* | kube-apiserver-requestheader-ca-key.pem** |
 |    Service Account Token   |                  -                  |    kube-service-account-token-key.pem   |
-* Is the same as kube-ca.pem 
-** Is the same as kube-ca-key
+
+\* Is the same as kube-ca.pem 
+\** Is the same as kube-ca-key
+
 ## Generating Certificate Signing Requests (CSRs) and Keys
 
 If you want to create and sign the certificates by a real Certificate Authority (CA), you can use RKE to generate a set of Certificate Signing Requests (CSRs) and keys. Using the `rke cert generate-csr` command, you can generate the CSRs and keys.

--- a/content/rke/latest/en/installation/certs/_index.md
+++ b/content/rke/latest/en/installation/certs/_index.md
@@ -36,11 +36,13 @@ The following certificates must exist in the certificate directory.
 |       Kube Scheduler       |          kube-scheduler.pem         |          kube-scheduler-key.pem         |
 |         Kube Proxy         |            kube-proxy.pem           |            kube-proxy-key.pem           |
 |         Kube Admin         |            kube-admin.pem           |            kube-admin-key.pem           |
+|         Kube Node          |            kube-node.pem           |            kube-node-key.pem             |
 |   Apiserver Proxy Client   |   kube-apiserver-proxy-client.pem   |   kube-apiserver-proxy-client-key.pem   |
 |         Etcd Nodes         |        kube-etcd-x-x-x-x.pem        |        kube-etcd-x-x-x-x-key.pem        |
-| Kube Api Request Header CA | kube-apiserver-requestheader-ca.pem | kube-apiserver-requestheader-ca-key.pem |
+| Kube Api Request Header CA | kube-apiserver-requestheader-ca.pem* | kube-apiserver-requestheader-ca-key.pem** |
 |    Service Account Token   |                  -                  |    kube-service-account-token-key.pem   |
-
+* Is the same as kube-ca.pem 
+** Is the same as kube-ca-key
 ## Generating Certificate Signing Requests (CSRs) and Keys
 
 If you want to create and sign the certificates by a real Certificate Authority (CA), you can use RKE to generate a set of Certificate Signing Requests (CSRs) and keys. Using the `rke cert generate-csr` command, you can generate the CSRs and keys.


### PR DESCRIPTION
From the original documentation, it was not clear where the "kube-apiserver-requestheader-ca.pem" and "kube-apiserver-requestheader-ca-key.pem" do come from if they do not get created via "kre cert generate-csr". 
From my understanding and what I have seen [here](https://rancher.com/blog/2019/kubernetes-certificate-expiry-and-rotation-in-rancher-kubernetes-clusters/#Non-working%20Cluster%20/%20Expired%20Certs) they are the same as the "kube-ca.pem".

In addition the generated cert "kube-node" was not listed in the table of required certificates. 


