### PR TITLE
fix: replaced tabs by spaces in code blocks

### DIFF
--- a/content/rancher/v2.x/en/installation/other-installation-methods/single-node-docker/_index.md
+++ b/content/rancher/v2.x/en/installation/other-installation-methods/single-node-docker/_index.md
@@ -44,8 +44,8 @@ Log into your Linux host, and then run the minimum installation command below.
 
 ```bash
 docker run -d --restart=unless-stopped \
-	-p 80:80 -p 443:443 \
-	rancher/rancher:latest
+  -p 80:80 -p 443:443 \
+  rancher/rancher:latest
 ```
 
 ### Option B: Bring Your Own Certificate, Self-signed
@@ -68,11 +68,11 @@ After creating your certificate, run the Docker command below to install Rancher
 
 ```bash
 docker run -d --restart=unless-stopped \
-	-p 80:80 -p 443:443 \
-	-v /<CERT_DIRECTORY>/<FULL_CHAIN.pem>:/etc/rancher/ssl/cert.pem \
-	-v /<CERT_DIRECTORY>/<PRIVATE_KEY.pem>:/etc/rancher/ssl/key.pem \
-	-v /<CERT_DIRECTORY>/<CA_CERTS.pem>:/etc/rancher/ssl/cacerts.pem \
-	rancher/rancher:latest
+  -p 80:80 -p 443:443 \
+  -v /<CERT_DIRECTORY>/<FULL_CHAIN.pem>:/etc/rancher/ssl/cert.pem \
+  -v /<CERT_DIRECTORY>/<PRIVATE_KEY.pem>:/etc/rancher/ssl/key.pem \
+  -v /<CERT_DIRECTORY>/<CA_CERTS.pem>:/etc/rancher/ssl/cacerts.pem \
+  rancher/rancher:latest
 ```
 
 ### Option C: Bring Your Own Certificate, Signed by a Recognized CA
@@ -97,11 +97,11 @@ After obtaining your certificate, run the Docker command below.
 
 ```bash
 docker run -d --restart=unless-stopped \
-	-p 80:80 -p 443:443 \
-	-v /<CERT_DIRECTORY>/<FULL_CHAIN.pem>:/etc/rancher/ssl/cert.pem \
-	-v /<CERT_DIRECTORY>/<PRIVATE_KEY.pem>:/etc/rancher/ssl/key.pem \
-	rancher/rancher:latest \
-	--no-cacerts
+  -p 80:80 -p 443:443 \
+  -v /<CERT_DIRECTORY>/<FULL_CHAIN.pem>:/etc/rancher/ssl/cert.pem \
+  -v /<CERT_DIRECTORY>/<PRIVATE_KEY.pem>:/etc/rancher/ssl/key.pem \
+  rancher/rancher:latest \
+  --no-cacerts
 ```
 
 ### Option D: Let's Encrypt Certificate
@@ -124,9 +124,9 @@ After you fulfill the prerequisites, you can install Rancher using a Let's Encry
 
 ```
 docker run -d --restart=unless-stopped \
-	-p 80:80 -p 443:443 \
-	rancher/rancher:latest \
-	--acme-domain <YOUR.DNS.NAME>
+  -p 80:80 -p 443:443 \
+  rancher/rancher:latest \
+  --acme-domain <YOUR.DNS.NAME>
 ```
 
 ## Advanced Options

--- a/content/rancher/v2.x/en/quick-start-guide/deployment/quickstart-manual-setup/_index.md
+++ b/content/rancher/v2.x/en/quick-start-guide/deployment/quickstart-manual-setup/_index.md
@@ -3,7 +3,7 @@ title: Manual Quick Start
 weight: 300
 ---
 Howdy Partner! This tutorial walks you through:
-    
+
 - Installation of {{< product >}} 2.x
 - Creation of your first cluster
 - Deployment of an application, Nginx
@@ -49,7 +49,7 @@ To install Rancher on your host, connect to it and then use a shell to install.
 2.  From your shell, enter the following command:
 
 	```
-	$ sudo docker run -d --restart=unless-stopped -p 80:80 -p 443:443 rancher/rancher
+sudo docker run -d --restart=unless-stopped -p 80:80 -p 443:443 rancher/rancher
 	```
 
 **Result:** Rancher is installed.

--- a/content/rancher/v2.x/en/upgrades/upgrades/single-node/_index.md
+++ b/content/rancher/v2.x/en/upgrades/upgrades/single-node/_index.md
@@ -135,7 +135,7 @@ Placeholder | Description
 docker run -d --volumes-from rancher-data \
   --restart=unless-stopped \
   -p 80:80 -p 443:443 \
-	rancher/rancher:<RANCHER_VERSION_TAG>
+  rancher/rancher:<RANCHER_VERSION_TAG>
 ```
 
 {{% /accordion %}}
@@ -157,11 +157,11 @@ Placeholder | Description
 ```
 docker run -d --volumes-from rancher-data \
   --restart=unless-stopped \
-	-p 80:80 -p 443:443 \
-	-v /<CERT_DIRECTORY>/<FULL_CHAIN.pem>:/etc/rancher/ssl/cert.pem \
-	-v /<CERT_DIRECTORY>/<PRIVATE_KEY.pem>:/etc/rancher/ssl/key.pem \
-	-v /<CERT_DIRECTORY>/<CA_CERTS.pem>:/etc/rancher/ssl/cacerts.pem \
-	rancher/rancher:<RANCHER_VERSION_TAG>
+  - 80:80 -p 443:443 \
+  - /<CERT_DIRECTORY>/<FULL_CHAIN.pem>:/etc/rancher/ssl/cert.pem \
+  - /<CERT_DIRECTORY>/<PRIVATE_KEY.pem>:/etc/rancher/ssl/key.pem \
+  - /<CERT_DIRECTORY>/<CA_CERTS.pem>:/etc/rancher/ssl/cacerts.pem \
+  rancher/rancher:<RANCHER_VERSION_TAG>
 ```
 
 {{% /accordion %}}
@@ -181,10 +181,10 @@ Placeholder | Description
 ```
 docker run -d --volumes-from rancher-data \
   --restart=unless-stopped \
-	-p 80:80 -p 443:443 \
- 	-v /<CERT_DIRECTORY>/<FULL_CHAIN.pem>:/etc/rancher/ssl/cert.pem \
-	-v /<CERT_DIRECTORY>/<PRIVATE_KEY.pem>:/etc/rancher/ssl/key.pem \
-	rancher/rancher:<RANCHER_VERSION_TAG> \
+  - 80:80 -p 443:443 \
+  - /<CERT_DIRECTORY>/<FULL_CHAIN.pem>:/etc/rancher/ssl/cert.pem \
+  - /<CERT_DIRECTORY>/<PRIVATE_KEY.pem>:/etc/rancher/ssl/key.pem \
+  rancher/rancher:<RANCHER_VERSION_TAG> \
   --no-cacerts
 ```
 {{% /accordion %}}
@@ -207,8 +207,8 @@ Placeholder | Description
 ```
 docker run -d --volumes-from rancher-data \
   --restart=unless-stopped \
-	-p 80:80 -p 443:443 \
-	rancher/rancher:<RANCHER_VERSION_TAG> \
+  -p 80:80 -p 443:443 \
+  rancher/rancher:<RANCHER_VERSION_TAG> \
   --acme-domain <YOUR.DNS.NAME>
 ```
 


### PR DESCRIPTION
Fixes an issue, that you could not copy these
commands into the console if they contained tabs.

