### PR TITLE
Update _index.md to correctly reference cloud_provider configuratuion 

### DIFF
--- a/content/rke/latest/en/config-options/cloud-providers/vsphere/config-reference/_index.md
+++ b/content/rke/latest/en/config-options/cloud-providers/vsphere/config-reference/_index.md
@@ -23,22 +23,23 @@ Given the following:
 The corresponding configuration for the provider would then be as follows:
 
 ```yaml
-(...)
-cloud_provider:
-  name: vsphere
-  vsphereCloudProvider:
-    virtual_center:
-      vc.example.com:
-        user: provisioner
-        password: secret
-        port: 443
-        datacenters: /eu-west-1
-    workspace:
-      server: vc.example.com
-      folder: /eu-west-1/folder/myvmfolder
-      default-datastore: /eu-west-1/datastore/ds-1
-      datacenter: /eu-west-1
-      resourcepool-path: /eu-west-1/host/hn1/resources/myresourcepool
+rancher_kubernetes_engine_config:
+  (...)
+  cloud_provider:
+    name: vsphere
+    vsphereCloudProvider:
+      virtual_center:
+        vc.example.com:
+          user: provisioner
+          password: secret
+          port: 443
+          datacenters: /eu-west-1
+      workspace:
+        server: vc.example.com
+        folder: myvmfolder
+        default-datastore: /eu-west-1/datastore/ds-1
+        datacenter: /eu-west-1
+        resourcepool-path: /eu-west-1/host/hn1/resources/myresourcepool
 
 ```
 # Configuration Options


### PR DESCRIPTION
Cloud provider config is under rancher_kubernetes_engine_config and should be noted that way also the folder selection is the name of the folder only, you don't have to specify the datacenter or a "/" before the name. 

The initial configuration of only "cloud_provider" with no indents is misleading and the folder reference is incorrect as I get an error in rancher logs when adding the folder with datacenter name, but works perfectly when only referencing the folder name