### PR TITLE
reference correct PagerDuty Prometheus integration documentation, fix…

### DIFF
--- a/content/rancher/v2.x/en/cluster-admin/tools/notifiers/_index.md
+++ b/content/rancher/v2.x/en/cluster-admin/tools/notifiers/_index.md
@@ -44,10 +44,10 @@ Set up a notifier so that you can begin configuring and sending alerts.
 {{% /accordion %}}
 {{% accordion id="pagerduty" label="PagerDuty" %}}
 1. Enter a **Name** for the notifier.
-1. From PagerDuty, create a webhook. For instructions, see the [PagerDuty Documentation](https://support.pagerduty.com/docs/webhooks).
-1. From PagerDuty, copy the webhook's **Integration Key**.
+1. From PagerDuty, create a Prometheus integration. For instructions, see the [PagerDuty Documentation](https://www.pagerduty.com/docs/guides/prometheus-integration-guide/).
+1. From PagerDuty, copy the integration's **Integration Key**.
 1. From Rancher, enter the key in the **Service Key** field.
-1. Click **Test**. If the test is successful, your PagerDuty endpoint outputs `PageDuty setting validated`.
+1. Click **Test**. If the test is successful, your PagerDuty endpoint outputs `PagerDuty setting validated`.
 {{% /accordion %}}
 {{% accordion id="webhook" label="WebHook" %}}
 1. Enter a **Name** for the notifier.


### PR DESCRIPTION
I am experiencing some confusion from the Rancher documentation and UI. They have conflicting information regarding how the PagerDuty notifier works. In the UI, a link is provided to [PagerDuty Prometheus integration](https://www.pagerduty.com/docs/guides/prometheus-integration-guide/) whereas in the documentation a link is provided to [PagerDuty WebHooks](https://support.pagerduty.com/docs/webhooks). I am inclined to go with the link provided in the UI, so I thought I would provide some related translations for the `ui` repository and an update to the `docs` repository. 

The related [pull request](https://github.com/rancher/ui/pull/3861) in `rancher/ui` is [here](https://github.com/rancher/ui/pull/3861). 

Following is some support for why I believe this change ought to be made. 

The `content/rancher/v2.x/en/cluster-admin/tools/monitoring/_index.md` file was introduced by the following commit, in which it was moved from its previous location at `content/rancher/v2.x/en/tools/notifiers-and-alerts/_index.md`. 

```
commit 2b7dd2867f95fb1bd03ba62900747c187d55db68
Author: Denise Schannon <denise@rancher.com>
Date:   Fri Mar 22 11:55:01 2019 -0700

    navigation reorg
```

The last time the line regarding the PagerDuty documentation was changed was in the following commit, which makes the contents of the file older than the contents of the UI. From this, I'm guessing that the UI is correct and the documentation needs to be updated. 

```
commit 7627219d0c5dcc6092cc2ca75fe53e422425ea0b
Author: Mark Bishop <mark@rancher.com>
Date:   Thu Jul 26 12:15:38 2018 -0700

    made updates based on Denise's feeback. Still awaiting: Austin to confirm deployment availability, Bill to explain difference between normal and warning events
```

Here is the corresponding commit from the `ui` repository showing (what I believe is) the correct documentation.

```
commit ad46729fbec090ff3135768a45d2845e24fe2bbe
Author: Sebastiaan van Steenis <mail@superseb.nl>
Date:   Wed Sep 12 11:43:08 2018 +0200

    Use Integration Key for PagerDuty notifier

diff --git a/translations/en-us.yaml b/translations/en-us.yaml
index 8355b5337..fd2e13047 100644
--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -1473,10 +1473,10 @@ notifierPage:
     defaultRecipient: Default Recipient (Address)
     defaultRecipientPlaceholder: e.g. admin@example.com
   pagerduty:
-    serviceKey: Service Key
-    serviceKeyPlaceholder: Your PagerDuty serviceKey
+    serviceKey: Integration Key
+    serviceKeyPlaceholder: Your PagerDuty Integration Key
     helpText: |
-      Here's how you <a href="https://support.pagerduty.com/docs/webhooks">create incoming WebHooks</a> for PagerDuty.
+      Here's how you <a href="https://www.pagerduty.com/docs/guides/prometheus-integration-guide/" target="_blank" rel="nofollow noopener noreferrer">create an Integration Key</a> for PagerDuty.
 
   webhook:
     url: URL
```