### PR TITLE
Fix wrong apiVersion for PodSecurityPolicy

### DIFF
--- a/content/rancher/v2.x/en/security/hardening-2.3.3/_index.md
+++ b/content/rancher/v2.x/en/security/hardening-2.3.3/_index.md
@@ -613,7 +613,7 @@ addons: |
     kind: Group
     name: system:authenticated
   ---
-  apiVersion: extensions/v1beta1
+  apiVersion: policy/v1beta1
   kind: PodSecurityPolicy
   metadata:
     name: restricted-psp


### PR DESCRIPTION
To create a PodSecurityPolicy, the apiVersion `policy/v1beta1` should be used. If I apply the current manifest, which use `apiVersion: policy/v1beta1`,  it throws out the error: 
`no matches for kind "PodSecurityPolicy" in version "extensions/v1beta1`