### PR TITLE
Add default backend section to ingress controllers

### DIFF
--- a/content/rke/latest/en/config-options/add-ons/ingress-controllers/_index.md
+++ b/content/rke/latest/en/config-options/add-ons/ingress-controllers/_index.md
@@ -52,6 +52,17 @@ ingress:
       enable-ssl-passthrough: ""
 ```
 
+### Disabling NGINX Ingress Default Backend
+
+As of v0.20.0, you can disable the [default backend service](https://kubernetes.github.io/ingress-nginx/user-guide/default-backend/) for the ingress controller. This is possible because `ingress-nginx` will fall back to a local 404 page, and does not require a backend service. The service can be enabled/disabled with a boolean value.
+
+```yaml
+ingress:
+    default_backend: false
+```
+
+> **What happens if the field is omitted?** The value of `default_backend` will default to `true`. This maintains behavior with older versions of `rke`. However, a future version of `rke` will change the default value to `false`.
+
 ## Configuring an NGINX Default Certificate
 
 When configuring an ingress object with TLS termination, you must provide it with a certificate used for encryption/decryption. Instead of explicitly defining a certificate each time you configure an ingress, you can set up a custom certificate that's used by default.


### PR DESCRIPTION
Add default backend section to ingress controllers. This section
provides a guide and brief explanation on the default backend service.

Docs issue: #2881

**Note:** This is a new PR since the original was from a `master` branch. The original PR has been closed (https://github.com/rancher/docs/pull/2888).