### PR TITLE
Update airgapped installation documentation to newer version of cert manager

### DIFF
--- a/content/rancher/v2.x/en/installation/other-installation-methods/air-gap/install-rancher/_index.md
+++ b/content/rancher/v2.x/en/installation/other-installation-methods/air-gap/install-rancher/_index.md
@@ -85,22 +85,19 @@ By default, Rancher generates a CA and uses cert-manager to issue the certificat
 1. Fetch the latest cert-manager chart available from the [Helm chart repository](https://hub.helm.sh/charts/jetstack/cert-manager).
 
    ```plain
-   helm fetch jetstack/cert-manager --version v0.12.0
+   helm fetch jetstack/cert-manager --version v0.15.1
    ```
 
 1. Render the cert manager template with the options you would like to use to install the chart. Remember to set the `image.repository` option to pull the image from your private registry. This will create a `cert-manager` directory with the Kubernetes manifest files.
    ```plain
-   helm template cert-manager ./cert-manager-v0.12.0.tgz --output-dir . \
+   helm template cert-manager ./cert-manager-v0.15.1.tgz --output-dir . \
        --namespace cert-manager \
        --set image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-controller \
        --set webhook.image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-webhook \
        --set cainjector.image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-cainjector
+       --set installCRDs=true
    ```
 
-1. Download the required CRD file for cert-manager
-   ```plain
-   curl -L -o cert-manager/cert-manager-crd.yaml https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/deploy/manifests/00-crds.yaml
-   ```
 1. Render the Rancher template, declaring your chosen options. Use the reference table below to replace each placeholder. Rancher needs to be configured to use the private registry in order to provision any Rancher launched Kubernetes clusters or Rancher tools.
 
 
@@ -183,18 +180,14 @@ If you are using self-signed certificates, install cert-manager:
 kubectl create namespace cert-manager
 ```
 
-1. Create the cert-manager CustomResourceDefinitions (CRDs).
+1. Launch cert-manager.
 ```plain
-kubectl apply -f cert-manager/cert-manager-crd.yaml
+kubectl apply -R -f ./cert-manager
 ```
 
     > **Note:**
     > If you are running Kubernetes v1.15 or below, you will need to add the `--validate=false` flag to your `kubectl apply` command above, or else you will receive a validation error relating to the `x-kubernetes-preserve-unknown-fields` field in cert-manager’s CustomResourceDefinition resources. This is a benign error and occurs due to the way kubectl performs resource validation.
 
-1. Launch cert-manager.
-```plain
-kubectl apply -R -f ./cert-manager
-```
 
 {{% /accordion %}}
 

--- a/content/rancher/v2.x/en/installation/other-installation-methods/air-gap/install-rancher/_index.md
+++ b/content/rancher/v2.x/en/installation/other-installation-methods/air-gap/install-rancher/_index.md
@@ -184,14 +184,18 @@ If you are using self-signed certificates, install cert-manager:
 kubectl create namespace cert-manager
 ```
 
-1. Launch cert-manager.
+1. Create the cert-manager CustomResourceDefinitions (CRDs).
 ```plain
-kubectl apply -R -f ./cert-manager
+kubectl apply -f cert-manager/cert-manager-crd.yaml
 ```
 
     > **Note:**
     > If you are running Kubernetes v1.15 or below, you will need to add the `--validate=false` flag to your `kubectl apply` command above, or else you will receive a validation error relating to the `x-kubernetes-preserve-unknown-fields` field in cert-manager’s CustomResourceDefinition resources. This is a benign error and occurs due to the way kubectl performs resource validation.
 
+1. Launch cert-manager.
+```plain
+kubectl apply -R -f ./cert-manager
+```
 
 {{% /accordion %}}
 

--- a/content/rancher/v2.x/en/installation/other-installation-methods/air-gap/install-rancher/_index.md
+++ b/content/rancher/v2.x/en/installation/other-installation-methods/air-gap/install-rancher/_index.md
@@ -85,17 +85,21 @@ By default, Rancher generates a CA and uses cert-manager to issue the certificat
 1. Fetch the latest cert-manager chart available from the [Helm chart repository](https://hub.helm.sh/charts/jetstack/cert-manager).
 
    ```plain
-   helm fetch jetstack/cert-manager --version v0.15.1
+   helm fetch jetstack/cert-manager --version v1.0.1
    ```
 
 1. Render the cert manager template with the options you would like to use to install the chart. Remember to set the `image.repository` option to pull the image from your private registry. This will create a `cert-manager` directory with the Kubernetes manifest files.
    ```plain
-   helm template cert-manager ./cert-manager-v0.15.1.tgz --output-dir . \
+   helm template cert-manager ./cert-manager-v1.0.1.tgz --output-dir . \
        --namespace cert-manager \
        --set image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-controller \
        --set webhook.image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-webhook \
        --set cainjector.image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-cainjector
-       --set installCRDs=true
+   ```
+
+1. Download the required CRD file for cert-manager
+   ```plain
+   curl -L -o cert-manager/cert-manager-crd.yaml https://github.com/jetstack/cert-manager/releases/download/v1.0.1/cert-manager.crds.yaml
    ```
 
 1. Render the Rancher template, declaring your chosen options. Use the reference table below to replace each placeholder. Rancher needs to be configured to use the private registry in order to provision any Rancher launched Kubernetes clusters or Rancher tools.

--- a/content/rancher/v2.x/en/installation/other-installation-methods/air-gap/populate-private-registry/_index.md
+++ b/content/rancher/v2.x/en/installation/other-installation-methods/air-gap/populate-private-registry/_index.md
@@ -59,7 +59,7 @@ In a Kubernetes Install, if you elect to use the Rancher default self-signed TLS
     ```plain
     helm repo add jetstack https://charts.jetstack.io
     helm repo update
-    helm fetch jetstack/cert-manager --version v0.12.0
+    helm fetch jetstack/cert-manager --version v0.15.1
     helm template ./cert-manager-<version>.tgz | grep -oP '(?<=image: ").*(?=")' >> ./rancher-images.txt
     ```
 

--- a/content/rancher/v2.x/en/installation/other-installation-methods/air-gap/populate-private-registry/_index.md
+++ b/content/rancher/v2.x/en/installation/other-installation-methods/air-gap/populate-private-registry/_index.md
@@ -59,7 +59,7 @@ In a Kubernetes Install, if you elect to use the Rancher default self-signed TLS
     ```plain
     helm repo add jetstack https://charts.jetstack.io
     helm repo update
-    helm fetch jetstack/cert-manager --version v0.15.1
+    helm fetch jetstack/cert-manager --version v1.0.1
     helm template ./cert-manager-<version>.tgz | grep -oP '(?<=image: ").*(?=")' >> ./rancher-images.txt
     ```
 


### PR DESCRIPTION
- Update docs to cert manager 0.15.1 (currently non-airgapped docs are using 0.15.0)
- Use the installCRDs option which allows us to skip some steps