### PR TITLE
Use the installCRDs option for cert-manager

### DIFF
--- a/content/rancher/v2.x/en/installation/k8s-install/helm-rancher/_index.md
+++ b/content/rancher/v2.x/en/installation/k8s-install/helm-rancher/_index.md
@@ -88,9 +88,6 @@ This step is only required to use certificates issued by Rancher's generated CA 
 These instructions are adapted from the [official cert-manager documentation](https://cert-manager.io/docs/installation/kubernetes/#installing-with-helm).
 
 ```
-# Install the CustomResourceDefinition resources separately
-kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.15.0/cert-manager.crds.yaml
-
 # **Important:**
 # If you are running Kubernetes v1.15 or below, you
 # will need to add the `--validate=false` flag to your
@@ -114,7 +111,8 @@ helm repo update
 helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
-  --version v0.15.0
+  --version v0.15.0 \
+  --set installCRDs=true
 ```
 
 Once you’ve installed cert-manager, you can verify it is deployed correctly by checking the cert-manager namespace for running pods:

--- a/content/rancher/v2.x/en/installation/k8s-install/helm-rancher/_index.md
+++ b/content/rancher/v2.x/en/installation/k8s-install/helm-rancher/_index.md
@@ -88,8 +88,8 @@ This step is only required to use certificates issued by Rancher's generated CA 
 These instructions are adapted from the [official cert-manager documentation](https://cert-manager.io/docs/installation/kubernetes/#installing-with-helm).
 
 ```
-# Install the CustomResourceDefinition resources separately	
-kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.0.1/cert-manager.crds.yaml	
+# Install the CustomResourceDefinition resources separately
+kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.0.1/cert-manager.crds.yaml
 
 # **Important:**
 # If you are running Kubernetes v1.15 or below, you

--- a/content/rancher/v2.x/en/installation/k8s-install/helm-rancher/_index.md
+++ b/content/rancher/v2.x/en/installation/k8s-install/helm-rancher/_index.md
@@ -89,7 +89,7 @@ These instructions are adapted from the [official cert-manager documentation](ht
 
 ```
 # Install the CustomResourceDefinition resources separately
-kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.0.1/cert-manager.crds.yaml
+kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.0.4/cert-manager.crds.yaml
 
 # **Important:**
 # If you are running Kubernetes v1.15 or below, you
@@ -114,7 +114,7 @@ helm repo update
 helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
-  --version v1.0.1
+  --version v1.0.4
 ```
 
 Once you’ve installed cert-manager, you can verify it is deployed correctly by checking the cert-manager namespace for running pods:

--- a/content/rancher/v2.x/en/installation/k8s-install/helm-rancher/_index.md
+++ b/content/rancher/v2.x/en/installation/k8s-install/helm-rancher/_index.md
@@ -88,6 +88,9 @@ This step is only required to use certificates issued by Rancher's generated CA 
 These instructions are adapted from the [official cert-manager documentation](https://cert-manager.io/docs/installation/kubernetes/#installing-with-helm).
 
 ```
+# Install the CustomResourceDefinition resources separately	
+kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.0.1/cert-manager.crds.yaml	
+
 # **Important:**
 # If you are running Kubernetes v1.15 or below, you
 # will need to add the `--validate=false` flag to your
@@ -111,8 +114,7 @@ helm repo update
 helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
-  --version v0.15.0 \
-  --set installCRDs=true
+  --version v1.0.1
 ```
 
 Once you’ve installed cert-manager, you can verify it is deployed correctly by checking the cert-manager namespace for running pods:


### PR DESCRIPTION
Uses this feature: https://github.com/jetstack/cert-manager/pull/2775

Given the recommended version in the docs is now 0.15.0 there's no real reason we can't use the flag provided. One less command for people to run too :)