### PR TITLE
Fix bogus text formatting introduced in #2583

### DIFF
--- a/content/k3s/latest/en/networking/_index.md
+++ b/content/k3s/latest/en/networking/_index.md
@@ -31,7 +31,7 @@ Traefik is deployed by default when starting the server. For more information se
 
 The Traefik ingress controller will use ports 80, 443, and 8080 on the host (i.e. these will not be usable for HostPort or NodePort).
 
-Traefik can be configured by editing the `traefik.yaml` file. To prevent k3s from using or overwriting the modified version, deploy k3s with `--no-deploy traefik` and store the modified copy in the `k3s/server/manifests directory`. For more information, refer to the official [Traefik for Helm Configuration Parameters.](https://github.com/helm/charts/tree/master/stable/traefik#configuration)
+Traefik can be configured by editing the `traefik.yaml` file. To prevent k3s from using or overwriting the modified version, deploy k3s with `--no-deploy traefik` and store the modified copy in the `k3s/server/manifests` directory. For more information, refer to the official [Traefik for Helm Configuration Parameters.](https://github.com/helm/charts/tree/master/stable/traefik#configuration)
 
 To disable it, start each server with the `--disable traefik` option.
 


### PR DESCRIPTION
In content/k3s/latest/en/networking/_index.md, "`k3s/server/manifests directory`" should be "`k3s/server/manifests`
directory".

I did not see this until it was too late, sorry about that.
