### PR TITLE
Update air gap and private registry docs for K3s

### DIFF
--- a/content/k3s/latest/en/installation/airgap/_index.md
+++ b/content/k3s/latest/en/installation/airgap/_index.md
@@ -5,14 +5,6 @@ weight: 60
 
 You can install K3s in an air-gapped environment using two different methods. You can either deploy a private registry and mirror docker.io or you can manually deploy images such as for small clusters.
 
-1. Provide the required images for K3s
-  - [Option A: Use a private Docker registry](#option-a-use-a-private-docker-registry)
-  - [Option B: Manually deploy images](#option-b-manually-deploy-images)
-2. Set environment variables and install K3s
-  - [Air gap installation for a single server node]
-  - [Air gap installation for agent nodes]
-  - [Air gap configuration for a high availability cluster]
-
 This document assumes you have already created your nodes in your air-gap environment and have a Docker private registry on your bastion host.
 
 If you have not yet set up a private Docker registry, refer to the official documentation [here](https://docs.docker.com/registry/deploying/#run-an-externally-accessible-registry).

--- a/content/k3s/latest/en/installation/airgap/_index.md
+++ b/content/k3s/latest/en/installation/airgap/_index.md
@@ -19,6 +19,8 @@ If you have not yet set up a private Docker registry, refer to the official docu
 
 Create and configure the `registry.yaml` file by following [this guide.]({{< baseurl >}}/k3s/latest/en/installation/private-registry)
 
+The `k3s-images.txt` file, included in the assets of each [K3s release,](https://github.com/k3s-io/k3s/releases) contains the images that will be used by K3s and should be pushed to the private registry.
+
 Once you have completed this, go to the [Install K3s](#install-k3s) section.
 
 ### Option B: Manually Deploy Images

--- a/content/k3s/latest/en/installation/airgap/upgrades/_index.md
+++ b/content/k3s/latest/en/installation/airgap/upgrades/_index.md
@@ -1,0 +1,33 @@
+---
+title: Upgrading K3s in an Air Gapped Environment
+weight: 1
+---
+
+Air gapped K3s Kubernetes clusters can be upgraded using an installation script, or by using an automated upgrade process.
+
+### Install Script Method
+
+Upgrading an air-gap environment can be accomplished in the following manner:
+
+1. Download the new air-gap images (tar file) from the [releases](https://github.com/rancher/k3s/releases) page for the version of K3s you will be upgrading to.
+1. Place the tar in the `/var/lib/rancher/k3s/agent/images/` directory on each node. Delete the old tar file.
+1. Copy and replace the old K3s binary in `/usr/local/bin` on each node.
+1. Copy over the install script at https://get.k3s.io (as it is possible it has changed since the last release).
+1. Run the script again just as you had done in the past,
+using the same environment variables.
+1. Restart the K3s service (if not restarted automatically by installer).
+
+### Automated Upgrades Method
+
+As of v1.17.4+k3s1 K3s supports [automated upgrades]({{< baseurl >}}/k3s/latest/en/upgrades/automated/). To enable this in air-gapped environments, you must ensure the required images are available in your private registry.
+
+You will need the version of rancher/k3s-upgrade that corresponds to the version of K3s you intend to upgrade to. Note, the image tag replaces the `+` in the K3s release with a `-` because Docker images do not support `+`.
+
+You will also need the versions of system-upgrade-controller and kubectl that are specified in the system-upgrade-controller manifest YAML that you will deploy. Check for the latest release of the system-upgrade-controller [here](https://github.com/rancher/system-upgrade-controller/releases/latest) and download the system-upgrade-controller.yaml to determine the versions you need to push to your private registry. For example, in release v0.4.0 of the system-upgrade-controller, these images are specified in the manifest YAML:
+
+```
+rancher/system-upgrade-controller:v0.4.0
+rancher/kubectl:v0.17.0
+```
+
+Once you have added the necessary rancher/k3s-upgrade, rancher/system-upgrade-controller, and rancher/kubectl images to your private registry, follow the [automated upgrades]({{< baseurl >}}/k3s/latest/en/upgrades/automated/) guide.


### PR DESCRIPTION
This PR is intended to address https://github.com/rancher/k3s/issues/1802 and https://github.com/rancher/k3s/issues/1148

It makes the following changes:

- Adds the correct example config for `registries.yaml` from this comment: https://github.com/rancher/k3s/issues/1802#issuecomment-629635293
- Adds the example containerd configuration template from this comment https://github.com/rancher/k3s/issues/1148#issuecomment-559407926
- Organizes the private registry and air gap installation pages for clarity
- Adds another mirror example for the mirrors section of the `registries.yaml` to hopefully convey that when you are naming your own private registry as a mirror, it shouldn't have quotes around it in one of the places it is named:

```
mirrors:
  docker.io:
    endpoint:
      - "https://mycustomreg.com:5000"
  <YOUR_PRIVATE_REGISTRY_IP>:<PORT>:
    endpoint:
      - "<YOUR_PRIVATE_REGISTRY_IP>:<PORT>"
```