### PR TITLE
add flannel backend port configuration example

### DIFF
--- a/content/rke/latest/en/config-options/add-ons/network-plugins/_index.md
+++ b/content/rke/latest/en/config-options/add-ons/network-plugins/_index.md
@@ -43,7 +43,6 @@ network:
     options:
         canal_iface: eth1
         canal_flannel_backend_type: vxlan
-        # must be 4789 if using Flannel VxLan mode in the cluster with Windows nodes
         canal_flannel_backend_port: "8472"
 ```
 
@@ -60,7 +59,6 @@ network:
     options:
         flannel_iface: eth1
         flannel_backend_type: vxlan
-        # must be 4789 if using VxLan mode in the cluster with Windows nodes
         flannel_backend_port: "8472"
 ```
 

--- a/content/rke/latest/en/config-options/add-ons/network-plugins/_index.md
+++ b/content/rke/latest/en/config-options/add-ons/network-plugins/_index.md
@@ -43,6 +43,8 @@ network:
     options:
         canal_iface: eth1
         canal_flannel_backend_type: vxlan
+        # must be 4789 if using Flannel VxLan mode in the cluster with Windows nodes
+        canal_flannel_backend_port: "8472"
 ```
 
 #### Canal Interface
@@ -58,6 +60,8 @@ network:
     options:
         flannel_iface: eth1
         flannel_backend_type: vxlan
+        # must be 4789 if using VxLan mode in the cluster with Windows nodes
+        flannel_backend_port: "8472"
 ```
 
 #### Flannel Interface


### PR DESCRIPTION
Sometimes the default 8472/udp port will conflict with virtualization platform, and we need to change it, while the doc doesn't mention that.