### PR TITLE
Add the statement that Rancher cluster must be separate from downstea…

### DIFF
--- a/content/rancher/v2.x/en/overview/architecture-recommendations/_index.md
+++ b/content/rancher/v2.x/en/overview/architecture-recommendations/_index.md
@@ -20,7 +20,7 @@ A user cluster is a downstream Kubernetes cluster that runs your apps and servic
 
 If you have a Docker installation of Rancher, the node running the Rancher server should be separate from your downstream clusters.
 
-In Kubernetes installations of Rancher, the Rancher server cluster should also be separate from the user clusters.
+Whilst technically possible, running other workloads or microservices in the same Kubernetes cluster that Rancher is installed on invalidates the Rancher Support SLA. Due to that, the Rancher server cluster must be separate from the user / downstream clusters to fulfill the Rancher SLA.
 
 ![Separation of Rancher Server from User Clusters]({{<baseurl>}}/img/rancher/rancher-architecture-separation-of-rancher-server.svg)
 


### PR DESCRIPTION
…m / user cluster

Just learned that it is not supported to have other workload / user workload in the same cluster as Rancher. 

See https://support.rancher.com/hc/en-us/articles/360047106752-Can-I-run-other-non-Rancher-workloads-on-the-same-Kubernetes-cluster-that-Rancher-is-installed-on-

So this should be reflected in the documentation, too.