### PR TITLE
[2.5.6] Add dockerRootDirectory to logging

### DIFF
--- a/content/rancher/v2.x/en/logging/v2.5/_index.md
+++ b/content/rancher/v2.x/en/logging/v2.5/_index.md
@@ -276,6 +276,11 @@ Let's break down what is happening here. First, we create a deployment of a cont
 
 > **Note on syslog** Official `syslog` support is coming in Rancher v2.5.4. However, this example still provides an overview on using unsupported plugins.
 
+# Working with a Custom Docker Root Directory
+
+If using a custom Docker root directory, you can set `global.dockerRootDirectory` in `values.yaml`.
+This will ensure that the Logging CRs created will use your specified path rather than the default Docker `data-root` location.
+
 # Working with Taints and Tolerations
 
 "Tainting" a Kubernetes node causes pods to repel running on that node.


### PR DESCRIPTION
**Applies to v2.5.6+.**

_Relevant issue_: https://github.com/rancher/docs/issues/3039

This is a cherry-pick from https://github.com/rancher/docs/pull/3038.

