### PR TITLE
[Rancher2] Add 2.5.6 Fleet upgrade workflow for Windows

### DIFF
--- a/content/rancher/v2.x/en/deploy-across-clusters/fleet/_index.md
+++ b/content/rancher/v2.x/en/deploy-across-clusters/fleet/_index.md
@@ -21,7 +21,8 @@ Fleet comes preinstalled in Rancher v2.5. To access it, go to the **Cluster Expl
 
 ### Windows Support
 
-Prior to Rancher v2.5.6, the `agent` would fail on downstream clusters with Windows nodes.
+Prior to Rancher v2.5.6, the `agent` did not have native Windows manifests on downstream clusters with Windows nodes.
+This would result in a failing `agent` pod for the cluster.
 If you are upgrading from an older version of Rancher to v2.5.6+, you can deploy a working `agent` with the following workflow *in the downstream cluster*:
 
 1. Cordon all Windows nodes.

--- a/content/rancher/v2.x/en/deploy-across-clusters/fleet/_index.md
+++ b/content/rancher/v2.x/en/deploy-across-clusters/fleet/_index.md
@@ -19,6 +19,25 @@ deploy everything in the cluster. This give a high degree of control, consistenc
 
 Fleet comes preinstalled in Rancher v2.5. To access it, go to the **Cluster Explorer** in the Rancher UI. In the top left dropdown menu, click **Cluster Explorer > Continuous Delivery.** On this page, you can edit Kubernetes resources and cluster groups managed by Fleet.
 
+### Windows Support
+
+Prior to Rancher v2.5.6, the `agent` would fail on downstream clusters with Windows nodes.
+If you are upgrading from an older version of Rancher to v2.5.6+, you can deploy a working `agent` with the following workflow *in the downstream cluster*:
+
+1. Cordon all Windows nodes.
+1. Apply the below toleration to the `agent` workload.
+1. Uncordon all Windows nodes.
+1. Delete all `agent` pods. New pods should be created with the new toleration.
+1. Once the `agent` pods are running, and auto-update is enabled for Fleet, they should be updated to a Windows-compatible `agent` version.
+
+```yaml
+tolerations:
+- effect: NoSchedule
+  key: cattle.io/os
+  operator: Equal
+  value: linux
+```
+
 ### GitHub Repository
 
 The Fleet Helm charts are available [here.](https://github.com/rancher/fleet/releases/latest)


### PR DESCRIPTION
Relevant issue: https://github.com/rancher/docs/issues/3003