### PR TITLE
Document known issue for migration to Rancher v2.5

### DIFF
--- a/content/rancher/v2.x/en/security/rancher-2.5/1.6-hardening-2.5/_index.md
+++ b/content/rancher/v2.x/en/security/rancher-2.5/1.6-hardening-2.5/_index.md
@@ -26,6 +26,9 @@ For more detail about evaluating a hardened cluster against the official CIS ben
 - Rancher **exec shell** and **view logs** for pods are **not** functional in a CIS 1.6 hardened setup when only public IP is provided when registering custom nodes. This functionality requires a private IP to be provided when registering the custom nodes.
 - When setting the `default_pod_security_policy_template_id:` to `restricted` Rancher creates **RoleBindings** and **ClusterRoleBindings** on the default service accounts. The CIS 1.6 5.1.5 check requires the default service accounts have no roles or cluster roles bound to it apart from the defaults. In addition the default service accounts should be configured such that it does not provide a service account token and does not have any explicit rights assignments.
 
+- Migration Rancher from 2.4 to 2.5. Addons were removed in HG 2.5, and therefore namespaces on migration may be not created on the downstream clusters. Pod may fail to run because of missing namesapce like ingress-nginx, cattlae-system.
+
+
 ### Configure Kernel Runtime Parameters
 
 The following `sysctl` configuration is recommended for all nodes type in the cluster. Set the following parameters in `/etc/sysctl.d/90-kubelet.conf`:


### PR DESCRIPTION
After migration to Rancher 2.5  customer had the problem of the pod not starting because of missing namespaces ingress-nginx and cattle-system on the downstream clusters.

In 2.4, these namespaces where were automatically created with the addons.

Please add this as a known issue to inform customers to create the missing namespace after migration.
