### PR TITLE
Remove secrets from read only project role

### DIFF
--- a/content/rancher/v2.x/en/admin-settings/rbac/cluster-project-roles/_index.md
+++ b/content/rancher/v2.x/en/admin-settings/rbac/cluster-project-roles/_index.md
@@ -113,11 +113,11 @@ The following table lists each built-in custom project role available in Rancher
 | Manage Services                    | ✓             | ✓                             |               |
 | Manage Volumes                     | ✓             | ✓                             |               |
 | Manage Workloads                   | ✓             | ✓                             |               |
+| View Secrets                       | ✓             | ✓                             |               |
 | View Config Maps                   | ✓             | ✓                             | ✓             |
 | View Ingress                       | ✓             | ✓                             | ✓             |
 | View Project Members               | ✓             | ✓                             | ✓             |
 | View Project Catalogs              | ✓             | ✓                             | ✓             |
-| View Secrets                       | ✓             | ✓                             | ✓             |
 | View Service Accounts              | ✓             | ✓                             | ✓             |
 | View Services                      | ✓             | ✓                             | ✓             |
 | View Volumes                       | ✓             | ✓                             | ✓             |


### PR DESCRIPTION
The read only project role does not grant the permission to view secrets, this commit updates the Project Role Reference table to reflect this