### PR TITLE
Update minimum EKS permissions

### DIFF
--- a/content/rancher/v2.5/en/cluster-provisioning/hosted-kubernetes-clusters/eks/_index.md
+++ b/content/rancher/v2.5/en/cluster-provisioning/hosted-kubernetes-clusters/eks/_index.md
@@ -517,6 +517,7 @@ Resource targeting uses `*` as the ARN of many of the resources created cannot b
             "Sid": "EC2Permisssions",
             "Effect": "Allow",
             "Action": [
+                "ec2:RunInstances",
                 "ec2:RevokeSecurityGroupIngress",
                 "ec2:RevokeSecurityGroupEgress",
                 "ec2:DescribeVpcs",
@@ -524,6 +525,8 @@ Resource targeting uses `*` as the ARN of many of the resources created cannot b
                 "ec2:DescribeSubnets",
                 "ec2:DescribeSecurityGroups",
                 "ec2:DescribeRouteTables",
+                "ec2:DescribeLaunchTemplateVersions",
+                "ec2:DescribeLaunchTemplates",
                 "ec2:DescribeKeyPairs",
                 "ec2:DescribeInternetGateways",
                 "ec2:DescribeImages",
@@ -534,6 +537,8 @@ Resource targeting uses `*` as the ARN of many of the resources created cannot b
                 "ec2:DeleteKeyPair",
                 "ec2:CreateTags",
                 "ec2:CreateSecurityGroup",
+                "ec2:CreateLaunchTemplateVersion",
+                "ec2:CreateLaunchTemplate",
                 "ec2:CreateKeyPair",
                 "ec2:AuthorizeSecurityGroupIngress",
                 "ec2:AuthorizeSecurityGroupEgress"


### PR DESCRIPTION
With Rancher 2.5.6, LaunchTemplates on EKS is used which requires additional EKS permissions are required as brought up by @dmitry-rancher 
The following permissions were added:

> ec2:RunInstances
ec2:CreateLaunchTemplateVersion
ec2:DescribeLaunchTemplates
ec2:DescribeLaunchTemplateVersions
ec2:CreateLaunchTemplate