### PR TITLE
Respond to feedback on CIS scan docs

### DIFF
--- a/content/rancher/v2.x/en/cis-scans/_index.md
+++ b/content/rancher/v2.x/en/cis-scans/_index.md
@@ -186,6 +186,13 @@ The report contains the following information:
 | `remediation`      | What needs to be fixed in order to pass the test. |
 | `state`    | Indicates if the test passed, failed, was skipped, or was not applicable. |
 | `node_type`        | The node role, which affects which tests are run on the node. Master tests are run on controlplane nodes, etcd tests are run on etcd nodes, and node tests are run on the worker nodes. |
+| `audit` | This is the audit check that `kube-bench` runs for this test. |
+| `audit_config` | Any configuration applicable to the audit script. |
+| `test_info` | Test-related info as reported by `kube-bench`, if any. |
+| `commands` | Test-related commands as reported by `kube-bench`, if any. |
+| `config_commands` | Test-related configuration data as reported by `kube-bench`, if any. |
+| `actual_value` | The test's actual value, present if reported by `kube-bench`. |
+| `expected_result` | The test's expected result, present if reported by `kube-bench`. |
 
 Refer to <a href="{{<baseurl>}}/rancher/v2.x/en/security/" target="_blank">the table in the cluster hardening guide</a> for information on which versions of Kubernetes, the Benchmark, Rancher, and our cluster hardening guide correspond to each other. Also refer to the hardening guide for configuration files of CIS-compliant clusters and information on remediating failed tests.
 

--- a/content/rancher/v2.x/en/cis-scans/configuration/_index.md
+++ b/content/rancher/v2.x/en/cis-scans/configuration/_index.md
@@ -28,6 +28,10 @@ spec:
 
 A profile contains the configuration for the CIS scan, which includes the benchmark version to use and any specific tests to skip in that benchmark.
 
+> By default, a few ClusterScanProfiles are installed as part of the `rancher-cis-benchmark` chart. If a user edits these default benchmarks or profiles, the next chart update will reset them back. So it is advisable for users to not edit the default  ClusterScanProfiles.
+
+Users can clone the ClusterScanProfiles to create custom profiles.
+
 Skipped tests are listed under the `skipTests` directive.
 
 When you create a new profile, you will also need to give it a name.

--- a/content/rancher/v2.x/en/cis-scans/legacy/skipped-tests/_index.md
+++ b/content/rancher/v2.x/en/cis-scans/legacy/skipped-tests/_index.md
@@ -3,8 +3,9 @@ title: Skipped and Not Applicable Tests
 weight: 1
 ---
 
-
 This section lists the tests that are skipped in the permissive test profile for RKE.
+
+All the tests that are skipped and not applicable on this page will be counted as Not Applicable in the v2.5 generated report. The skipped test count will only mention the user-defined skipped tests. This allows user-skipped tests to be distinguished from the tests that are skipped by default in the RKE permissive test profile.
 
 - [CIS Benchmark v1.5](#cis-benchmark-v1-5)
 - [CIS Benchmark v1.4](#cis-benchmark-v1-4)

--- a/content/rancher/v2.x/en/cis-scans/rbac/_index.md
+++ b/content/rancher/v2.x/en/cis-scans/rbac/_index.md
@@ -13,6 +13,8 @@ However, the `rancher-cis-benchmark` chart installs three default `ClusterRoles`
 - cis-edit
 - cis-view
 
+In Rancher, only cluster owners and global administrators have `cis-admin` access by default. 
+
 # Cluster-Admin Access
 
 Rancher CIS Scans is a cluster-admin only feature by default.

--- a/content/rancher/v2.x/en/cis-scans/skipped-tests/_index.md
+++ b/content/rancher/v2.x/en/cis-scans/skipped-tests/_index.md
@@ -5,6 +5,8 @@ weight: 3
 
 This section lists the tests that are skipped in the permissive test profile for RKE.
 
+> All the tests that are skipped and not applicable on this page will be counted as Not Applicable in the v2.5 generated report. The skipped test count will only mention the user-defined skipped tests. This allows user-skipped tests to be distinguished from the tests that are skipped by default in the RKE permissive test profile.
+
 # CIS Benchmark v1.5
 
 ### CIS Benchmark v1.5 Skipped Tests


### PR DESCRIPTION
For this this PR:

- I added the information about the new columns in the report
- I validated the test descriptions against the 1.5.0 benchmark (they didn't change)
- On the configuration page it now says the default profiles and benchmarks should not be edited. (It already said that in the benchmark configuration section, but now it also says that in the profile configuration section.)
- It now says that all the tests that are skipped and NA - all will be counted as Not Applicable in the v2.5 report. The skipped test count will only mention the user-defined skipped tests.
- The RBAC section says that in Rancher, only cluster-owner and global-admin have admin access by default. 