### PR TITLE
Update OS requirements section in K3s docs

### DIFF
--- a/content/k3s/latest/en/installation/installation-requirements/_index.md
+++ b/content/k3s/latest/en/installation/installation-requirements/_index.md
@@ -17,17 +17,14 @@ If all your nodes have the same hostname, use the `--with-node-id` option to app
 
 ## Operating Systems
 
-K3s should run on just about any flavor of Linux.
+K3s is expected to work on most modern Linux systems.
 
-K3s is officially supported and tested on the following operating systems and their subsequent non-major releases:
+Some OSs have specific requirements:
 
-*    Ubuntu 16.04 (amd64)
-*    Ubuntu 18.04 (amd64)
-*    Raspbian Buster*
+- If you are using **Raspbian Buster**, follow [these steps]({{<baseurl>}}/k3s/latest/en/advanced/#enabling-legacy-iptables-on-raspbian-buster) to switch to legacy iptables.
+- If you are using **Alpine Linux**, follow [these steps]({{<baseurl>}}/k3s/latest/en/advanced/#additional-preparation-for-alpine-linux-setup) for additional setup.
 
-\* If you are using **Raspbian Buster**, follow [these steps]({{<baseurl>}}/k3s/latest/en/advanced/#enabling-legacy-iptables-on-raspbian-buster) to switch to legacy iptables.
-
-If you are using **Alpine Linux**, follow [these steps]({{<baseurl>}}/k3s/latest/en/advanced/#additional-preparation-for-alpine-linux-setup) for additional setup.
+For more information on which OSs were tested with Rancher managed K3s clusters, refer to the [Rancher support and maintenance terms.](https://rancher.com/support-maintenance-terms/)
 
 ## Hardware
 


### PR DESCRIPTION
This PR is intended to bring the K3s OS requirements inline with the recommendations in this Slack thread. https://rancher.slack.com/archives/C039Y2P93/p1604507461130500?thread_ts=1604459764.129000&cid=C039Y2P93

This should clarify that as far as support goes, the Rancher support and maintenance terms define what is tested and supported. There is no separate support and maintenance document for K3s, mainly because support is not sold separately for K3s.