### PR TITLE
Add note for update-only actions

### DIFF
--- a/content/rke/latest/en/managing-clusters/_index.md
+++ b/content/rke/latest/en/managing-clusters/_index.md
@@ -20,6 +20,8 @@ After you've made changes to add/remove nodes, run `rke up` with the updated `cl
 
 You can add/remove only worker nodes, by running `rke up --update-only`. This will ignore everything else in the `cluster.yml` except for any worker nodes.
 
+> **Note:** When using `--update-only`, other actions that do not specifically relate to nodes may be deployed or updated, for example [addons]({{< baseurl >}}/rke/latest/en/config-options/add-ons).
+
 ### Removing Kubernetes Components from Nodes
 
 In order to remove the Kubernetes components from nodes, you use the `rke remove` command.


### PR DESCRIPTION
Other actions can occur with `rke up --update-only` which can cause confusion.

Add note to cover that the flag will deploy the addons, and changes can still occur outside of the worker plane.