### PR TITLE
Remove Longhorn no longer needed storageclass info

### DIFF
--- a/content/k3s/latest/en/storage/_index.md
+++ b/content/k3s/latest/en/storage/_index.md
@@ -89,12 +89,6 @@ kubectl apply -f https://raw.githubusercontent.com/longhorn/longhorn/master/depl
 
 Longhorn will be installed in the namespace `longhorn-system`.
 
-Before we create a PVC, we will create a storage class for Longhorn with this yaml:
-
-```
-kubectl create -f https://raw.githubusercontent.com/longhorn/longhorn/master/examples/storageclass.yaml
-```
-
 Apply the yaml to create the PVC and pod:
 
 ```


### PR DESCRIPTION
This MR removes a no longer needed step about running a `kubectl create -f` method with Longhorn `storageclass` as that `storageclass` is now included in [the base yaml executed one step before](https://raw.githubusercontent.com/longhorn/longhorn/master/deploy/longhorn.yaml)