### PR TITLE
Update rollback and restore docs

### DIFF
--- a/content/rancher/v2.x/en/backups/v2.0.x-v2.4.x/restore/rke-restore/v2.0-v2.1/_index.md
+++ b/content/rancher/v2.x/en/backups/v2.0.x-v2.4.x/restore/rke-restore/v2.0-v2.1/_index.md
@@ -1,0 +1,75 @@
+---
+title: "Rolling back to v2.0.0-v2.1.5"
+weight: 1
+---
+
+> Rolling back to Rancher v2.0-v2.1 is no longer supported. The instructions for rolling back to these versions are preserved here and are intended to be used only in cases where upgrading to Rancher v2.2+ is not feasible.
+
+If you are rolling back to versions in either of these scenarios, you must follow some extra instructions in order to get your clusters working.
+
+- Rolling back from v2.1.6+ to any version between v2.1.0 - v2.1.5 or v2.0.0 - v2.0.10.
+- Rolling back from v2.0.11+ to any version between v2.0.0 - v2.0.10.  
+
+Because of the changes necessary to address [CVE-2018-20321](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-20321), special steps are necessary if the user wants to roll back to a previous version of Rancher where this vulnerability exists. The steps are as follows:
+
+1. Record the `serviceAccountToken` for each cluster.  To do this, save the following script on a machine with `kubectl` access to the Rancher management plane and execute it.  You will need to run these commands on the machine where the rancher container is running. Ensure JQ is installed before running the command. The commands will vary depending on how you installed Rancher.
+
+    **Rancher Installed with Docker**
+    ```
+    docker exec <NAME OF RANCHER CONTAINER> kubectl get clusters -o json | jq '[.items[] | select(any(.status.conditions[]; .type == "ServiceAccountMigrated")) | {name: .metadata.name, token: .status.serviceAccountToken}]' > tokens.json
+    ```
+
+    **Rancher Installed on a Kubernetes Cluster**
+    ```
+    kubectl get clusters -o json | jq '[.items[] | select(any(.status.conditions[]; .type == "ServiceAccountMigrated")) | {name: .metadata.name, token: .status.serviceAccountToken}]' > tokens.json
+    ```
+
+2. After executing the command a `tokens.json` file will be created.  Important! Back up this file in a safe place.** You will need it to restore functionality to your clusters after rolling back Rancher.  **If you lose this file, you may lose access to your clusters.**
+
+3. Rollback Rancher following the [normal instructions]({{<baseurl>}}/rancher/v2.x/en/upgrades/rollbacks/).
+
+4. Once Rancher comes back up, every cluster managed by Rancher (except for Imported clusters) will be in an `Unavailable` state.
+
+5. Apply the backed up tokens based on how you installed Rancher.
+
+    **Rancher Installed with Docker**
+
+    Save the following script as `apply_tokens.sh` to the machine where the Rancher docker container is running. Also copy the `tokens.json` file created previously to the same directory as the script.
+    ```
+    set -e
+
+    tokens=$(jq .[] -c tokens.json)
+    for token in $tokens; do
+        name=$(echo $token | jq -r .name)
+        value=$(echo $token | jq -r .token)
+
+        docker exec $1 kubectl patch --type=merge clusters $name -p "{\"status\": {\"serviceAccountToken\": \"$value\"}}"
+    done
+    ```
+     the script to allow execution (`chmod +x apply_tokens.sh`) and execute the script as follows:
+    ```
+    ./apply_tokens.sh <DOCKER CONTAINER NAME>
+    ```
+    After a few moments the clusters will go from Unavailable back to Available.
+
+    **Rancher Installed on a Kubernetes Cluster**
+
+    Save the following script as `apply_tokens.sh` to a machine with kubectl access to the Rancher management plane. Also copy the `tokens.json` file created previously to the same directory as the script.
+    ```
+    set -e
+
+    tokens=$(jq .[] -c tokens.json)
+    for token in $tokens; do
+        name=$(echo $token | jq -r .name)
+        value=$(echo $token | jq -r .token)
+
+       kubectl patch --type=merge clusters $name -p "{\"status\": {\"serviceAccountToken\": \"$value\"}}"
+    done
+    ```
+    Set the script to allow execution (`chmod +x apply_tokens.sh`) and execute the script as follows:
+    ```
+    ./apply_tokens.sh
+    ```
+    After a few moments the clusters will go from `Unavailable` back to `Available`.
+
+6. Continue using Rancher as normal.

