### PR TITLE
Update _index.md of installation/other-installation-methods/behind-proxy/install-rancher/

### DIFF
--- a/content/rancher/v2.x/en/installation/other-installation-methods/behind-proxy/install-rancher/_index.md
+++ b/content/rancher/v2.x/en/installation/other-installation-methods/behind-proxy/install-rancher/_index.md
@@ -65,6 +65,7 @@ helm upgrade --install rancher rancher-latest/rancher \
    --namespace cattle-system \
    --set hostname=rancher.example.com \
    --set proxy=http://${proxy_host}
+   --set no_proxy=127.0.0.0/8\\,10.0.0.0/8\\,172.16.0.0/12\\,192.168.0.0/16\\,.svc\\,.cluster.local
 ```
 
 After waiting for the deployment to finish:


### PR DESCRIPTION
Rancher install command should also have no_proxy settings due to https://rancher.com/docs/rancher/v2.x/en/installation/install-rancher-on-k8s/chart-options/#http-proxy