### PR TITLE
jetstack cert-manager doc update

### DIFF
--- a/content/rancher/v2.x/en/installation/k8s-install/helm-rancher/_index.md
+++ b/content/rancher/v2.x/en/installation/k8s-install/helm-rancher/_index.md
@@ -89,7 +89,7 @@ These instructions are adapted from the [official cert-manager documentation](ht
 
 ```
 # Install the CustomResourceDefinition resources separately
-kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/deploy/manifests/00-crds.yaml
+kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.15.0/cert-manager.crds.yaml
 
 # **Important:**
 # If you are running Kubernetes v1.15 or below, you
@@ -114,7 +114,7 @@ helm repo update
 helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
-  --version v0.12.0
+  --version v0.15.0
 ```
 
 Once you’ve installed cert-manager, you can verify it is deployed correctly by checking the cert-manager namespace for running pods:


### PR DESCRIPTION
jetstack made a path change, updating doc, also to latest version
reference: https://hub.helm.sh/charts/jetstack/cert-manager