### PR TITLE
Fixes the not working upgrade commands

### DIFF
--- a/content/rancher/v2.x/en/upgrades/upgrades/single-node/_index.md
+++ b/content/rancher/v2.x/en/upgrades/upgrades/single-node/_index.md
@@ -157,10 +157,10 @@ Placeholder | Description
 ```
 docker run -d --volumes-from rancher-data \
   --restart=unless-stopped \
-  - 80:80 -p 443:443 \
-  - /<CERT_DIRECTORY>/<FULL_CHAIN.pem>:/etc/rancher/ssl/cert.pem \
-  - /<CERT_DIRECTORY>/<PRIVATE_KEY.pem>:/etc/rancher/ssl/key.pem \
-  - /<CERT_DIRECTORY>/<CA_CERTS.pem>:/etc/rancher/ssl/cacerts.pem \
+  -p 80:80 -p 443:443 \
+  -v /<CERT_DIRECTORY>/<FULL_CHAIN.pem>:/etc/rancher/ssl/cert.pem \
+  -v /<CERT_DIRECTORY>/<PRIVATE_KEY.pem>:/etc/rancher/ssl/key.pem \
+  -v /<CERT_DIRECTORY>/<CA_CERTS.pem>:/etc/rancher/ssl/cacerts.pem \
   rancher/rancher:<RANCHER_VERSION_TAG>
 ```
 
@@ -181,9 +181,9 @@ Placeholder | Description
 ```
 docker run -d --volumes-from rancher-data \
   --restart=unless-stopped \
-  - 80:80 -p 443:443 \
-  - /<CERT_DIRECTORY>/<FULL_CHAIN.pem>:/etc/rancher/ssl/cert.pem \
-  - /<CERT_DIRECTORY>/<PRIVATE_KEY.pem>:/etc/rancher/ssl/key.pem \
+  -p 80:80 -p 443:443 \
+  -v /<CERT_DIRECTORY>/<FULL_CHAIN.pem>:/etc/rancher/ssl/cert.pem \
+  -v /<CERT_DIRECTORY>/<PRIVATE_KEY.pem>:/etc/rancher/ssl/key.pem \
   rancher/rancher:<RANCHER_VERSION_TAG> \
   --no-cacerts
 ```


### PR DESCRIPTION
Fixes #2664

Fixes the not working upgrade commands

* OPTION B-BRING YOUR OWN CERTIFICATE: SELF-SIGNED
* OPTION C-BRING YOUR OWN CERTIFICATE: SIGNED BY RECOGNIZED CA

Added port (-p) and volume (-v) flags.

Btw: My editor (Visual studio Code) said that the Table of Content is not up to date and changed it, but I did not checked this in, because if it's an issue I don't think it belongs in this PR.
