### PR TITLE
Updated retention in snapshots

### DIFF
--- a/content/rancher/v2.x/en/installation/k8s-install/kubernetes-rke/_index.md
+++ b/content/rancher/v2.x/en/installation/k8s-install/kubernetes-rke/_index.md
@@ -161,7 +161,7 @@ services:
   etcd:
     snapshot: true
     creation: 6h
-    retention: 24h
+    retention: 24
 
 # Required for external TLS termination with
 # ingress-nginx v0.22+


### PR DESCRIPTION
https://rancher.com/docs/rke/latest/en/etcd-snapshots/recurring-snapshots/
as in this document RKE 0.2 + uses a numbered retention not a hours

The number of snapshots to retain before rotation. This supercedes the retention option and will override it if both are specified.