### PR TITLE
Dynamic storage provisioning - Making instructions clearer

### DIFF
--- a/content/rancher/v2.x/en/cluster-admin/volumes-and-storage/provisioning-new-storage/_index.md
+++ b/content/rancher/v2.x/en/cluster-admin/volumes-and-storage/provisioning-new-storage/_index.md
@@ -44,7 +44,7 @@ To use a storage provisioner that is not on the above list, you will need to use
 
 These steps describe how to set up a storage class at the cluster level.
 
-1. Go to the cluster for which you want to dynamically provision persistent storage volumes.
+1. Go to the **Cluster Explorer** of the cluster for which you want to dynamically provision persistent storage volumes.
 
 1. From the cluster view, select `Storage > Storage Classes`. Click `Add Class`.
 
@@ -64,7 +64,7 @@ For full information about the storage class parameters, refer to the official [
 
 These steps describe how to set up a PVC in the namespace where your stateful workload will be deployed.
 
-1. Go to the project containing a workload that you want to add a PVC to.
+1. Go to the **Cluster Manager** to the project containing a workload that you want to add a PVC to.
 
 1. From the main navigation bar, choose **Resources > Workloads.** (In versions prior to v2.3.0, choose **Workloads** on the main navigation bar.) Then select the **Volumes** tab. Click **Add Volume**.
 


### PR DESCRIPTION
I was stuck myself when following instructions as the section no. 1 refers to the Cluster Explorer and in section no. 2 one needs to go to the Cluster Manager.
I think it's a good idea to make this clear in step no. 1 of each of these sections.