### PR TITLE
Update K3s security documentation.

### DIFF
--- a/content/k3s/latest/en/security/_index.md
+++ b/content/k3s/latest/en/security/_index.md
@@ -3,7 +3,9 @@ title: "Security"
 weight: 90
 ---
 
-This section describes the methodology and means of securing a K3s cluster. It's broken into 2 sections.
+This section describes the methodology and means of securing a K3s cluster. It's broken into 2 sections. 
+
+The documents below apply to both CIS 1.5 & 1.6.
 
 * [Hardening Guide](./hardening_guide/)
 * [CIS Benchmark Self-Assessment Guide](./self_assessment/)

--- a/content/k3s/latest/en/security/_index.md
+++ b/content/k3s/latest/en/security/_index.md
@@ -3,7 +3,7 @@ title: "Security"
 weight: 90
 ---
 
-This section describes the methodology and means of securing a K3s cluster. It's broken into 2 sections. 
+This section describes the methodology and means of securing a K3s cluster. It's broken into 2 sections. These guides assume k3s is running with embedded etcd.
 
 The documents below apply to both CIS 1.5 & 1.6.
 

--- a/content/k3s/latest/en/security/hardening_guide/_index.md
+++ b/content/k3s/latest/en/security/hardening_guide/_index.md
@@ -280,6 +280,28 @@ spec:
             name: kube-system
 ```
 
+With the applied restrictions, DNS will be blocked unless purposely allowed. Below is a network policy that will allow for traffic to exist for DNS.
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-network-dns-policy
+  namespace: <NAMESPACE>
+spec:
+  ingress:
+  - ports:
+    - port: 53
+      protocol: TCP
+    - port: 53
+      protocol: UDP
+  podSelector:
+    matchLabels:
+      k8s-app: kube-dns
+  policyTypes:
+  - Ingress
+```
+
 > **Note:** Operators must manage network policies as normal for additional namespaces that are created.
 
 ## Known Issues


### PR DESCRIPTION
Update security page to indicate that CIS 1.5 and 1.6 are covered by
this section.

Add network policy to Hardening Guide that shows how to allow for DNS
traffic.
