### PR TITLE
Update _index.md

### DIFF
--- a/content/rancher/v2.x/en/quick-start-guide/deployment/digital-ocean-qs/_index.md
+++ b/content/rancher/v2.x/en/quick-start-guide/deployment/digital-ocean-qs/_index.md
@@ -32,7 +32,7 @@ See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [DO Q
 Suggestions include:
     - `do_region` - DigitalOcean region, choose the closest instead of the default
     - `prefix` - Prefix for all created resources
-    - `droplet_size` - Droplet size used, minimum is `s-2vcpu-4gb` but `s-4vcpu-8g` could be used if within budget
+    - `droplet_size` - Droplet size used, minimum is `s-2vcpu-4gb` but `s-4vcpu-8gb` could be used if within budget
     - `ssh_key_file_name` - Use a specific SSH key instead of `~/.ssh/id_rsa` (public key is assumed to be `${ssh_key_file_name}.pub`)
 
 1. Run `terraform init`.


### PR DESCRIPTION
change `s-4vcpu-8g` to `s-4vcpu-8gb`.
refer to https://developers.digitalocean.com/documentation/v2/#sizes

Using `s-4vcpu-8g` will course below error when executing `terraform apply`
```
Error: Error creating droplet: POST https://api.digitalocean.com/v2/droplets: 422 You specified an invalid size for Droplet creation.
```