### PR TITLE
Fix bad link

### DIFF
--- a/content/rancher/v2.x/en/cluster-admin/tools/_index.md
+++ b/content/rancher/v2.x/en/cluster-admin/tools/_index.md
@@ -50,4 +50,4 @@ Alerts are rules that trigger those notifications. Before you can receive alerts
 
 ## OPA Gatekeeper
 
- [OPA Gatekeeper](https://github.com/open-policy-agent/gatekeeper) is an open-source project that provides integration between OPA and Kubernetes to provide policy control via admission controller webhooks. For details on how to enable Gatekeeper in Rancher, refer to the [OPA Gatekeeper section.]({{<baseurl>}}/rancher/v2.x/en/opa-gatekeeper)
+ [OPA Gatekeeper](https://github.com/open-policy-agent/gatekeeper) is an open-source project that provides integration between OPA and Kubernetes to provide policy control via admission controller webhooks. For details on how to enable Gatekeeper in Rancher, refer to the [OPA Gatekeeper section.]({{<baseurl>}}/rancher/v2.x/en/opa-gatekeper)


### PR DESCRIPTION
Either the link needs to be fixed, since gate-keeper is misspelled in the working URL, or this needs to point to the correct (misspelled) link.