### PR TITLE
VApp permissions are needed when the VApp provisioning mode is used.

### DIFF
--- a/content/rancher/v2.x/en/cluster-provisioning/rke-clusters/node-pools/vsphere/provisioning-vsphere-clusters/creating-credentials/_index.md
+++ b/content/rancher/v2.x/en/cluster-provisioning/rke-clusters/node-pools/vsphere/provisioning-vsphere-clusters/creating-credentials/_index.md
@@ -13,6 +13,7 @@ The following table lists the permissions required for the vSphere user account:
 | Network               | Assign |
 | Resource              | AssignVMToPool |
 | Virtual Machine       | Config (All) </br> GuestOperations (All) </br> Interact (All) </br> Inventory (All) </br> Provisioning (All) |
+| VApp                  | VApp application configuration </br> VApp instance configuration  |
 
 The following steps create a role with the required privileges and then assign it to a new user in the vSphere console:
 


### PR DESCRIPTION
I have found that based on currently available documentation / suggestions around using Node Templates with Distro Images and setting VApp properties to control IP addresses through network protocol profiles these VApp permissions are required on the cloud credential rancher is using or the provisioning will fail with a Permission denied error.

VCenter 6.7 U2.
Rancher 2.4.10