### PR TITLE
URL(restoring your cluster from a snapshot) is 404

### DIFF
--- a/content/rke/latest/en/managing-clusters/_index.md
+++ b/content/rke/latest/en/managing-clusters/_index.md
@@ -26,7 +26,7 @@ You can add/remove only worker nodes, by running `rke up --update-only`. This wi
 
 In order to remove the Kubernetes components from nodes, you use the `rke remove` command.
 
-> **Warning:** This command is irreversible and will destroy the Kubernetes cluster, including etcd snapshots on S3. If there is a disaster and your cluster is inaccessible, refer to the process for [restoring your cluster from a snapshot]({{<baseurl>}}rke/latest/en/etcd-snapshots/#etcd-disaster-recovery).
+> **Warning:** This command is irreversible and will destroy the Kubernetes cluster, including etcd snapshots on S3. If there is a disaster and your cluster is inaccessible, refer to the process for [restoring your cluster from a snapshot]({{<baseurl>}}/rke/latest/en/etcd-snapshots/#etcd-disaster-recovery).
 
 The `rke remove` command does the following to each node in the `cluster.yml`:
 


### PR DESCRIPTION
The following URL was a 404.

[Rancher Docs: Backups and Disaster Recovery](https://rancher.com/docs/rke/latest/en/etcd-snapshots/)