### PR TITLE
[k3s] Update system-upgrade-controller to v0.6.2

### DIFF
--- a/content/k3s/latest/en/upgrades/automated/_index.md
+++ b/content/k3s/latest/en/upgrades/automated/_index.md
@@ -33,7 +33,7 @@ To automate upgrades in this manner you must:
 ### Install the system-upgrade-controller
 The system-upgrade-controller can be installed as a deployment into your cluster. The deployment requires a service-account, clusterRoleBinding, and a configmap. To install these components, run the following command:
 ```
-kubectl apply -f https://github.com/rancher/system-upgrade-controller/releases/download/v0.4.0/system-upgrade-controller.yaml
+kubectl apply -f https://github.com/rancher/system-upgrade-controller/releases/download/v0.6.2/system-upgrade-controller.yaml
 ```
 The controller can be configured and customized via the previously mentioned configmap, but the controller must be redeployed for the changes to be applied.
 


### PR DESCRIPTION
Hi, I have spent longer than I would like to admit on configuring tolerations for plans, only to find out it was fixed in newer versions (>= v0.5.0) 😄 

I hope this update will save some time to other users who encountered the same issue (https://github.com/rancher/system-upgrade-controller/issues/76)!