### PR TITLE
Acessing Fleet should be in Continuous Delivery

### DIFF
--- a/content/rancher/v2.x/en/deploy-across-clusters/fleet/_index.md
+++ b/content/rancher/v2.x/en/deploy-across-clusters/fleet/_index.md
@@ -17,7 +17,7 @@ deploy everything in the cluster. This give a high degree of control, consistenc
 
 ### Accessing Fleet in the Rancher UI
 
-Fleet comes preinstalled in Rancher v2.5. To access it, go to the **Cluster Explorer** in the Rancher UI. In the top left dropdown menu, click **Cluster Explorer > Fleet.** On this page, you can edit Kubernetes resources and cluster groups managed by Fleet.
+Fleet comes preinstalled in Rancher v2.5. To access it, go to the **Cluster Explorer** in the Rancher UI. In the top left dropdown menu, click **Cluster Explorer > Continuous Delivery.** On this page, you can edit Kubernetes resources and cluster groups managed by Fleet.
 
 ### GitHub Repository
 


### PR DESCRIPTION
I'm using the Rancher server version `v2.5.3`, the way to access Fleet is through `Cluster Explorer > Continuous Delivery`.

![image](https://user-images.githubusercontent.com/49380831/102319056-4a1d5980-3fb5-11eb-9f8c-b7f1bffa3f64.png)

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>