### PR TITLE
Update k3s node password docs for new secrets

### DIFF
--- a/content/k3s/latest/en/architecture/_index.md
+++ b/content/k3s/latest/en/architecture/_index.md
@@ -48,7 +48,9 @@ After registration, the agent nodes establish a connection directly to one of th
 
 Agent nodes are registered with a websocket connection initiated by the `k3s agent` process, and the connection is maintained by a client-side load balancer running as part of the agent process.
 
-Agents will register with the server using the node cluster secret along with a randomly generated password for the node, stored at `/etc/rancher/node/password`. The server will store the passwords for individual nodes at `/var/lib/rancher/k3s/server/cred/node-passwd`, and any subsequent attempts must use the same password.
+Agents will register with the server using the node cluster secret along with a randomly generated password for the node, stored at `/etc/rancher/node/password`. The server will store the passwords for individual nodes as Kubernetes secrets, and any subsequent attempts must use the same password. Node password secrets are stored in the `kube-system` namespace with names using the template `<host>.node-password.k3s`.
+
+Note: Prior to K3s v1.20.2 servers stored passwords on disk at `/var/lib/rancher/k3s/server/cred/node-passwd`.
 
 If the `/etc/rancher/node` directory of an agent is removed, the password file should be recreated for the agent, or the entry removed from the server.
 


### PR DESCRIPTION
Modify architecture to describe new use of secrets for node passwords.

Provides note for on disk location used by versions prior to k3s v1.20.2.

For https://github.com/k3s-io/k3s/issues/2717