### PR TITLE
remove inconsistent reference

### DIFF
--- a/content/rancher/v2.x/en/catalog/_index.md
+++ b/content/rancher/v2.x/en/catalog/_index.md
@@ -59,7 +59,7 @@ Within Rancher, there are default catalogs packaged as part of Rancher. These ca
 
     - **Library**
 
-    	The Library Catalog includes charts curated by Rancher. Rancher stores charts in a Git repository to expedite the fetch and update of charts. In Rancher 2.x, only global catalogs are supported. Support for cluster-level and project-level charts will be added in the future.
+    	The Library Catalog includes charts curated by Rancher. Rancher stores charts in a Git repository to expedite the fetch and update of charts. 
 
     	This catalog features Rancher Charts, which include some [notable advantages]({{< baseurl >}}/rancher/v2.x/en/catalog/custom/#chart-types) over native Helm charts.
 


### PR DESCRIPTION
this appears to be an outdated statement. i was able to add the same rancher global catalog URL to the project with no issue, and i watched it refresh.  that means two things:

1. we can add stuff at the project level (or cluster level)
2. we can add rancher app catalogs at the project level (or cluster level)

the latter is relevant because depending on how it's interpreted the statement i removed could be saying either #1 or #2 was not yet possible. 

