### PR TITLE
fix "Node Options" table formatting

### DIFF
--- a/content/rancher/v2.5/en/cluster-admin/nodes/_index.md
+++ b/content/rancher/v2.5/en/cluster-admin/nodes/_index.md
@@ -29,6 +29,7 @@ This section covers the following topics:
 # Node Options Available for Each Cluster Creation Option
 
 The following table lists which node options are available for each type of cluster in Rancher. Click the links in the **Option** column for more detailed information about each feature.
+
 | Option                                           | [Nodes Hosted by an Infrastructure Provider][1]                                   | [Custom Node][2] | [Hosted Cluster][3] | [Registered EKS Nodes][4] | [All Other Registered Nodes][5] | Description                                                        |
 | ------------------------------------------------ | ------------------------------------------------ | ---------------- | ------------------- | ------------------- | -------------------| ------------------------------------------------------------------ |
 | [Cordon](#cordoning-a-node)                      | ✓                                                | ✓                | ✓                   | ✓                   | ✓                  | Marks the node as unschedulable.                                   |


### PR DESCRIPTION
The "Node Options" table is not properly rendered on Rancher's online documentation, although it is correctly displayed on Github. I'd say that's because there's a missing line ending, at least thats how the rest of the tables are being used.

Screenshot below as to how it is shown right now on [Rancher's online documentation](https://rancher.com/docs/rancher/v2.5/en/cluster-admin/nodes/):

![image](https://user-images.githubusercontent.com/3204332/112487930-6b909d00-8d7d-11eb-9c9c-81649a1c7cf4.png)
