### PR TITLE
reflect PagerDuty nomenclature in notifier docs

### DIFF
--- a/content/rancher/v2.x/en/cluster-admin/tools/notifiers/_index.md
+++ b/content/rancher/v2.x/en/cluster-admin/tools/notifiers/_index.md
@@ -44,8 +44,8 @@ Set up a notifier so that you can begin configuring and sending alerts.
 {{% /accordion %}}
 {{% accordion id="pagerduty" label="PagerDuty" %}}
 1. Enter a **Name** for the notifier.
-1. From PagerDuty, create a webhook. For instructions, see the [PagerDuty Documentation](https://support.pagerduty.com/docs/webhooks).
-1. From PagerDuty, copy the webhook's **Integration Key**.
+1. From PagerDuty, create a generic Events API integration for your service. For instructions, see the [PagerDuty Documentation](https://support.pagerduty.com/docs/services-and-integrations#section-create-a-generic-events-api-integration).
+1. From PagerDuty, copy the integration's **Integration Key**.
 1. From Rancher, enter the key in the **Service Key** field.
 1. Click **Test**. If the test is successful, your PagerDuty endpoint outputs `PageDuty setting validated`.
 {{% /accordion %}}


### PR DESCRIPTION
a [webhook in PagerDuty](https://support.pagerduty.com/docs/webhooks) refers to pushes from PagerDuty to arbitrary HTTP endpoints, not from client machines able to make outbound HTTP connections to PagerDuty's API