### PR TITLE
Make it clear why you'd use HelmChartConfig

### DIFF
--- a/content/k3s/latest/en/helm/_index.md
+++ b/content/k3s/latest/en/helm/_index.md
@@ -70,6 +70,8 @@ Content placed in `/var/lib/rancher/k3s/server/static/` can be accessed anonymou
 
 To allow overriding values for packaged components that are deployed as HelmCharts (such as Traefik), K3s versions starting with v1.19.0+k3s1 support customizing deployments via a HelmChartConfig resources. The HelmChartConfig resource must match the name and namespace of its corresponding HelmChart, and supports providing additional `valuesContent`, which is passed to the `helm` command as an additional value file.
 
+The reason to create a `HelmChartConfig` instead of simply modifying the existing `HelmChart` CRD is to cause the `helmchart-controller` to redeploy the chart with the new values. If you simply modify the `HelmChart` the changes will not be propagated if the chart has already been deployed.
+
 > **Note:** HelmChart `spec.set` values override HelmChart and HelmChartConfig `spec.valuesContent` settings.
 
 For example, to customize the packaged Traefik ingress configuration, you can create a file named `/var/lib/rancher/k3s/server/manifests/traefik-config.yaml` and populate it with the following content:

--- a/content/k3s/latest/en/networking/_index.md
+++ b/content/k3s/latest/en/networking/_index.md
@@ -32,7 +32,7 @@ Traefik is deployed by default when starting the server. For more information se
 
 The Traefik ingress controller will use ports 80, 443, and 8080 on the host (i.e. these will not be usable for HostPort or NodePort).
 
-To configure Traefik, see [Customizing Helm Chart Components with `HelmChartConfig`]({{<baseurl>}}/k3s/latest/en/helm/#customizing-packaged-components-with-helmchartconfig). [For more information, refer to the official [Traefik for Helm Configuration Parameters.](https://github.com/helm/charts/tree/master/stable/traefik#configuration)
+To configure Traefik, see [Customizing Helm Chart Components with `HelmChartConfig`]({{<baseurl>}}/k3s/latest/en/helm/#customizing-packaged-components-with-helmchartconfig). For more information, refer to the official [Traefik for Helm Configuration Parameters.](https://github.com/helm/charts/tree/master/stable/traefik#configuration)
 
 To disable it, start each server with the `--disable traefik` option.
 

--- a/content/k3s/latest/en/networking/_index.md
+++ b/content/k3s/latest/en/networking/_index.md
@@ -32,7 +32,7 @@ Traefik is deployed by default when starting the server. For more information se
 
 The Traefik ingress controller will use ports 80, 443, and 8080 on the host (i.e. these will not be usable for HostPort or NodePort).
 
-Traefik can be configured by editing the `traefik.yaml` file. To prevent k3s from using or overwriting the modified version, deploy k3s with `--no-deploy traefik` and store the modified copy in the `k3s/server/manifests` directory. For more information, refer to the official [Traefik for Helm Configuration Parameters.](https://github.com/helm/charts/tree/master/stable/traefik#configuration)
+To configure Traefik, see [Customizing Helm Chart Components with `HelmChartConfig`]({{<baseurl>}}/k3s/latest/en/helm/#customizing-packaged-components-with-helmchartconfig). [For more information, refer to the official [Traefik for Helm Configuration Parameters.](https://github.com/helm/charts/tree/master/stable/traefik#configuration)
 
 To disable it, start each server with the `--disable traefik` option.
 


### PR DESCRIPTION
My understanding of the use case is from:

https://github.com/rancher/rke2/issues/162

The documentation at https://rancher.com/docs/k3s/latest/en/networking/#traefik-ingress-controller
suggests modifying the included `HelmChart` crd and doing a dance with the `--no-deploy traefik`,
but this isn't necessary any more with the `HelmChartConfig` crd.