### PR TITLE
Move cluster-capabilities-table to a headless bundle

### DIFF
--- a/content/rancher/v2.x/en/cluster-admin/_index.md
+++ b/content/rancher/v2.x/en/cluster-admin/_index.md
@@ -23,7 +23,7 @@ Alternatively, you can switch between projects and clusters directly in the navi
 
 After clusters have been [provisioned into Rancher]({{<baseurl>}}/rancher/v2.x/en/cluster-provisioning/), [cluster owners]({{<baseurl>}}/rancher/v2.x/en/admin-settings/rbac/cluster-project-roles/#cluster-roles) will need to manage these clusters. There are many different options of how to manage your cluster. 
 
-{{% readfile file="/rancher/v2.x/en/cluster-admin/cluster-capabilities-table.md" markdown="true" %}}
+{{% include file="/rancher/v2.x/en/cluster-provisioning/cluster-capabilities-table" %}}
 
 ## Configuring Tools
 

--- a/content/rancher/v2.x/en/cluster-admin/editing-clusters/_index.md
+++ b/content/rancher/v2.x/en/cluster-admin/editing-clusters/_index.md
@@ -12,7 +12,7 @@ The options and settings available for an existing cluster change based on the m
 
 The following table summarizes the options and settings available for each cluster type:
 
-{{% readfile file="/rancher/v2.x/en/cluster-admin/cluster-capabilities-table.md" markdown="true" %}}
+{{% include file="/rancher/v2.x/en/cluster-provisioning/cluster-capabilities-table" %}}
 
 ## Editing Cluster Membership
 

--- a/content/rancher/v2.x/en/cluster-provisioning/_index.md
+++ b/content/rancher/v2.x/en/cluster-provisioning/_index.md
@@ -28,7 +28,7 @@ This section covers the following topics:
 
 The following table summarizes the options and settings available for each cluster type:
 
-{{% readfile file="/rancher/v2.x/en/cluster-admin/cluster-capabilities-table.md" markdown="true" %}}
+{{% include file="/rancher/v2.x/en/cluster-provisioning/cluster-capabilities-table" %}}
 
 # Setting up Clusters in a Hosted Kubernetes Provider
 

--- a/content/rancher/v2.x/en/cluster-provisioning/cluster-capabilities-table/index.md
+++ b/content/rancher/v2.x/en/cluster-provisioning/cluster-capabilities-table/index.md
@@ -1,3 +1,6 @@
+---
+headless: true
+---
 | Action | [Rancher launched Kubernetes Clusters]({{<baseurl>}}/rancher/v2.x/en/cluster-provisioning/rke-clusters/) | [Hosted Kubernetes Clusters]({{<baseurl>}}/rancher/v2.x/en/cluster-provisioning/hosted-kubernetes-clusters/) | [Imported Clusters]({{<baseurl>}}/rancher/v2.x/en/cluster-provisioning/imported-clusters) |
 | --- | --- | ---| ---|
 | [Using kubectl and a kubeconfig file to Access a Cluster]({{<baseurl>}}/rancher/v2.x/en/cluster-admin/cluster-access/kubectl/) | ✓ | ✓ | ✓ |

--- a/content/rancher/v2.x/en/overview/_index.md
+++ b/content/rancher/v2.x/en/overview/_index.md
@@ -60,4 +60,4 @@ After a cluster is created with Rancher, a cluster administrator can manage clus
 
 The following table summarizes the options and settings available for each cluster type:
 
-{{% readfile file="/rancher/v2.x/en/cluster-admin/cluster-capabilities-table.md" markdown="true" %}}
+{{% include file="/rancher/v2.x/en/cluster-provisioning/cluster-capabilities-table" %}}

--- a/layouts/shortcodes/include.html
+++ b/layouts/shortcodes/include.html
@@ -1,0 +1,5 @@
+{{$file := .Get "file"}}
+
+{{- with .Site.GetPage $file -}}
+{{- .Content | markdownify -}}
+{{- end -}}


### PR DESCRIPTION
Move cluster-capabilities-table to a headless bundle and include it as a page instead of reading the file

This prevents the table to automatically be included on pages of other bundles.
By including the page instead of reading the file also the shortcodes in the table are expanded correctly.

This fixes broken links in the table.

Fixes #2577

Follow up PR of https://github.com/rancher/docs/pull/2585 which also works now on a fresh build.