### PR TITLE
Remove note for Auto Upgrade for >2.5.8

### DIFF
--- a/content/rancher/v2.5/en/cluster-provisioning/hosted-kubernetes-clusters/gke/config-reference/_index.md
+++ b/content/rancher/v2.5/en/cluster-provisioning/hosted-kubernetes-clusters/gke/config-reference/_index.md
@@ -201,8 +201,6 @@ GKE's node auto-repair feature helps you keep the nodes in your cluster in a hea
 
 ### Auto Upgrade
 
-> Note: Enabling the Auto Upgrade feature for Nodes is not recommended.
-
 When enabled, the auto-upgrade feature keeps the nodes in your cluster up-to-date with the cluster control plane (master) version when your control plane is [updated on your behalf.](https://cloud.google.com/kubernetes-engine/upgrades#automatic_cp_upgrades) For more information about auto-upgrading nodes, see [this page.](https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-upgrades)
 
 ### Access Scopes


### PR DESCRIPTION
Prior to 2.5.8, enabling Auto Upgrade for GKE hosted clusters was not
recommended because it could cause the state of the cluster in GKE to
become out of sync with the state of the cluster in Rancher. With 2.5.8,
this is not a concern any more because of the syncing mechanism in the
new GKE provisioner. Therefore, it's recommended to use the Auto Upgrade
feature, which defaults to enabled in both Rancher and the GKE console.
This change removes the note erroneously added in 74b31fae.