### PR TITLE
Add Docker backup link to "Backups and Disaster Recovery" index

### DIFF
--- a/content/rancher/v2.x/en/backups/_index.md
+++ b/content/rancher/v2.x/en/backups/_index.md
@@ -10,7 +10,7 @@ To protect yourself from a disaster scenario, you should create backups on a reg
   - Rancher server backups:
     - [Rancher installed on a K3s Kubernetes cluster](./backups/k3s-backups)
     - [Rancher installed on an RKE Kubernetes cluster](./backups/ha-backups)
-    - Rancher installed with Docker
+    - [Rancher installed with Docker](./backups/single-node-backups/)
   - [Backing up Rancher Launched Kubernetes Clusters]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/backing-up-etcd/)
 
 In a disaster scenario, you can restore your `etcd` database by restoring a backup.


### PR DESCRIPTION
When I was looking at this page, I was bummed you didn't have docs for Docker-based backups.  Then I realized it just wasn't linked (whereas it was from pages further down the content hierarchy).

This simply adds the missing link.