### PR TITLE
Update Rancher requirements to include RKE2 installs

### DIFF
--- a/content/rancher/v2.5/en/installation/requirements/_index.md
+++ b/content/rancher/v2.5/en/installation/requirements/_index.md
@@ -16,7 +16,9 @@ Make sure the node(s) for the Rancher server fulfill the following requirements:
   - [RKE and Hosted Kubernetes](#rke-and-hosted-kubernetes)
   - [K3s Kubernetes](#k3s-kubernetes)
   - [RancherD](#rancherd)
+  - [RKE2](#rke2-kubernetes)
   - [CPU and Memory for Rancher before v2.4.0](#cpu-and-memory-for-rancher-before-v2-4-0)
+- [Ingress](#ingress)
 - [Disks](#disks)
 - [Networking Requirements](#networking-requirements)
   - [Node IP Addresses](#node-ip-addresses)
@@ -30,7 +32,7 @@ The Rancher UI works best in Firefox or Chrome.
 
 Rancher should work with any modern Linux distribution.
 
-Docker is required for nodes that will run RKE Kubernetes clusters. It is not required for RancherD installs.
+Docker is required for nodes that will run RKE Kubernetes clusters. It is not required for RancherD or RKE2 Kubernetes installs.
 
 Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/)
 
@@ -52,7 +54,7 @@ For the container runtime, RKE should work with any modern Docker version.
 
 For the container runtime, K3s should work with any modern version of Docker or containerd.
 
-Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/) To specify the K3s version, use the INSTALL_K3S_VERSION environment variable when running the K3s installation script.
+Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/) To specify the K3s version, use the INSTALL_K3S_VERSION environment variable when running the K3s installation script. 
 
 If you are installing Rancher on a K3s cluster with **Raspbian Buster**, follow [these steps]({{<baseurl>}}/k3s/latest/en/advanced/#enabling-legacy-iptables-on-raspbian-buster) to switch to legacy iptables.
 
@@ -66,7 +68,17 @@ At this time, only Linux OSes that leverage systemd are supported.
 
 To install RancherD on SELinux Enforcing CentOS 8 or RHEL 8 nodes, some [additional steps](#rancherd-on-selinux-enforcing-centos-8-or-rhel-8-nodes) are required.	
 
-Docker is not required for RancherD installs.	
+Docker is not required for RancherD installs.
+
+### RKE2 Specific Requirements
+
+_The RKE2 install is available as of v2.5.6._
+
+For details on which OS versions were tested with RKE2, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/)
+
+Docker is not required for RKE2 installs.
+
+The Ingress should be deployed as DaemonSet to ensure your load balancer can successfully route traffic to all nodes. Currently, RKE2 deploys nginx-ingress as a deployment by default, so you will need to deploy it as a DaemonSet by following [these steps.]({{<baseurl>}}/rancher/v2.5/en/installation/resources/k8s-tutorials/ha-rke2/#5-configure-nginx-to-be-a-daemonset)
 
 ### Installing Docker
 
@@ -86,6 +98,8 @@ Hardware requirements scale based on the size of your Rancher deployment. Provis
 These CPU and memory requirements apply to each host in the Kubernetes cluster where the Rancher server is installed.
 
 These requirements apply to RKE Kubernetes clusters, as well as to hosted Kubernetes clusters such as EKS.
+
+
 
 | Deployment Size | Clusters   | Nodes        | vCPUs  | RAM     |
 | --------------- | ---------- | ------------ | -------| ------- |
@@ -122,14 +136,40 @@ These CPU and memory requirements apply to each instance with RancherD installed
 | Small           | Up to 5  | Up to 50  | 2     | 5 GB |
 | Medium          | Up to 15 | Up to 200 | 3     | 9 GB |
 
+### RKE2 Kubernetes
+
+These CPU and memory requirements apply to each instance with RKE2 installed. Minimum recommendations are outlined here.
+
+| Deployment Size | Clusters | Nodes     | vCPUs | RAM  |
+| --------------- | -------- | --------- | ----- | ---- |
+| Small           | Up to 5  | Up to 50  | 2     | 5 GB |
+| Medium          | Up to 15 | Up to 200 | 3     | 9 GB |
+
 ### Docker
 
-These CPU and memory requirements apply to a host with a [single-node]({{<baseurl>}}/rancher/v2.x/en/installation/other-installation-methods/single-node-docker) installation of Rancher.
+These CPU and memory requirements apply to a host with a [single-node]({{<baseurl>}}/rancher/v2.5/en/installation/other-installation-methods/single-node-docker) installation of Rancher.
 
 | Deployment Size | Clusters | Nodes     | vCPUs | RAM  |
 | --------------- | -------- | --------- | ----- | ---- |
 | Small           | Up to 5  | Up to 50  | 1     | 4 GB |
 | Medium          | Up to 15 | Up to 200 | 2     | 8 GB |
+
+# Ingress
+
+Each node in the Kubernetes cluster that Rancher is installed on should run an Ingress.
+
+The Ingress should be deployed as DaemonSet to ensure your load balancer can successfully route traffic to all nodes.
+
+For RKE, K3s and RancherD installations, you don't have to install the Ingress manually because is is installed by default.
+
+For hosted Kubernetes clusters (EKS, GKE, AKS) and RKE2 Kubernetes installations, you will need to set up the ingress.
+
+### Ingress for RKE2
+
+Currently, RKE2 deploys nginx-ingress as a deployment by default, so you will need to deploy it as a DaemonSet by following [these steps.]({{<baseurl>}}/rancher/v2.5/en/installation/resources/k8s-tutorials/ha-rke2/#5-configure-nginx-to-be-a-daemonset)
+
+### Ingress for EKS
+For an example of how to deploy an nginx-ingress-controller with a LoadBalancer service, refer to [this section.]({{<baseurl>}}/rancher/v2.5/en/installation/install-rancher-on-k8s/amazon-eks/#5-install-an-ingress)
 
 # Disks
 

--- a/content/rancher/v2.5/en/installation/resources/k8s-tutorials/ha-rke2/_index.md
+++ b/content/rancher/v2.5/en/installation/resources/k8s-tutorials/ha-rke2/_index.md
@@ -11,7 +11,7 @@ This section describes how to install a Kubernetes cluster according to the [bes
 
 # Prerequisites
 
-These instructions assume you have set up three nodes, a load balancer, and a DNS record as described [this section.]({{<baseurl>}}/rancher/v2.x/en/installation/resources/k8s-tutorials/infrastructure-tutorials/infra-for-rke2-ha)
+These instructions assume you have set up three nodes, a load balancer, and a DNS record, as described in [this section.]({{<baseurl>}}/rancher/v2.5/en/installation/resources/k8s-tutorials/infrastructure-tutorials/infra-for-rke2-ha)
 
 Note that in order for RKE2 to work correctly with the load balancer, you need to set up two listeners: one for the supervisor on port 9345, and one for the Kubernetes API on port 6443.
 
@@ -163,7 +163,7 @@ Currently, RKE2 deploys nginx-ingress as a deployment, and that can impact the R
 
 To rectify that, place the following file in /var/lib/rancher/rke2/server/manifests on any of the server nodes:
 
-```
+```yaml
 apiVersion: helm.cattle.io/v1
 kind: HelmChartConfig
 metadata:
@@ -175,7 +175,4 @@ spec:
       kind: DaemonSet
       daemonset:
         useHostPort: true
-      image:
-        repository: us.gcr.io/k8s-artifacts-prod/ingress-nginx/controller
-        tag: "v0.34.1"
 ```

--- a/content/rancher/v2.x/en/installation/requirements/_index.md
+++ b/content/rancher/v2.x/en/installation/requirements/_index.md
@@ -16,7 +16,7 @@ Make sure the node(s) for the Rancher server fulfill the following requirements:
   - [RKE and Hosted Kubernetes](#rke-and-hosted-kubernetes)
   - [K3s Kubernetes](#k3s-kubernetes)
   - [RancherD](#rancherd)
-  - [RKE2](#rke2)
+  - [RKE2 Kubernetes](#rke2-kubernetes)
   - [CPU and Memory for Rancher before v2.4.0](#cpu-and-memory-for-rancher-before-v2-4-0)
 - [Ingress](#ingress)
 - [Disks](#disks)

--- a/content/rancher/v2.x/en/installation/requirements/_index.md
+++ b/content/rancher/v2.x/en/installation/requirements/_index.md
@@ -16,6 +16,7 @@ Make sure the node(s) for the Rancher server fulfill the following requirements:
   - [RKE and Hosted Kubernetes](#rke-and-hosted-kubernetes)
   - [K3s Kubernetes](#k3s-kubernetes)
   - [RancherD](#rancherd)
+  - [RKE2](#rke2)
   - [CPU and Memory for Rancher before v2.4.0](#cpu-and-memory-for-rancher-before-v2-4-0)
 - [Disks](#disks)
 - [Networking Requirements](#networking-requirements)
@@ -30,7 +31,7 @@ The Rancher UI works best in Firefox or Chrome.
 
 Rancher should work with any modern Linux distribution.
 
-Docker is required for nodes that will run RKE Kubernetes clusters. It is not required for RancherD installs.
+Docker is required for nodes that will run RKE Kubernetes clusters. It is not required for RancherD or RKE2 Kubernetes installs.
 
 Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/)
 
@@ -66,7 +67,15 @@ At this time, only Linux OSes that leverage systemd are supported.
 
 To install RancherD on SELinux Enforcing CentOS 8 or RHEL 8 nodes, some [additional steps](#rancherd-on-selinux-enforcing-centos-8-or-rhel-8-nodes) are required.	
 
-Docker is not required for RancherD installs.	
+Docker is not required for RancherD installs.
+
+### RKE2 Specific Requirements
+
+_The RKE2 install is available as of v2.5.6._
+
+For details on which OS versions were tested with RKE2, refer to the [RKE documentation.](https://docs.rke2.io/install/requirements/#operating-systems)
+
+Docker is not required for RKE2 installs.
 
 ### Installing Docker
 
@@ -118,6 +127,15 @@ These CPU and memory requirements apply to each host in a [K3s Kubernetes cluste
 _RancherD is available as of v2.5.4. It is an experimental feature._
 
 These CPU and memory requirements apply to each instance with RancherD installed. Minimum recommendations are outlined here.
+
+| Deployment Size | Clusters | Nodes     | vCPUs | RAM  |
+| --------------- | -------- | --------- | ----- | ---- |
+| Small           | Up to 5  | Up to 50  | 2     | 5 GB |
+| Medium          | Up to 15 | Up to 200 | 3     | 9 GB |
+
+### RKE2 Kubernetes
+
+These CPU and memory requirements apply to each instance with RKE2 installed. Minimum recommendations are outlined here.
 
 | Deployment Size | Clusters | Nodes     | vCPUs | RAM  |
 | --------------- | -------- | --------- | ----- | ---- |

--- a/content/rancher/v2.x/en/installation/requirements/_index.md
+++ b/content/rancher/v2.x/en/installation/requirements/_index.md
@@ -18,6 +18,7 @@ Make sure the node(s) for the Rancher server fulfill the following requirements:
   - [RancherD](#rancherd)
   - [RKE2](#rke2)
   - [CPU and Memory for Rancher before v2.4.0](#cpu-and-memory-for-rancher-before-v2-4-0)
+- [Ingress](#ingress)
 - [Disks](#disks)
 - [Networking Requirements](#networking-requirements)
   - [Node IP Addresses](#node-ip-addresses)
@@ -73,9 +74,11 @@ Docker is not required for RancherD installs.
 
 _The RKE2 install is available as of v2.5.6._
 
-For details on which OS versions were tested with RKE2, refer to the [RKE documentation.](https://docs.rke2.io/install/requirements/#operating-systems)
+For details on which OS versions were tested with RKE2, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/)
 
 Docker is not required for RKE2 installs.
+
+The Ingress should be deployed as DaemonSet to ensure your load balancer can successfully route traffic to all nodes. Currently, RKE2 deploys nginx-ingress as a deployment by default, so you will need to deploy it as a DaemonSet by following [these steps.]({{<baseurl>}}/rancher/v2.x/en/installation/resources/k8s-tutorials/ha-rke2/#5-configure-nginx-to-be-a-daemonset)
 
 ### Installing Docker
 
@@ -164,6 +167,23 @@ These CPU and memory requirements apply to installing Rancher on an RKE Kubernet
 | X-Large         | Up to 100 | Up to 1000 | 32                                              | 128 GB                                          |
 | XX-Large        | 100+      | 1000+      | [Contact Rancher](https://rancher.com/contact/) | [Contact Rancher](https://rancher.com/contact/) |
 {{% /accordion %}}
+
+# Ingress
+
+Each node in the Kubernetes cluster that Rancher is installed on should run an Ingress.
+
+The Ingress should be deployed as DaemonSet to ensure your load balancer can successfully route traffic to all nodes.
+
+For RKE, K3s and RancherD installations, you don't have to install the Ingress manually because is is installed by default.
+
+For hosted Kubernetes clusters (EKS, GKE, AKS) and RKE2 Kubernetes installations, you will need to set up the ingress.
+
+### Ingress for RKE2
+
+Currently, RKE2 deploys nginx-ingress as a deployment by default, so you will need to deploy it as a DaemonSet by following [these steps.]({{<baseurl>}}/rancher/v2.x/en/installation/resources/k8s-tutorials/ha-rke2/#5-configure-nginx-to-be-a-daemonset)
+
+### Ingress for EKS
+For an example of how to deploy an nginx-ingress-controller with a LoadBalancer service, refer to [this section.]({{<baseurl>}}/rancher/v2.x/en/installation/install-rancher-on-k8s/amazon-eks/#5-install-an-ingress)
 
 # Disks
 

--- a/content/rancher/v2.x/en/installation/resources/k8s-tutorials/ha-RKE2/_index.md
+++ b/content/rancher/v2.x/en/installation/resources/k8s-tutorials/ha-RKE2/_index.md
@@ -9,7 +9,7 @@ This section describes how to install a Kubernetes cluster according to the [bes
 
 # Prerequisites
 
-These instructions assume you have set up three nodes, a load balancer, a DNS record, [this section.]({{<baseurl>}}/rancher/v2.x/en/installation/resources/k8s-tutorials/infrastructure-tutorials/infra-for-rke2-ha)
+These instructions assume you have set up three nodes, a load balancer, and a DNS record, as described in [this section.]({{<baseurl>}}/rancher/v2.x/en/installation/resources/k8s-tutorials/infrastructure-tutorials/infra-for-rke2-ha)
 
 Note that in order for RKE2 to work correctly with the load balancer, you need to set up two listeners: one for the supervisor on port 9345, and one for the Kubernetes API on port 6443.
 
@@ -161,7 +161,7 @@ Currently, RKE2 deploys nginx-ingress as a deployment, and that can impact the R
 
 To rectify that, place the following file in /var/lib/rancher/rke2/server/manifests on any of the server nodes:
 
-```
+```yaml
 apiVersion: helm.cattle.io/v1
 kind: HelmChartConfig
 metadata:
@@ -173,7 +173,4 @@ spec:
       kind: DaemonSet
       daemonset:
         useHostPort: true
-      image:
-        repository: us.gcr.io/k8s-artifacts-prod/ingress-nginx/controller
-        tag: "v0.34.1"
 ```


### PR DESCRIPTION
https://github.com/rancher/docs/issues/3157

The 2.x docs are maintained for Rancher versions up to and including v2.5.6, so I'm adding these requirements there.

These changes will also be made to the 2.5 docs section once approved.

This still needs to be updated with steps for setting up the ingress.