### PR TITLE
[K3s] Modify About Channel Server section > Release Channels

### DIFF
--- a/content/k3s/latest/en/upgrades/automated/_index.md
+++ b/content/k3s/latest/en/upgrades/automated/_index.md
@@ -94,7 +94,7 @@ Third, the server-plan targets server nodes by specifying a label selector that 
 
 Fourth, the `prepare` step in the agent-plan will cause upgrade jobs for that plan to wait for the server-plan to complete before they execute.
 
-Fifth, both plans have the `version` field set to v1.17.4+k3s1. Alternatively, you can omit the `version` field and set the `channel` field to a URL that resolves to a release of K3s. This will cause the controller to monitor that URL and upgrade the cluster any time it resolves to a new release. This works well with the [channel server](https://github.com/rancher/channelserver). Thus, you can configure your plans with the following channel to ensure your cluster is always automatically upgraded to the newest stable release of K3s:
+Fifth, both plans have the `version` field set to v1.17.4+k3s1. Alternatively, you can omit the `version` field and set the `channel` field to a URL that resolves to a release of K3s. This will cause the controller to monitor that URL and upgrade the cluster any time it resolves to a new release. This works well with the [release channels]({{< baseurl >}}/k3s/latest/en/upgrades/basic/#release-channels). Thus, you can configure your plans with the following channel to ensure your cluster is always automatically upgraded to the newest stable release of K3s:
 ```
 apiVersion: upgrade.cattle.io/v1
 kind: Plan

--- a/content/k3s/latest/en/upgrades/basic/_index.md
+++ b/content/k3s/latest/en/upgrades/basic/_index.md
@@ -7,9 +7,17 @@ You can upgrade K3s by using the installation script, or by manually installing 
 
 >**Note:** When upgrading, upgrade server nodes first one at a time, then any worker nodes.
 
-### About the Channel Server
+### Release Channels
 
-The [channel server](https://github.com/rancher/channelserver) allows the install script to install or upgrade K3s within specific channels such as `stable` (default), `latest`, or `testing`. For additional channels, see [https://update.k3s.io/v1-release/channels](https://update.k3s.io/v1-release/channels).
+Upgrades performed via the installation script or using our [automated upgrades]({{< baseurl >}}/k3s/latest/en/upgrades/automated/) feature can be tied to different release channels. The following channels are available:
+
+| Channel |   Description  |
+|---------------|---------|
+|      stable     | (Default) Stable is recommended for production environments. These releases have been through a period of community hardening. |
+|      latest      | Latest is recommended for trying out the latest features.  These releases have not yet been through a period of community hardening. |
+|      v1.18 (example)      | There is a release channel tied to each supported Kubernetes minor version. At the time of this writing, they are `v1.18`, `v1.17`, and `v1.16`. These channels will select the latest patch available, not necessarily a stable release. |
+
+For an exhaustive and up-to-date list of channels, you can visit the [k3s channel service API](https://update.k3s.io/v1-release/channels). For more technical details on how channels work, you see the [channelserver project](https://github.com/rancher/channelserver).
 
 ### Upgrade K3s Using the Installation Script
 
@@ -63,7 +71,7 @@ To restart servers manually:
 sudo service k3s restart
 ```
 
-To restart agents mantually:
+To restart agents manually:
 ```sh
 sudo service k3s-agent restart
 ```


### PR DESCRIPTION
- Addresses Craig's comment outlined here https://github.com/rancher/docs/pull/2488/files#r420489320
- This tweaks the /upgrades/basic and /upgrades/automate pages. The basic page now goes into more depth about the release channels -- outlining specific examples. The automated page now calls out a link directly to this section on the /basic page instead of linking to the channelserver github project.
- I called out in the "v1.18" example that this selects the LATEST in the specific minor release. This does not select stable (I don't want people to confuse that with a stable channel).
- Minor spelling fix