### PR TITLE
Add the new "Configuration File" entry to the TOC

### DIFF
--- a/content/k3s/latest/en/installation/install-options/_index.md
+++ b/content/k3s/latest/en/installation/install-options/_index.md
@@ -9,6 +9,7 @@ This page focuses on the options that can be used when you set up K3s for the fi
 - [Options for installation from binary](#options-for-installation-from-binary)
 - [Registration options for the K3s server](#registration-options-for-the-k3s-server)
 - [Registration options for the K3s agent](#registration-options-for-the-k3s-agent)
+- [Configuration File](#configuration-file)
 
 In addition to configuring K3s with environment variables and CLI arguments, K3s can also use a [config file.](#configuration-file)
 


### PR DESCRIPTION
I missed this info by overlooking it as it wasn't mentioned in the top of page TOC.