### PR TITLE
Add cloudformation:DeleteStack permission

### DIFF
--- a/content/rancher/v2.x/en/cluster-provisioning/hosted-kubernetes-clusters/eks/_index.md
+++ b/content/rancher/v2.x/en/cluster-provisioning/hosted-kubernetes-clusters/eks/_index.md
@@ -263,7 +263,8 @@ Resource targeting uses `*` as the ARN of many of the resources created cannot b
                 "cloudformation:DescribeStackResources",
                 "cloudformation:DescribeStacks",
                 "cloudformation:ListStacks",
-                "cloudformation:CreateStack"
+                "cloudformation:CreateStack",
+                "cloudformation:DeleteStack"
             ],
             "Resource": "*"
         },


### PR DESCRIPTION
Further permission is needed to delete the stack after creating a cluster:

`2020/06/30 03:43:42 [ERROR] Error removing cluster [c-xxxx] with driver [amazonelasticcontainerservice]. Check for stray resources on cloud provider: error deleting service role stack: error deleting stack: AccessDenied: User: arn:aws:iam::xxx is not authorized to perform: cloudformation:DeleteStack on resource:`