### PR TITLE
Update and centralize cluster capabilities table

### DIFF
--- a/content/rancher/v2.x/en/cluster-admin/_index.md
+++ b/content/rancher/v2.x/en/cluster-admin/_index.md
@@ -23,22 +23,7 @@ Alternatively, you can switch between projects and clusters directly in the navi
 
 After clusters have been [provisioned into Rancher]({{<baseurl>}}/rancher/v2.x/en/cluster-provisioning/), [cluster owners]({{<baseurl>}}/rancher/v2.x/en/admin-settings/rbac/cluster-project-roles/#cluster-roles) will need to manage these clusters. There are many different options of how to manage your cluster. 
 
-| Action | [Rancher launched Kubernetes Clusters]({{<baseurl>}}/rancher/v2.x/en/cluster-provisioning/rke-clusters/) | [Hosted Kubernetes Clusters]({{<baseurl>}}/rancher/v2.x/en/cluster-provisioning/hosted-kubernetes-clusters/) | [Imported Clusters]({{<baseurl>}}/rancher/v2.x/en/cluster-provisioning/imported-clusters) |
-| --- | --- | ---| ---|
-| [Using kubectl and a kubeconfig file to Access a Cluster]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/cluster-access/kubectl/) | ✓ | ✓ | ✓ |
-| [Adding Cluster Members]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/cluster-access/cluster-members/) | ✓ | ✓ | ✓ |
-| [Editing Clusters]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/editing-clusters/) | ✓ | ✓ | * |
-| [Managing Nodes]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/nodes) | ✓ | ✓ | ✓ |
-| [Managing Persistent Volumes and Storage Classes]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/volumes-and-storage/) | ✓ | ✓ | ✓ |
-| [Managing Projects and Namespaces]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/projects-and-namespaces/) | ✓ | ✓ | ✓ |
-| [Configuring Tools](#configuring-tools) | ✓ | ✓ | ✓ |
-| [Cloning Clusters]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/cloning-clusters/)| ✓ | ✓ | |
-| [Ability to rotate certificates]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/certificate-rotation/) | ✓ |  | |
-| [Ability to back up your Kubernetes Clusters]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/backing-up-etcd/) | ✓ | | |
-| [Ability to recover and restore etcd]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/restoring-etcd/) | ✓ | | |
-| [Cleaning Kubernetes components when clusters are no longer reachable from Rancher]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/cleaning-cluster-nodes/) | ✓ | | |
-
-/* Cluster configuration options can't be edited for imported clusters, except for [K3s clusters.]({{<baseurl>}}/rancher/v2.x/en/cluster-provisioning/imported-clusters/#additional-features-for-imported-k3s-clusters)
+{{% readfile file="/rancher/v2.x/en/cluster-admin/cluster-capabilities-table.md" markdown="true" %}}
 
 ## Configuring Tools
 
@@ -48,5 +33,7 @@ Rancher contains a variety of tools that aren't included in Kubernetes to assist
 - Notifiers
 - Logging
 - Monitoring
+- Istio Service Mesh
+- OPA Gatekeeper
 
 For more information, see [Tools]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/tools/)

--- a/content/rancher/v2.x/en/cluster-admin/cluster-capabilities-table.md
+++ b/content/rancher/v2.x/en/cluster-admin/cluster-capabilities-table.md
@@ -1,0 +1,19 @@
+| Action | [Rancher launched Kubernetes Clusters]({{<baseurl>}}/rancher/v2.x/en/cluster-provisioning/rke-clusters/) | [Hosted Kubernetes Clusters]({{<baseurl>}}/rancher/v2.x/en/cluster-provisioning/hosted-kubernetes-clusters/) | [Imported Clusters]({{<baseurl>}}/rancher/v2.x/en/cluster-provisioning/imported-clusters) |
+| --- | --- | ---| ---|
+| [Using kubectl and a kubeconfig file to Access a Cluster]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/cluster-access/kubectl/) | ✓ | ✓ | ✓ |
+| [Managing Cluster Members]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/cluster-access/cluster-members/) | ✓ | ✓ | ✓ |
+| [Editing and Upgrading Clusters]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/editing-clusters/) | ✓ | ✓ | * |
+| [Managing Nodes]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/nodes) | ✓ | ✓ | ✓ |
+| [Managing Persistent Volumes and Storage Classes]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/volumes-and-storage/) | ✓ | ✓ | ✓ |
+| [Managing Projects, Namespaces and Workloads]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/projects-and-namespaces/) | ✓ | ✓ | ✓ |
+| [Using App Catalogs]({{<baseurl>}}/rancher/v2.x/en/catalog/) | ✓ | ✓ | ✓ |
+| [Configuring Tools (Alerts, Notifiers, Logging, Monitoring, Istio)]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/tools/) | ✓ | ✓ | ✓ |
+| [Cloning Clusters]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/cloning-clusters/)| ✓ | ✓ | |
+| [Ability to rotate certificates]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/certificate-rotation/) | ✓ |  | |
+| [Ability to back up your Kubernetes Clusters]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/backing-up-etcd/) | ✓ | | |
+| [Ability to recover and restore etcd]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/restoring-etcd/) | ✓ | | |
+| [Cleaning Kubernetes components when clusters are no longer reachable from Rancher]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/cleaning-cluster-nodes/) | ✓ | | |
+| [Configuring Pod Security Policies]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/pod-security-policy/) | ✓ |  | |
+| [Running Security Scans]({{<baseurl>}}/rancher/v2.x/en/security/security-scan/) | ✓ |  | |
+
+/* Cluster configuration options can't be edited for imported clusters, except for [K3s clusters.]({{<baseurl>}}/rancher/v2.x/en/cluster-provisioning/imported-clusters/#additional-features-for-imported-k3s-clusters)

--- a/content/rancher/v2.x/en/cluster-admin/editing-clusters/_index.md
+++ b/content/rancher/v2.x/en/cluster-admin/editing-clusters/_index.md
@@ -12,11 +12,7 @@ The options and settings available for an existing cluster change based on the m
 
 The following table summarizes the options and settings available for each cluster type:
 
- Rancher Capability | RKE Launched | Hosted Kubernetes Cluster | Imported Cluster
- ---------|----------|---------|---------|
- Manage member roles | ✓ | ✓ | ✓
- Edit cluster options | ✓ | | 
- Manage node pools | ✓ | |
+{{% readfile file="/rancher/v2.x/en/cluster-admin/cluster-capabilities-table.md" markdown="true" %}}
 
 ## Editing Cluster Membership
 

--- a/content/rancher/v2.x/en/cluster-provisioning/_index.md
+++ b/content/rancher/v2.x/en/cluster-provisioning/_index.md
@@ -28,13 +28,7 @@ This section covers the following topics:
 
 The following table summarizes the options and settings available for each cluster type:
 
-| Rancher Capability   | RKE Launched | Hosted Kubernetes Cluster | Imported Cluster |
-| -------------------- | ------------ | ------------------------- | ---------------- |
-| Manage member roles  | ✓            | ✓                         | ✓                |
-| Edit cluster options | ✓            |                           |   *              |
-| Manage node pools    | ✓            |                           |
-
-/* Cluster configuration options can't be edited for imported clusters, except for [K3s clusters.](#importing-and-editing-k3s-clusters)
+{{% readfile file="/rancher/v2.x/en/cluster-admin/cluster-capabilities-table.md" markdown="true" %}}
 
 # Setting up Clusters in a Hosted Kubernetes Provider
 

--- a/content/rancher/v2.x/en/overview/_index.md
+++ b/content/rancher/v2.x/en/overview/_index.md
@@ -60,8 +60,4 @@ After a cluster is created with Rancher, a cluster administrator can manage clus
 
 The following table summarizes the options and settings available for each cluster type:
 
- Rancher Capability | RKE Launched | Hosted Kubernetes Cluster | Imported Cluster
- ---------|----------|---------|---------|
- Manage member roles | ✓ | ✓ | ✓
- Edit cluster options | ✓ | | 
- Manage node pools | ✓ | |
+{{% readfile file="/rancher/v2.x/en/cluster-admin/cluster-capabilities-table.md" markdown="true" %}}


### PR DESCRIPTION
Currently there are 4 different occurrences of the cluster capabilities table that compares which features you can use in Rancher with RKE clusters, hosted cloud provider clusters and imported clusters. One of them is very detailed but a bit outdated, the other ones only mention basic features and are not complete.

This commit centralizes the table and includes it on all 4 pages and updates it for features introduced with 2.4