### PR TITLE
update air gap - helm3 template change in syntax

### DIFF
--- a/content/rancher/v2.5/en/installation/install-rancher-on-k8s/upgrades/_index.md
+++ b/content/rancher/v2.5/en/installation/install-rancher-on-k8s/upgrades/_index.md
@@ -200,8 +200,7 @@ Placeholder | Description
 ### Option A: Default Self-signed Certificate
 
  ```plain
-helm template ./rancher-<VERSION>.tgz --output-dir . \
- --name rancher \
+helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
  --namespace cattle-system \
  --set hostname=<RANCHER.YOURDOMAIN.COM> \
  --set certmanager.version=<CERTMANAGER_VERSION> \
@@ -213,8 +212,7 @@ helm template ./rancher-<VERSION>.tgz --output-dir . \
 ### Option B: Certificates from Files using Kubernetes Secrets
 
 ```plain
-helm template ./rancher-<VERSION>.tgz --output-dir . \
---name rancher \
+helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
 --namespace cattle-system \
 --set hostname=<RANCHER.YOURDOMAIN.COM> \
 --set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \
@@ -226,8 +224,7 @@ helm template ./rancher-<VERSION>.tgz --output-dir . \
 If you are using a Private CA signed cert, add `--set privateCA=true` following `--set ingress.tls.source=secret`:
 
 ```plain
-helm template ./rancher-<VERSION>.tgz --output-dir . \
---name rancher \
+helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
 --namespace cattle-system \
 --set hostname=<RANCHER.YOURDOMAIN.COM> \
 --set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \


### PR DESCRIPTION
starting with helm 3 the flag `--name` was removed
https://helm.sh/docs/helm/helm_template/
```
helm template ./rancher-2.5.7.tgz --output-dir . --name rancher
Error: unknown flag: --name
```
it should be used as an option:
`helm template rancher ./rancher-2.5.7.tgz --output-dir . `