### PR TITLE
Possible typo in filename kube_config_rancher-cluster.yml?

### DIFF
--- a/content/rancher/v2.x/en/faq/kubectl/_index.md
+++ b/content/rancher/v2.x/en/faq/kubectl/_index.md
@@ -11,12 +11,12 @@ See [kubectl Installation](https://kubernetes.io/docs/tasks/tools/install-kubect
 
 ### Configuration
 
-When you create a Kubernetes cluster with RKE, RKE creates a `kube_config_rancher_cluster.yml` in the local directory that contains credentials to connect to your new cluster with tools like `kubectl` or `helm`.
+When you create a Kubernetes cluster with RKE, RKE creates a `kube_config_cluster.yml` in the local directory that contains credentials to connect to your new cluster with tools like `kubectl` or `helm`.
 
-You can copy this file to `$HOME/.kube/config` or if you are working with multiple Kubernetes clusters, set the `KUBECONFIG` environmental variable to the path of `kube_config_rancher_cluster.yml`.
+You can copy this file to `$HOME/.kube/config` or if you are working with multiple Kubernetes clusters, set the `KUBECONFIG` environmental variable to the path of `kube_config_cluster.yml`.
 
 ```
-export KUBECONFIG=$(pwd)/kube_config_rancher_cluster.yml
+export KUBECONFIG=$(pwd)/kube_config_cluster.yml
 ```
 
 Test your connectivity with `kubectl` and see if you can get the list of nodes back.

--- a/content/rancher/v2.x/en/faq/kubectl/_index.md
+++ b/content/rancher/v2.x/en/faq/kubectl/_index.md
@@ -11,12 +11,12 @@ See [kubectl Installation](https://kubernetes.io/docs/tasks/tools/install-kubect
 
 ### Configuration
 
-When you create a Kubernetes cluster with RKE, RKE creates a `kube_config_rancher-cluster.yml` in the local directory that contains credentials to connect to your new cluster with tools like `kubectl` or `helm`.
+When you create a Kubernetes cluster with RKE, RKE creates a `kube_config_rancher_cluster.yml` in the local directory that contains credentials to connect to your new cluster with tools like `kubectl` or `helm`.
 
-You can copy this file to `$HOME/.kube/config` or if you are working with multiple Kubernetes clusters, set the `KUBECONFIG` environmental variable to the path of `kube_config_rancher-cluster.yml`.
+You can copy this file to `$HOME/.kube/config` or if you are working with multiple Kubernetes clusters, set the `KUBECONFIG` environmental variable to the path of `kube_config_rancher_cluster.yml`.
 
 ```
-export KUBECONFIG=$(pwd)/kube_config_rancher-cluster.yml
+export KUBECONFIG=$(pwd)/kube_config_rancher_cluster.yml
 ```
 
 Test your connectivity with `kubectl` and see if you can get the list of nodes back.


### PR DESCRIPTION
Running RKE version: v1.2.7

```
rke util get-kubeconfig                          
INFO[0000] Creating new kubeconfig file                 
INFO[0000] Copied file [./kube_config_cluster.yml] to new location [kube_config090097404] as back-up 
INFO[0000] [reconcile] Rebuilding and updating local kube config 
INFO[0000] Successfully Deployed local admin kubeconfig at [./kube_config_cluster.yml] 
INFO[0000] [reconcile] host [osl-argusdev-kube-cluster1.mnemonic.no] is a control plane node with reachable Kubernetes API endpoint in the cluster
```

Output is without dash and only underscore.