### PR TITLE
Update _index.md

### DIFF
--- a/content/rancher/v2.x/en/installation/other-installation-methods/air-gap/install-rancher/_index.md
+++ b/content/rancher/v2.x/en/installation/other-installation-methods/air-gap/install-rancher/_index.md
@@ -206,7 +206,7 @@ kubectl -n cattle-system apply -R -f ./rancher
 ```
 **Step Result:** If you are installing Rancher v2.3.0+, the installation is complete.
 
-> **Note:** If you don't intend to send telemetry data, opt out [telemetry]({{<baseurl>}}/rancher/v2.x/en/faq/telemetry/) during the initial login.
+> **Note:** If you don't intend to send telemetry data, opt out [telemetry]({{<baseurl>}}/rancher/v2.x/en/faq/telemetry/) during the initial login. Leaving this active in an air-gapped environment can cause issues if the socket's can not be opened successfully.
 
 ### E. For Rancher versions prior to v2.3.0, Configure System Charts
 

--- a/content/rancher/v2.x/en/installation/other-installation-methods/air-gap/install-rancher/_index.md
+++ b/content/rancher/v2.x/en/installation/other-installation-methods/air-gap/install-rancher/_index.md
@@ -206,7 +206,7 @@ kubectl -n cattle-system apply -R -f ./rancher
 ```
 **Step Result:** If you are installing Rancher v2.3.0+, the installation is complete.
 
-> **Note:** If you don't intend to send telemetry data, opt out [telemetry]({{<baseurl>}}/rancher/v2.x/en/faq/telemetry/) during the initial login. Leaving this active in an air-gapped environment can cause issues if the socket's can not be opened successfully.
+> **Note:** If you don't intend to send telemetry data, opt out [telemetry]({{<baseurl>}}/rancher/v2.x/en/faq/telemetry/) during the initial login. Leaving this active in an air-gapped environment can cause issues if the sockets cannot be opened successfully.
 
 ### E. For Rancher versions prior to v2.3.0, Configure System Charts
 


### PR DESCRIPTION
The note should be clearer.  Leaving this enabled in an Air-gapped env caused a LOT of issues that were hard to track as sockets were slowly being used up.  It might be worth having this be even clearer than my addition, or just outright saying to disable telemetry for air-gapped envs.