### PR TITLE
[K3s] Fix formatting of registry.yaml example in airgap docs

### DIFF
--- a/content/k3s/latest/en/installation/airgap/_index.md
+++ b/content/k3s/latest/en/installation/airgap/_index.md
@@ -28,11 +28,11 @@ The registries.yaml file should look like this before plugging in the necessary 
 ```
 ---
 mirrors:
-  customreg:
+  "mycustomreg.com:5000":
     endpoint:
-      - "https://ip-to-server:5000"
+      - "https://mycustomreg.com:5000"
 configs:
-  customreg:
+  "mycustomreg:5000":
     auth:
       username: xxxxxx # this is the registry username
       password: xxxxxx # this is the registry password


### PR DESCRIPTION
- Resolves issue outlined in this comment: https://github.com/rancher/k3s/issues/1121#issuecomment-581852683

- Closes https://github.com/rancher/k3s/issues/1121