### PR TITLE
Added doc note FW rule for GKE private clusters

### DIFF
--- a/content/rancher/v2.x/en/installation/requirements/ports/_index.md
+++ b/content/rancher/v2.x/en/installation/requirements/ports/_index.md
@@ -168,6 +168,14 @@ The following tables break down the port requirements for Rancher nodes, for inb
 
 {{% /accordion %}}
 
+### Ports for Rancher Server in GCP GKE
+
+When deploying Rancher into a Google Kubernetes Engine [private cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters), the nodes where Rancher runs must be accessible from the control plane:
+
+| Protocol | Port | Source | Description |
+|-----|-----|----------------|---|
+| TCP | 9443 | The GKE master `/28` range | Rancher webhooks |
+
 # Downstream Kubernetes Cluster Nodes
 
 Downstream Kubernetes clusters run your apps and services. This section describes what ports need to be opened on the nodes in downstream clusters so that Rancher can communicate with them.


### PR DESCRIPTION
Hello,

Raising a PR for an important note on how to get Rancher working correctly in a GKE private cluster.

Fixes https://github.com/rancher/rancher/issues/29451