### PR TITLE
Adds section on deploying istio with PSP enabled

### DIFF
--- a/content/rancher/v2.x/en/cluster-admin/tools/istio/setup/enable-istio-in-cluster/_index.md
+++ b/content/rancher/v2.x/en/cluster-admin/tools/istio/setup/enable-istio-in-cluster/_index.md
@@ -7,6 +7,8 @@ This cluster uses the default Nginx controller to allow traffic into the cluster
 
 A Rancher [administrator]({{<baseurl>}}/rancher/v2.x/en/admin-settings/rbac/global-permissions/) or [cluster owner]({{<baseurl>}}/rancher/v2.x/en/admin-settings/rbac/cluster-project-roles/#cluster-roles) can configure Rancher to deploy Istio in a Kubernetes cluster.
 
+> If the cluster has a Pod Security Policy enabled there are [prerequisites steps]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/tools/istio/setup/enable-istio-in-cluster/enable-istio-with-psp/)
+
 1. From the **Global** view, navigate to the **cluster** where you want to enable Istio.
 1. Click **Tools > Istio.**
 1. Optional: Configure member access and [resource limits]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/tools/istio/resources/) for the Istio components. Ensure you have enough resources on your worker nodes to enable Istio.

--- a/content/rancher/v2.x/en/cluster-admin/tools/istio/setup/enable-istio-in-cluster/enable-istio-with-psp/_index.md
+++ b/content/rancher/v2.x/en/cluster-admin/tools/istio/setup/enable-istio-in-cluster/enable-istio-with-psp/_index.md
@@ -6,7 +6,7 @@ title: Enable Istio with Pod Security Policies
 
 If you have restrictive Pod Security Policies enabled, then Istio may not be able to function correctly, because it needs certain permissions in order to install itself and manage pod infrastructure. In this section, we will configure a cluster with PSPs enabled for an Istio install, and also set up the Istio CNI plugin. 
 