--- a/content/rancher/v2.x/en/backups/v2.5/restoring-rancher/_index.md
+++ b/content/rancher/v2.x/en/backups/v2.5/restoring-rancher/_index.md
@@ -13,9 +13,7 @@ A restore is performed by creating a Restore custom resource.
 > * Follow the instructions from this page for restoring rancher on the same cluster where it was backed up from. In order to migrate rancher to a new cluster, follow the steps to [migrate rancher.](../migrating-rancher)  
 > * While restoring rancher on the same setup, the operator will scale down the rancher deployment when restore starts, and it will scale back up the deployment once restore completes. So Rancher will be unavailable during the restore.
 
-First, create the Restore custom resource. Then restart Rancher using the previous Rancher version.
-
-### 1. Create the Restore Custom Resource
+### Create the Restore Custom Resource
 
 1. In the **Cluster Explorer,** go to the dropdown menu in the upper left corner and click **Rancher Backups.**
 1. Click **Restore.**
@@ -44,7 +42,7 @@ First, create the Restore custom resource. Then restart Rancher using the previo
 
 1. Click **Create.**
 
-The rancher-operator scales down the rancher deployment during restore, and scales it back up once the restore completes. The resources are restored in this order:
+**Result:** The rancher-operator scales down the rancher deployment during restore, and scales it back up once the restore completes. The resources are restored in this order:
 
 1. Custom Resource Definitions (CRDs)
 2. Cluster-scoped resources
@@ -55,33 +53,4 @@ To check how the restore is progressing, you can check the logs of the operator.
 ```yaml
 kubectl get pods -n cattle-resources-system
 kubectl logs <pod name from above command> -n cattle-resources-system -f
-```
-
-2. Restart Rancher
-
-Rancher has to be started with the lower/previous version after a rollback using the Rancher backup operator. It should be started with the same Helm chart values as the previous install.
-
-Get the values, which were passed with `--set`, from the current Rancher Helm chart that is installed:
-
-```
-helm get values rancher -n cattle-system
-
-hostname: rancher.my.org
-```
-
-> **Note:** There will be more values that are listed with this command. This is just an example of one of the values.
-
-Alternatively, it's possible to export the current values to a file and reference that file during upgrade. For example, to only change the Rancher version:
-
-```
-helm get values rancher -n cattle-system -o yaml > values.yaml
-```
-
-Then upgrade the Helm chart to the previous Rancher version, using the previous values. In this example, the values are taken from the file:
-
-```
-helm upgrade rancher rancher-<CHART_REPO>/rancher \
-  --namespace cattle-system \
-  -f values.yaml \
-  --version=X.Y.Z
 ```

--- a/content/rancher/v2.x/en/installation/install-rancher-on-k8s/rollbacks/_index.md
+++ b/content/rancher/v2.x/en/installation/install-rancher-on-k8s/rollbacks/_index.md
@@ -10,81 +10,82 @@ aliases:
   - /rancher/v2.x/en/installation/install-rancher-on-k8s/upgrades-rollbacks/rollbacks
 ---
 
