### PR TITLE
Fix broken links in K3s docs

### DIFF
--- a/content/k3s/latest/en/installation/ha/_index.md
+++ b/content/k3s/latest/en/installation/ha/_index.md
@@ -31,7 +31,7 @@ Setting up an HA cluster requires the following steps:
 You will first need to create an external datastore for the cluster. See the [Cluster Datastore Options]({{<baseurl>}}/k3s/latest/en/installation/datastore/) documentation for more details.
 
 ### 2. Launch Server Nodes
-K3s requires two or more server nodes for this HA configuration. See the [Installation Requirements]({{<baseurl>}}/k3s/latest/en/installation/node-requirements/) guide for minimum machine requirements.
+K3s requires two or more server nodes for this HA configuration. See the [Installation Requirements]({{<baseurl>}}/k3s/latest/en/installation/installation-requirements/) guide for minimum machine requirements.
 
 When running the `k3s server` command on these nodes, you must set the `datastore-endpoint` parameter so that K3s knows how to connect to the external datastore.
 

--- a/content/k3s/latest/en/installation/installation-requirements/_index.md
+++ b/content/k3s/latest/en/installation/installation-requirements/_index.md
@@ -1,6 +1,8 @@
 ---
 title: Installation Requirements
 weight: 1
+aliases:
+  - /k3s/latest/en/installation/node-requirements/
 ---
 
 K3s is very lightweight, but has some minimum requirements as outlined below.
@@ -18,7 +20,7 @@ K3s should run on just about any flavor of Linux. However, K3s is tested on the 
 *    Ubuntu 16.04 (amd64)
 *    Ubuntu 18.04 (amd64)
 
-> * If you are using **Raspbian Buster**, follow [these steps]({{<baseurl>}}/k3s/latest/en/advanced/#raspbian-buster---enable-legacy-iptables) to switch to legacy iptables.
+> * If you are using **Raspbian Buster**, follow [these steps]({{<baseurl>}}/k3s/latest/en/advanced/#enabling-legacy-iptables-on-raspbian-buster) to switch to legacy iptables.
 > * If you are using **Alpine Linux**, follow [these steps]({{<baseurl>}}/k3s/latest/en/advanced/#additional-preparation-for-alpine-linux-setup) for additional setup.
 
 

--- a/content/k3s/latest/en/networking/_index.md
+++ b/content/k3s/latest/en/networking/_index.md
@@ -7,7 +7,7 @@ weight: 35
 
 Open Ports
 ----------
-Please reference the [Installation Requirements]({{<baseurl>}}/k3s/latest/en/installation/node-requirements/#networking) page for port information.
+Please reference the [Installation Requirements]({{<baseurl>}}/k3s/latest/en/installation/installation-requirements/#networking) page for port information.
 
 CoreDNS
 -------


### PR DESCRIPTION
- Add alias to old node-requirements page on installation-requirements page so any old links / search engines will redirect node-requirements link accordingly
- Fix broken legacy iptables link for raspian at /k3s/latest/en/installation/installation-requirements/#operating-systems
- Fix broken installation requirements link at /k3s/latest/en/installation/ha/#2-launch-server-nodes
- Fix broken installation requirements link at /k3s/latest/en/networking/#open-ports

Closes https://github.com/rancher/k3s/issues/1600