### PR TITLE
Changed formatting for `noProxy` flag

### DIFF
--- a/content/rancher/v2.x/en/installation/install-rancher-on-k8s/chart-options/_index.md
+++ b/content/rancher/v2.x/en/installation/install-rancher-on-k8s/chart-options/_index.md
@@ -145,7 +145,7 @@ Add your IP exceptions to the `noProxy` list. Make sure you add the Pod cluster 
 
 ```plain
 --set proxy="http://<username>:<password>@<proxy_url>:<proxy_port>/"
---set noProxy="127.0.0.0/8\,10.0.0.0/8\,172.16.0.0/12\,192.168.0.0/16,.svc,.cluster.local"
+--set noProxy="127.0.0.0/8\,10.0.0.0/8\,172.16.0.0/12\,192.168.0.0/16\,.svc\,.cluster.local"
 ```
 
 ### Additional Trusted CAs


### PR DESCRIPTION
When installing Rancher via Helm and using the `noProxy` flag we need to properly format this flag.
So, instead of using `--set noProxy="127.0.0.0/8\,10.0.0.0/8\,172.16.0.0/12\,192.168.0.0/16,.svc,.cluster.local"`
We should use `--set noProxy="127.0.0.0/8\,10.0.0.0/8\,172.16.0.0/12\,192.168.0.0/16\,.svc\,.cluster.local"`