### PR TITLE
Hardcode keys in kubectl create secret commands

### DIFF
--- a/content/rancher/v2.x/en/installation/options/chart-options/_index.md
+++ b/content/rancher/v2.x/en/installation/options/chart-options/_index.md
@@ -139,7 +139,7 @@ If you have private registries, catalogs or a proxy that intercepts certificates
 Once the Rancher deployment is created, copy your CA certs in pem format into a file named `ca-additional.pem` and use `kubectl` to create the `tls-ca-additional` secret in the `cattle-system` namespace.
 
 ```plain
-kubectl -n cattle-system create secret generic tls-ca-additional --from-file=ca-additional.pem
+kubectl -n cattle-system create secret generic tls-ca-additional --from-file=ca-additional.pem=./ca-additional.pem
 ```
 
 ### Private Registry and Air Gap Installs

--- a/content/rancher/v2.x/en/installation/options/helm2/helm-rancher/chart-options/_index.md
+++ b/content/rancher/v2.x/en/installation/options/helm2/helm-rancher/chart-options/_index.md
@@ -135,7 +135,7 @@ If you have private registries, catalogs or a proxy that intercepts certificates
 Once the Rancher deployment is created, copy your CA certs in pem format into a file named `ca-additional.pem` and use `kubectl` to create the `tls-ca-additional` secret in the `cattle-system` namespace.
 
 ```plain
-kubectl -n cattle-system create secret generic tls-ca-additional --from-file=ca-additional.pem
+kubectl -n cattle-system create secret generic tls-ca-additional --from-file=ca-additional.pem=./ca-additional.pem
 ```
 
 ### Private Registry and Air Gap Installs

--- a/content/rancher/v2.x/en/installation/options/helm2/helm-rancher/tls-secrets/_index.md
+++ b/content/rancher/v2.x/en/installation/options/helm2/helm-rancher/tls-secrets/_index.md
@@ -27,9 +27,7 @@ If you are using a private CA, Rancher requires a copy of the CA certificate whi
 
 Copy the CA certificate into a file named `cacerts.pem` and use `kubectl` to create the `tls-ca` secret in the `cattle-system` namespace.
 
->**Important:** Make sure the file is called `cacerts.pem` as Rancher uses that filename to configure the CA certificate.
-
 ```
 kubectl -n cattle-system create secret generic tls-ca \
-  --from-file=cacerts.pem
+  --from-file=cacerts.pem=./cacerts.pem
 ```

--- a/content/rancher/v2.x/en/installation/options/tls-secrets/_index.md
+++ b/content/rancher/v2.x/en/installation/options/tls-secrets/_index.md
@@ -28,11 +28,9 @@ If you are using a private CA, Rancher requires a copy of the CA certificate whi
 
 Copy the CA certificate into a file named `cacerts.pem` and use `kubectl` to create the `tls-ca` secret in the `cattle-system` namespace.
 
->**Important:** Make sure the file is called `cacerts.pem` as Rancher uses that filename to configure the CA certificate.
-
 ```
 kubectl -n cattle-system create secret generic tls-ca \
-  --from-file=cacerts.pem
+  --from-file=cacerts.pem=./cacerts.pem
 ```
 
 > **Note:** The configured `tls-ca` secret is retrieved when Rancher starts. On a running Rancher installation the updated CA will take effect after new Rancher pods are started.


### PR DESCRIPTION
This hardcodes the generated key name in all `kubectl create secret` commands where the `--from-file` option is used. It ensures that the stored key is the one that Rancher expects and does not rely on the local file name.

From the kubectl docs:

```
  # Create a new secret named my-secret with specified keys instead of names on disk
  kubectl create secret generic my-secret --from-file=ssh-privatekey=path/to/id_rsa
--from-file=ssh-publickey=path/to/id_rsa.pub
```

This syntax is also already used in other places like https://github.com/rancher/docs/blob/master/content/rancher/v2.x/en/cluster-admin/tools/monitoring/custom-metrics/_index.md#L158-L158