### PR TITLE
RKE install add supported Docker versions

### DIFF
--- a/content/rke/latest/en/installation/_index.md
+++ b/content/rke/latest/en/installation/_index.md
@@ -93,7 +93,7 @@ $ port upgrade rke
 
 The Kubernetes cluster components are launched using Docker on a Linux distro. You can use any Linux you want, as long as you can install Docker on it.
 
-> RKE supports Docker versions 1.13.x, 17.03.x, 17.06.x, 17.09.x, 18.06.x, 18.09.x, 19.03.x., the latest Docker version 20.x.x is not supported.
+> For information on which Docker versions were tested with your version of RKE, refer to the [terms of service](https://rancher.com/support-maintenance-terms) for installing Rancher on RKE.
 
 Review the [OS requirements]({{<baseurl>}}/rke/latest/en/installation/os/) and configure each node appropriately.
 

--- a/content/rke/latest/en/installation/_index.md
+++ b/content/rke/latest/en/installation/_index.md
@@ -93,6 +93,8 @@ $ port upgrade rke
 
 The Kubernetes cluster components are launched using Docker on a Linux distro. You can use any Linux you want, as long as you can install Docker on it.
 
+> RKE supports Docker versions 1.13.x, 17.03.x, 17.06.x, 17.09.x, 18.06.x, 18.09.x, 19.03.x., the latest Docker version 20.x.x is not supported.
+
 Review the [OS requirements]({{<baseurl>}}/rke/latest/en/installation/os/) and configure each node appropriately.
 
 ## Creating the Cluster Configuration File


### PR DESCRIPTION
RKE does not support the latest Docker (at the moment of this PR creation its v20.10.0).
The following error is received with Docker v20.10.0 when running `rke up --config rancher-cluster.yml`:

> FAT[0000] Unsupported Docker version found [20.10.0] on host [IP]. supported versions are [1.13.x 17.03.x 17.06.x 17.09.x 18.06.x 18.09.x 19.03.x

This PR updates the [RKE install page](https://rancher.com/docs/rke/latest/en/installation/) with the supported Docker versions.