### PR TITLE
Remove docker.io from mirror specification

### DIFF
--- a/content/k3s/latest/en/installation/private-registry/_index.md
+++ b/content/k3s/latest/en/installation/private-registry/_index.md
@@ -25,7 +25,7 @@ Mirrors is a directive that defines the names and endpoints of the private regis
 
 ```
 mirrors:
-  docker.io:
+  mycustomreg.com:
     endpoint:
       - "https://mycustomreg.com:5000"
 ```


### PR DESCRIPTION
Previously, we specified docker.io as the registry key in this config section, but with a mirror endpoint of `mycustomreg.com`. 

This is misleading in cases where there are private images to be pulled that are not obtained from that registry. If you use `docker.io` or don't prefix your images, containerd will 401 trying to pull because the creds are invalid for hub.docker.com