### PR TITLE
Make clear ipsec flannel backend is not functional

### DIFF
--- a/content/k3s/latest/en/installation/network-options/_index.md
+++ b/content/k3s/latest/en/installation/network-options/_index.md
@@ -16,7 +16,7 @@ If you wish to use WireGuard as your flannel backend it may require additional k
   CLI Flag and Value | Description
   -------------------|------------
  <span style="white-space: nowrap">`--flannel-backend=vxlan`</span> | (Default) Uses the VXLAN backend. |
- <span style="white-space: nowrap">`--flannel-backend=ipsec`</span> | Uses the IPSEC backend which encrypts network traffic. |
+ <span style="white-space: nowrap">`--flannel-backend=ipsec`</span> | Uses the IPSEC backend which encrypts network traffic. [Traffic between nodes doesn't work](https://github.com/k3s-io/k3s/issues/1613) |
  <span style="white-space: nowrap">`--flannel-backend=host-gw`</span> |  Uses the host-gw backend. |
  <span style="white-space: nowrap">`--flannel-backend=wireguard`</span> | Uses the WireGuard backend which encrypts network traffic. May require additional kernel modules and configuration. |
 


### PR DESCRIPTION
Currently ipsec backend is a recommended set up method that doesn't work. Until https://github.com/k3s-io/k3s/issues/1613 is fixed, mark the ipsec backend as not functional