### PR TITLE
Add documentation for using Ambassador

### DIFF
--- a/content/k3s/latest/en/networking/_index.md
+++ b/content/k3s/latest/en/networking/_index.md
@@ -29,6 +29,19 @@ You can tweak traefik to meet your needs by setting options in the traefik.yaml 
 
 To disable it, start each server with the `--no-deploy traefik` option.
 
+Ambassador Ingress Controller
+--------------------------
+
+[Ambassador](https://www.getambassador.io/) provides all the functionality of a traditional ingress controller (i.e., path-based routing) while exposing many additional capabilities such as authentication, URL rewriting, CORS, rate limiting and automatic metrics collection.
+
+The Ambassador ingress controller will use ports 80 and 443 on the host (i.e. these will not be usable for HostPort or NodePort).
+
+#### Installing Ambassador
+- First, disable traefik to avoid port conflicts by starting the server with `--no-deploy traefik` option.
+- Install Ambassador by following the instructions [here](https://www.getambassador.io/docs/latest/topics/install/install-ambassador-oss/).
+
+Read the [official documentation](https://www.getambassador.io/docs/latest/topics/running/ingress-controller/) on how to configure and use Ambassador as an ingress controller.
+
 Service Load Balancer
 ---------------------
 


### PR DESCRIPTION
This PR adds documentation around using Ambassador (https://www.getambassador.io/) as an ingress controller in k3s.

CC: @brucehorn @inercia