### PR TITLE
Adapt default value for noProxy helm chart variable

### DIFF
--- a/content/rancher/v2.x/en/installation/other-installation-methods/behind-proxy/install-rancher/_index.md
+++ b/content/rancher/v2.x/en/installation/other-installation-methods/behind-proxy/install-rancher/_index.md
@@ -34,7 +34,7 @@ helm upgrade --install cert-manager jetstack/cert-manager \
   --namespace cert-manager --version v0.15.2 \
   --set http_proxy=http://${proxy_host} \
   --set https_proxy=http://${proxy_host} \
-  --set no_proxy=127.0.0.0/8\\,10.0.0.0/8\\,172.16.0.0/12\\,192.168.0.0/16
+  --set no_proxy=127.0.0.0/8\\,10.0.0.0/8\\,172.16.0.0/12\\,192.168.0.0/16\\,.svc\\,.cluster.local
 ```
 
 Now you should wait until cert-manager is finished starting up:

--- a/content/rancher/v2.x/en/installation/other-installation-methods/single-node-docker/proxy/_index.md
+++ b/content/rancher/v2.x/en/installation/other-installation-methods/single-node-docker/proxy/_index.md
@@ -26,6 +26,8 @@ Passing environment variables to the Rancher container can be done using `-e KEY
 - `127.0.0.1`
 - `0.0.0.0`
 - `10.0.0.0/8`
+- `.svc`
+- `.cluster.local`
 
 The example below is based on a proxy server accessible at `http://192.168.0.1:3128`, and excluding usage the proxy when accessing network range `192.168.10.0/24` and every hostname under the domain `example.com`.
 
@@ -34,7 +36,7 @@ docker run -d --restart=unless-stopped \
   -p 80:80 -p 443:443 \
   -e HTTP_PROXY="http://192.168.10.1:3128" \
   -e HTTPS_PROXY="http://192.168.10.1:3128" \
-  -e NO_PROXY="localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,192.168.10.0/24,example.com" \
+  -e NO_PROXY="localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,192.168.10.0/24,.svc,.cluster.local,example.com" \
   --privileged \
   rancher/rancher:latest
 ```

--- a/content/rancher/v2.x/en/installation/resources/chart-options/_index.md
+++ b/content/rancher/v2.x/en/installation/resources/chart-options/_index.md
@@ -54,7 +54,7 @@ aliases:
 | `ingress.configurationSnippet` | ""                                                    | `string` - Add additional Nginx configuration. Can be used for proxy configuration. _Note: Available as of v2.0.15, v2.1.10 and v2.2.4_           |
 | `letsEncrypt.ingress.class`    | ""                                                    | `string` - optional ingress class for the cert-manager acmesolver ingress that responds to the Let's Encrypt ACME challenges                      |
 | `proxy`                        | ""                                                    | `string` - HTTP[S] proxy server for Rancher                                                                                                       |
-| `noProxy`                      | "127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16" | `string` - comma separated list of hostnames or ip address not to use the proxy                                                                   |
+| `noProxy`                      | "127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local" | `string` - comma separated list of hostnames or ip address not to use the proxy                                                                   |
 | `resources`                    | {}                                                    | `map` - rancher pod resource requests & limits                                                                                                    |
 | `rancherImage`                 | "rancher/rancher"                                     | `string` - rancher image source                                                                                                                   |
 | `rancherImageTag`              | same as chart version                                 | `string` - rancher/rancher image tag                                                                                                              |
@@ -134,11 +134,11 @@ Example on setting a static proxy header with `ingress.configurationSnippet`. Th
 
 Rancher requires internet access for some functionality (helm charts). Use `proxy` to set your proxy server.
 
-Add your IP exceptions to the `noProxy` list. Make sure you add the Service cluster IP range (default: 10.43.0.1/16) and any worker cluster `controlplane` nodes. Rancher supports CIDR notation ranges in this list.
+Add your IP exceptions to the `noProxy` list. Make sure you add the Pod cluster IP range (default: `10.42.0.0/16`), Service cluster IP range (default: `10.43.0.0/16`), the internal cluster domains (default: `.svc,.cluster.local`) and any worker cluster `controlplane` nodes. Rancher supports CIDR notation ranges in this list.
 
 ```plain
 --set proxy="http://<username>:<password>@<proxy_url>:<proxy_port>/"
---set noProxy="127.0.0.0/8\,10.0.0.0/8\,172.16.0.0/12\,192.168.0.0/16"
+--set noProxy="127.0.0.0/8\,10.0.0.0/8\,172.16.0.0/12\,192.168.0.0/16,.svc,.cluster.local"
 ```
 
 ### Additional Trusted CAs


### PR DESCRIPTION
Adapt default value for noProxy helm chart variable. New value was introduced in 2.5 with https://github.com/rancher/rancher/commit/7feec1fb9713df4903a056c5375926a613a5d85d, PR: https://github.com/rancher/rancher/pull/29491
