### PR TITLE
Minor update to sample IAM policy

### DIFF
--- a/content/rancher/v2.x/en/cluster-provisioning/rke-clusters/node-pools/ec2/_index.md
+++ b/content/rancher/v2.x/en/cluster-provisioning/rke-clusters/node-pools/ec2/_index.md
@@ -128,7 +128,8 @@ After creating your cluster, you can access it through the Rancher UI. As a best
                 "ec2:CreateKeyPair",
                 "ec2:CreateSecurityGroup",
                 "ec2:CreateTags",
-                "ec2:DeleteKeyPair"
+                "ec2:DeleteKeyPair",
+                "ec2:ModifyInstanceMetadataOptions"
             ],
             "Resource": "*"
         },
@@ -180,7 +181,8 @@ After creating your cluster, you can access it through the Rancher UI. As a best
                 "ec2:CreateKeyPair",
                 "ec2:CreateSecurityGroup",
                 "ec2:CreateTags",
-                "ec2:DeleteKeyPair"
+                "ec2:DeleteKeyPair",
+                "ec2:ModifyInstanceMetadataOptions"
             ],
             "Resource": "*"
         },


### PR DESCRIPTION
The current sample IAM policies are missing `ec2:ModifyInstanceMetadataOptions` role.

This trips up cluster provisioning in AWS, this minor tweak addresses the same.

The rancher-machine driver does call ec2 ModifyInstanceMetadataOptions method.

https://github.com/rancher/machine/blob/master/drivers/amazonec2/amazonec2.go#L808