-To roll back to Rancher v2.5.0+, use the `rancher-backup` application and restore Rancher from backup according to [this section.]({{<baseurl>}}/rancher/v2.x/en/backups/v2.5/restoring-rancher/) Rancher has to be started with the lower/previous version after a rollback using the Rancher backup operator.
+- [Rolling Back to Rancher v2.5.0+](#rolling-back-to-rancher-v2-5-0)
+- [Rolling Back to Rancher v2.2-v2.4+](#rolling-back-to-rancher-v2-2-v2-4)
+- [Rolling Back to Rancher v2.0-v2.1](#rolling-back-to-rancher-v2-0-v2-1)
 
-To roll back to Rancher prior to v2.5, follow the procedure detailed here: [Restoring Backups — Kubernetes installs]({{<baseurl>}}/rancher/v2.x/en/backups/restorations/ha-restoration) Restoring a snapshot of the Rancher Server cluster will revert Rancher to the version and state at the time of the snapshot.
+# Rolling Back to Rancher v2.5.0+
+
+To roll back to Rancher v2.5.0+, use the `rancher-backup` application and restore Rancher from backup.
+
+Rancher has to be started with the lower/previous version after a rollback.
+
+A restore is performed by creating a Restore custom resource.
+
+> **Important**
+>
+> * Follow the instructions from this page for restoring rancher on the same cluster where it was backed up from. In order to migrate rancher to a new cluster, follow the steps to [migrate rancher.](../migrating-rancher)
+> * While restoring rancher on the same setup, the operator will scale down the rancher deployment when restore starts, and it will scale back up the deployment once restore completes. So Rancher will be unavailable during the restore.
+
+### Create the Restore Custom Resource
+
+1. In the **Cluster Explorer,** go to the dropdown menu in the upper left corner and click **Rancher Backups.**
+1. Click **Restore.**
+1. Create the Restore with the form, or with YAML.  For creating the Restore resource using form, refer to the [configuration reference](../configuration/restore-config) and to the [examples.](../examples/#restore)
+1. For using the YAML editor, we can click **Create > Create from YAML.** Enter the Restore YAML.
+
+    ```yaml
+    apiVersion: resources.cattle.io/v1
+	kind: Restore
+	metadata:
+	  name: restore-migration
+	spec:
+	  backupFilename: backup-b0450532-cee1-4aa1-a881-f5f48a007b1c-2020-09-15T07-27-09Z.tar.gz
+	  encryptionConfigSecretName: encryptionconfig
+	  storageLocation:
+	    s3:
+	      credentialSecretName: s3-creds
+	      credentialSecretNamespace: default
+	      bucketName: rancher-backups
+	      folder: rancher
+	      region: us-west-2
+	      endpoint: s3.us-west-2.amazonaws.com
+      ```
+
+      For help configuring the Restore, refer to the [configuration reference](../configuration/restore-config) and to the [examples.](../examples/#restore)
+
+1. Click **Create.**
+
+**Result:** The rancher-operator scales down the rancher deployment during restore, and scales it back up once the restore completes. The resources are restored in this order:
+
+1. Custom Resource Definitions (CRDs)
+2. Cluster-scoped resources
+3. Namespaced resources
+
+To check how the restore is progressing, you can check the logs of the operator. Follow these steps to get the logs:
+
+```yaml
+kubectl get pods -n cattle-resources-system
+kubectl logs -n cattle-resources-system -f
+```
+
+### Roll back to the previous Rancher version
+
+Rancher can be rolled back using the Rancher UI.
+
+1. In the Rancher UI, go to the local cluster. 
+1. Go to the System project.
+1. Edit Rancher deployment and modify image to version that you are rolling back to.
+1. Save changes made.
+
+# Rolling Back to Rancher v2.2-v2.4+
+
+To roll back to Rancher prior to v2.5, follow the procedure detailed here: [Restoring Backups — Kubernetes installs]({{<baseurl>}}/rancher/v2.x/en/backups/v2.0.x-v2.4.x/restore/rke-restore/) Restoring a snapshot of the Rancher server cluster will revert Rancher to the version and state at the time of the snapshot.
 
 For information on how to roll back Rancher installed with Docker, refer to [this page.]({{<baseurl>}}/rancher/v2.x/en/installation/other-installation-methods/single-node-docker/single-node-rollbacks)
 
 > Managed clusters are authoritative for their state. This means restoring the rancher server will not revert workload deployments or changes made on managed clusters after the snapshot was taken.
 
-### Rolling back to v2.0.0-v2.1.5
+# Rolling Back to Rancher v2.0-v2.1
 
-If you are rolling back to versions in either of these scenarios, you must follow some extra instructions in order to get your clusters working.
-
-- Rolling back from v2.1.6+ to any version between v2.1.0 - v2.1.5 or v2.0.0 - v2.0.10.
-- Rolling back from v2.0.11+ to any version between v2.0.0 - v2.0.10.  
-
-Because of the changes necessary to address [CVE-2018-20321](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-20321), special steps are necessary if the user wants to roll back to a previous version of Rancher where this vulnerability exists. The steps are as follows:
-
-1. Record the `serviceAccountToken` for each cluster.  To do this, save the following script on a machine with `kubectl` access to the Rancher management plane and execute it.  You will need to run these commands on the machine where the rancher container is running. Ensure JQ is installed before running the command. The commands will vary depending on how you installed Rancher.
-
-    **Rancher Installed with Docker**
-    ```
-    docker exec <NAME OF RANCHER CONTAINER> kubectl get clusters -o json | jq '[.items[] | select(any(.status.conditions[]; .type == "ServiceAccountMigrated")) | {name: .metadata.name, token: .status.serviceAccountToken}]' > tokens.json
-    ```
-
-    **Rancher Installed on a Kubernetes Cluster**
-    ```
-    kubectl get clusters -o json | jq '[.items[] | select(any(.status.conditions[]; .type == "ServiceAccountMigrated")) | {name: .metadata.name, token: .status.serviceAccountToken}]' > tokens.json
-    ```
-
-2. After executing the command a `tokens.json` file will be created.  Important! Back up this file in a safe place.** You will need it to restore functionality to your clusters after rolling back Rancher.  **If you lose this file, you may lose access to your clusters.**
-
-3. Rollback Rancher following the [normal instructions]({{<baseurl>}}/rancher/v2.x/en/upgrades/rollbacks/).
-
-4. Once Rancher comes back up, every cluster managed by Rancher (except for Imported clusters) will be in an `Unavailable` state.
-
-5. Apply the backed up tokens based on how you installed Rancher.
-
-    **Rancher Installed with Docker**
-
-    Save the following script as `apply_tokens.sh` to the machine where the Rancher docker container is running. Also copy the `tokens.json` file created previously to the same directory as the script.
-    ```
-    set -e
-
-    tokens=$(jq .[] -c tokens.json)
-    for token in $tokens; do
-        name=$(echo $token | jq -r .name)
-        value=$(echo $token | jq -r .token)
-
-        docker exec $1 kubectl patch --type=merge clusters $name -p "{\"status\": {\"serviceAccountToken\": \"$value\"}}"
-    done
-    ```
-     the script to allow execution (`chmod +x apply_tokens.sh`) and execute the script as follows:
-    ```
-    ./apply_tokens.sh <DOCKER CONTAINER NAME>
-    ```
-    After a few moments the clusters will go from Unavailable back to Available.
-
-    **Rancher Installed on a Kubernetes Cluster**
-
-    Save the following script as `apply_tokens.sh` to a machine with kubectl access to the Rancher management plane. Also copy the `tokens.json` file created previously to the same directory as the script.
-    ```
-    set -e
-
-    tokens=$(jq .[] -c tokens.json)
-    for token in $tokens; do
-        name=$(echo $token | jq -r .name)
-        value=$(echo $token | jq -r .token)
-
-       kubectl patch --type=merge clusters $name -p "{\"status\": {\"serviceAccountToken\": \"$value\"}}"
-    done
-    ```
-    Set the script to allow execution (`chmod +x apply_tokens.sh`) and execute the script as follows:
-    ```
-    ./apply_tokens.sh
-    ```
-    After a few moments the clusters will go from `Unavailable` back to `Available`.
-
-6. Continue using Rancher as normal.
+Rolling back to Rancher v2.0-v2.1 is no longer supported. The instructions for rolling back to these versions are preserved [here]({{<baseurl>}}/rancher/v2.x/en/backups/v2.0.x-v2.4.x/restore/rke-restore/v2.0-v2.1) and are intended to be used only in cases where upgrading to Rancher v2.2+ is not feasible.


### PR DESCRIPTION
In this PR I've made the following changes:

1. In the restoring Rancher page, removed the irrelevant steps about changing the Rancher version.
2. In the rolling back Rancher page, added all the information that was in the restoring Rancher page, PLUS the extra steps about changing the Rancher version.
3. Moved the really outdated docs for rolling back to Rancher prior to 2.2 into a separate page, and included warnings that those steps are no longer supported.