### PR TITLE
Legacy iptables for Raspbian Buster

### DIFF
--- a/content/k3s/latest/en/advanced/_index.md
+++ b/content/k3s/latest/en/advanced/_index.md
@@ -15,6 +15,7 @@ This section contains advanced information describing the different ways you can
 - [Starting the server with the installation script](#starting-the-server-with-the-installation-script)
 - [Additional preparation for Alpine Linux setup](#additional-preparation-for-alpine-linux-setup)
 - [Running K3d (K3s in Docker) and docker-compose](#running-k3d-k3s-in-docker-and-docker-compose)
+- [Raspbian Buster - Enable legacy iptables](#raspbian-buster---enable-legacy-iptables)
 
 # Auto-Deploying Manifests
 
@@ -162,3 +163,13 @@ Alternatively the `docker run` command can also be used:
       -e K3S_TOKEN=${NODE_TOKEN} \
       --privileged rancher/k3s:vX.Y.Z
 
+
+# Raspbian Buster - enable legacy iptables
+
+Raspbian Buster defaults to using `nftables` instead of `iptables`.  **K3S** networking features require `iptables` and do not work with `nftables`.  Follow the steps below to switch configure **Buster** to use `legacy iptables`:
+```
+sudo iptables -F
+sudo update-alternatives --set iptables /usr/sbin/iptables-legacy
+sudo update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
+sudo reboot
+```

--- a/content/k3s/latest/en/installation/installation-requirements/_index.md
+++ b/content/k3s/latest/en/installation/installation-requirements/_index.md
@@ -17,9 +17,11 @@ K3s should run on just about any flavor of Linux. However, K3s is tested on the 
 
 *    Ubuntu 16.04 (amd64)
 *    Ubuntu 18.04 (amd64)
-*    Raspbian Buster (armhf)
+*    Raspbian Buster (armhf)  **NOTE: requires legacy iptables.  See Note below.
 
-> If you are using Alpine Linux, follow [these steps]({{<baseurl>}}/k3s/latest/en/advanced/#additional-preparation-for-alpine-linux-setup) for additional setup.
+> * If you are using **Raspbian Buster**, follow [these steps]({{<baseurl>}}/k3s/latest/en/advanced/#raspbian-buster---enable-legacy-iptables) to switch to legacy iptables.
+> * If you are using **Alpine Linux**, follow [these steps]({{<baseurl>}}/k3s/latest/en/advanced/#additional-preparation-for-alpine-linux-setup) for additional setup.
+
 
 ## Hardware
 


### PR DESCRIPTION
k3s networking requires legacy iptables.  Update documentation with instructions to configure this for Raspbian Buster

Resolves #2370 