### PR TITLE
Remove --reuse-values from upgrade docs

### DIFF
--- a/content/rancher/v2.x/en/installation/upgrades-rollbacks/upgrades/ha/_index.md
+++ b/content/rancher/v2.x/en/installation/upgrades-rollbacks/upgrades/ha/_index.md
@@ -114,12 +114,14 @@ helm upgrade rancher rancher-<CHART_REPO>/rancher \
 
 > **Note:** The above is an example, there may be more values from the previous step that need to be appended.
 
-Alternatively, it's possible to reuse current values and make small changes with the `--reuse-values` flag. For example, to only change the Rancher version:
+Alternatively, it's possible to export the current values to a file and reference that file during upgrade. For example, to only change the Rancher version:
 
 ```
+helm get values rancher -n cattle-system -o yaml > values.yaml
+
 helm upgrade rancher rancher-<CHART_REPO>/rancher \
   --namespace cattle-system \
-  --reuse-values \
+  -f values.yaml \
   --version=2.4.5
 ```
 


### PR DESCRIPTION
Due to an issue with helm templating, remove --reuse-values and instead export current values to file and reference file during upgrade.
See https://github.com/rancher/rancher/issues/30190