### PR TITLE
Add hardware requirements for RancherD

### DIFF
--- a/content/rancher/v2.x/en/installation/requirements/_index.md
+++ b/content/rancher/v2.x/en/installation/requirements/_index.md
@@ -75,7 +75,7 @@ This section describes the CPU, memory, and disk requirements for the nodes wher
 Hardware requirements scale based on the size of your Rancher deployment. Provision each individual node according to the requirements. The requirements are different depending on if you are installing Rancher in a single container with Docker, or if you are installing Rancher on a Kubernetes cluster.
 
 {{% tabs %}}
-{{% tab "RKE Install Requirements" %}}
+{{% tab "RKE" %}}
 
 These requirements apply to each host in an [RKE Kubernetes cluster where the Rancher server is installed.]({{<baseurl>}}/rancher/v2.x/en/installation/install-rancher-on-k8s/)
 
@@ -92,7 +92,7 @@ Performance increased in Rancher v2.4.0. For the requirements of Rancher prior t
 [Contact Rancher](https://rancher.com/contact/) for more than 2000 clusters and/or 20,000 nodes. 
 {{% /tab %}}
 
-{{% tab "K3s Install Requirements" %}}
+{{% tab "K3s" %}}
 
 These requirements apply to each host in a [K3s Kubernetes cluster where the Rancher server is installed.]({{<baseurl>}}/rancher/v2.x/en/installation/install-rancher-on-k8s/)
 
@@ -108,7 +108,20 @@ These requirements apply to each host in a [K3s Kubernetes cluster where the Ran
 
 {{% /tab %}}
 
-{{% tab "Docker Install Requirements" %}}
+{{% tab "RancherD" %}}
+
+_RancherD is available as of v2.5.4. It is an experimental feature._
+
+The following requirements apply to each instance with RancherD installed. Minimum recommendations are outlined here.
+
+| Deployment Size | Clusters | Nodes     | vCPUs | RAM  |
+| --------------- | -------- | --------- | ----- | ---- |
+| Small           | Up to 5  | Up to 50  | 2     | 5 GB |
+| Medium          | Up to 15 | Up to 200 | 3     | 9 GB |
+
+{{% /tab %}}
+
+{{% tab "Docker" %}}
 
 These requirements apply to a host with a [single-node]({{<baseurl>}}/rancher/v2.x/en/installation/other-installation-methods/single-node-docker) installation of Rancher.
 


### PR DESCRIPTION
To get the CPU and memory requirements for RancherD, I took the requirements for an RKE2 cluster and added the requirements for the Rancher images.

The requirements for RKE2 are:

> Hardware requirements scale based on the size of your deployments. Minimum recommendations are outlined here.
> 
> - RAM: 512MB Minimum (we recommend at least 1GB)
> - CPU: 1 Minimum

Confirmed with Menna/Daishan