### PR TITLE
Added acme.sh as an example

### DIFF
--- a/content/rancher/v2.x/en/installation/options/helm2/helm-rancher/tls-secrets/_index.md
+++ b/content/rancher/v2.x/en/installation/options/helm2/helm-rancher/tls-secrets/_index.md
@@ -8,6 +8,9 @@ Kubernetes will create all the objects and services for Rancher, but it will not
 
 Combine the server certificate followed by any intermediate certificate(s) needed into a file named `tls.crt`. Copy your certificate key into a file named `tls.key`.
 
+For example, [acme.sh](https://acme.sh) provides server certificate and CA chains in `fullchain.cer` file. 
+This `fullchain.cer` should be renamed to `tls.crt` & certificate key file as `tls.key`.
+
 Use `kubectl` with the `tls` secret type to create the secrets.
 
 ```

--- a/content/rancher/v2.x/en/installation/options/tls-secrets/_index.md
+++ b/content/rancher/v2.x/en/installation/options/tls-secrets/_index.md
@@ -9,6 +9,9 @@ Kubernetes will create all the objects and services for Rancher, but it will not
 
 Combine the server certificate followed by any intermediate certificate(s) needed into a file named `tls.crt`. Copy your certificate key into a file named `tls.key`.
 
+For example, [acme.sh](https://acme.sh) provides server certificate and CA chains in `fullchain.cer` file. 
+This `fullchain.cer` should be renamed to `tls.crt` & certificate key file as `tls.key`.
+
 Use `kubectl` with the `tls` secret type to create the secrets.
 
 ```


### PR DESCRIPTION
Added acme.sh as an example as the users usually miss to add intermediate CA certificates in tls.crt.