-The Istio CNI plugin removes the need for each application pod to have a priveleged `NET_ADMIN` container. For further information, see the [Istio CNI Plugin docs](https://istio.io/docs/setup/additional-setup/cni). Please note that the [Istio CNI Plugin is in alpha](https://istio.io/about/feature-stages/).
+The Istio CNI plugin removes the need for each application pod to have a privileged `NET_ADMIN` container. For further information, see the [Istio CNI Plugin docs](https://istio.io/docs/setup/additional-setup/cni). Please note that the [Istio CNI Plugin is in alpha](https://istio.io/about/feature-stages/).
 
 - 1. [Allow access to iptables.](#1-allow-access-to-iptables)
 - 2. [Configure the System Project Policy to allow Istio install.](#2-configure-the-system-project-policy-to-allow-istio-install)

--- a/content/rancher/v2.x/en/cluster-admin/tools/istio/setup/enable-istio-in-cluster/enable-istio-with-psp/_index.md
+++ b/content/rancher/v2.x/en/cluster-admin/tools/istio/setup/enable-istio-in-cluster/enable-istio-with-psp/_index.md
@@ -8,34 +8,18 @@ If you have restrictive Pod Security Policies enabled, then Istio may not be abl
 
 The Istio CNI plugin removes the need for each application pod to have a privileged `NET_ADMIN` container. For further information, see the [Istio CNI Plugin docs](https://istio.io/docs/setup/additional-setup/cni). Please note that the [Istio CNI Plugin is in alpha](https://istio.io/about/feature-stages/).
 
-- 1. [Allow access to iptables.](#1-allow-access-to-iptables)
-- 2. [Configure the System Project Policy to allow Istio install.](#2-configure-the-system-project-policy-to-allow-istio-install)
-- 3. [Install the CNI plugin in the System project.](#3-install-the-cni-plugin-in-the-system-project)
-- 4. [Install Istio.](#4-install-istio)
+- 1. [Configure the System Project Policy to allow Istio install.](#2-configure-the-system-project-policy-to-allow-istio-install)
+- 2. [Install the CNI plugin in the System project.](#3-install-the-cni-plugin-in-the-system-project)
+- 3. [Install Istio.](#4-install-istio)
 
-### 1. Allow access to iptables
-
-Configure the cluster to allow the CNI plugin to set networking rules via iptables modules:
-
-1. From the **Global** view, navigate to the cluster where you want to enable Istio.
-1. Select the **Ellipsis (...) > Edit**.
-1. Click "Edit as YAML", find the services block, and edit to include:
-
-```
-services:
-  kubelet:
-    extra_binds:
-      - '/lib/modules:/lib/modules'
-```
-
-### 2. Configure the System Project Policy to allow Istio install
+### 1. Configure the System Project Policy to allow Istio install
 
 1. From the main menu of the **Dashboard**, select **Projects/Namespaces**.
 1. Find the **Project: System** project and select the **Ellipsis (...) > Edit**.
 1. Change the Pod Security Policy option to be unrestricted, then click Save.
 
 
-### 3. Install the CNI Plugin in the System Project
+### 2. Install the CNI Plugin in the System Project
 
 1. From the main menu of the **Dashboard**, select **Projects/Namespaces**.
 1. Select the **Project: System** project.
@@ -47,7 +31,8 @@ services:
 1. From the main menu select **Apps**
 1. Click Launch and select istio-cni
 1. Update the namespace to be "kube-system"
-1. In the answers section, click "Edit as YAML", and paste in the following:
+1. In the answers section, click "Edit as YAML" and paste in the following, then click launch:
+
 ```
 ---
   logLevel: "info"
@@ -55,9 +40,8 @@ services:
     - "istio-system"
     - "kube-system"
 ```
-1. Click Launch
 
-### 4. Install Istio
+### 3. Install Istio
 
 Follow the [primary instructions]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/tools/istio/setup/enable-istio-in-cluster/), adding a custom answer: `istio_cni.enabled: true`.
 

--- a/content/rancher/v2.x/en/cluster-admin/tools/istio/setup/enable-istio-in-cluster/enable-istio-with-psp/_index.md
+++ b/content/rancher/v2.x/en/cluster-admin/tools/istio/setup/enable-istio-in-cluster/enable-istio-with-psp/_index.md
@@ -1,0 +1,59 @@
+---
+title: Enable Istio with Pod Security Policies
+---
+
+ >**Note:** The following guide is only for RKE provisioned clusters
+
+If you have restrictive Pod Security Policies enabled, then istio may not be able to function correctly as it needs certain permissions in order to install itself and manage pod infrastructure. In this section we will configure a cluster with PSP's enabled for an Istio install, and also setup the Istio CNI plugin. 
+
+The Istio CNI plugin removes the need for each application pod to have a priveleged `NET_ADMIN` container. For further information see the [Istio CNI Plugin docs](https://istio.io/docs/setup/additional-setup/cni). Please note that the [Istio CNI Plugin is in alpha](https://istio.io/about/feature-stages/).
+
+#### Allow access to iptables
+
+Configure the cluster to allow the CNI plugin to set networking rules via iptables modules
+
+1. From the **Global** view, navigate to the **cluster** where you want to enable Istio.
+1. Select the **Ellipsis (...) > Edit**.
+1. Click "Edit as YAML", find the services block and edit to include:
+
+```
+services:
+  kubelet:
+    extra_binds:
+      - '/lib/modules:/lib/modules'
+```
+
+#### Configure the System Project Policy to allow Istio install
+
+1. From the main menu of the **Dashboard**, select **Projects/Namespaces**.
+1. Find the **Project: System** project and select the **Ellipsis (...) > Edit**.
+1. Change the Pod Security Policy option to be unrestricted, then click Save.
+
+
+#### Install the CNI Plugin in the System Project
+
+1. From the main menu of the **Dashboard**, select **Projects/Namespaces**.
+1. Select the **Project: System** project.
+1. Choose **Tools > Catalogs** in the navigation bar.
+1. Add a catalog with the following:
+	1. Name: istio-cni
+	1. Catalog URL: https://github.com/istio/cni
+	1. Branch: The branch that matches your current release, for example: `release-1.4`.
+1. From the main menu select **Apps**
+1. Click Launch and select istio-cni
+1. Update the namespace to be "kube-system"
+1. In the answers section, click "Edit as YAML", and paste in the following:
+```
+---
+  logLevel: "info"
+  excludeNamespaces:
+    - "istio-system"
+    - "kube-system"
+```
+1. Click Launch
+
+#### Install Istio
+
+Follow the [primary instructions]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/tools/istio/setup/enable-istio-in-cluster/), adding a custom answer: `istio_cni.enabled: true`.
+
+After Istio has finished installing, the Apps page in System Projects should show both istio and istio-cni applications deployed successfully. Sidecar injection will now be functional.

--- a/content/rancher/v2.x/en/cluster-admin/tools/istio/setup/enable-istio-in-cluster/enable-istio-with-psp/_index.md
+++ b/content/rancher/v2.x/en/cluster-admin/tools/istio/setup/enable-istio-in-cluster/enable-istio-with-psp/_index.md
@@ -2,19 +2,24 @@
 title: Enable Istio with Pod Security Policies
 ---
 
- >**Note:** The following guide is only for RKE provisioned clusters
+ >**Note:** The following guide is only for RKE provisioned clusters.
 
-If you have restrictive Pod Security Policies enabled, then istio may not be able to function correctly as it needs certain permissions in order to install itself and manage pod infrastructure. In this section we will configure a cluster with PSP's enabled for an Istio install, and also setup the Istio CNI plugin. 
+If you have restrictive Pod Security Policies enabled, then Istio may not be able to function correctly, because it needs certain permissions in order to install itself and manage pod infrastructure. In this section, we will configure a cluster with PSPs enabled for an Istio install, and also set up the Istio CNI plugin. 
 
-The Istio CNI plugin removes the need for each application pod to have a priveleged `NET_ADMIN` container. For further information see the [Istio CNI Plugin docs](https://istio.io/docs/setup/additional-setup/cni). Please note that the [Istio CNI Plugin is in alpha](https://istio.io/about/feature-stages/).
+The Istio CNI plugin removes the need for each application pod to have a priveleged `NET_ADMIN` container. For further information, see the [Istio CNI Plugin docs](https://istio.io/docs/setup/additional-setup/cni). Please note that the [Istio CNI Plugin is in alpha](https://istio.io/about/feature-stages/).
 
-#### Allow access to iptables
+- 1. [Allow access to iptables.](#1-allow-access-to-iptables)
+- 2. [Configure the System Project Policy to allow Istio install.](#2-configure-the-system-project-policy-to-allow-istio-install)
+- 3. [Install the CNI plugin in the System project.](#3-install-the-cni-plugin-in-the-system-project)
+- 4. [Install Istio.](#4-install-istio)
 
-Configure the cluster to allow the CNI plugin to set networking rules via iptables modules
+### 1. Allow access to iptables
 
-1. From the **Global** view, navigate to the **cluster** where you want to enable Istio.
+Configure the cluster to allow the CNI plugin to set networking rules via iptables modules:
+
+1. From the **Global** view, navigate to the cluster where you want to enable Istio.
 1. Select the **Ellipsis (...) > Edit**.
-1. Click "Edit as YAML", find the services block and edit to include:
+1. Click "Edit as YAML", find the services block, and edit to include:
 
 ```
 services:
@@ -23,14 +28,14 @@ services:
       - '/lib/modules:/lib/modules'
 ```
 
-#### Configure the System Project Policy to allow Istio install
+### 2. Configure the System Project Policy to allow Istio install
 
 1. From the main menu of the **Dashboard**, select **Projects/Namespaces**.
 1. Find the **Project: System** project and select the **Ellipsis (...) > Edit**.
 1. Change the Pod Security Policy option to be unrestricted, then click Save.
 
 
-#### Install the CNI Plugin in the System Project
+### 3. Install the CNI Plugin in the System Project
 
 1. From the main menu of the **Dashboard**, select **Projects/Namespaces**.
 1. Select the **Project: System** project.
@@ -52,8 +57,8 @@ services:
 ```
 1. Click Launch
 
-#### Install Istio
+### 4. Install Istio
 
 Follow the [primary instructions]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/tools/istio/setup/enable-istio-in-cluster/), adding a custom answer: `istio_cni.enabled: true`.
 
-After Istio has finished installing, the Apps page in System Projects should show both istio and istio-cni applications deployed successfully. Sidecar injection will now be functional.
+After Istio has finished installing, the Apps page in System Projects should show both istio and `istio-cni` applications deployed successfully. Sidecar injection will now be functional.


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/22469

This issue is technically in 2.4.1, but its not version specific. Should work all the way back to 2.3.