### PR TITLE
Modified cert-manager install instructions

### DIFF
--- a/content/rancher/v2.x/en/installation/install-rancher-on-k8s/_index.md
+++ b/content/rancher/v2.x/en/installation/install-rancher-on-k8s/_index.md
@@ -109,7 +109,7 @@ These instructions are adapted from the [official cert-manager documentation](ht
 
 ```
 # Install the CustomResourceDefinition resources separately
-kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.0.4/cert-manager.crds.yaml
+$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.crds.yaml
 
 # **Important:**
 # If you are running Kubernetes v1.15 or below, you
@@ -131,10 +131,11 @@ helm repo add jetstack https://charts.jetstack.io
 helm repo update
 
 # Install the cert-manager Helm chart
-helm install \
+$ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
-  --version v1.0.4
+  --version v1.2.0 \
+  --create-namespace
 ```
 
 Once you’ve installed cert-manager, you can verify it is deployed correctly by checking the cert-manager namespace for running pods:


### PR DESCRIPTION
Modified cert-manager install instructions to point to the latest version v.1.2.0 instead of v1.0.4.