### PR TITLE
fix the minimal SMS receiver configuration

### DIFF
--- a/content/rancher/v2.5/en/monitoring-alerting/configuration/alertmanager/_index.md
+++ b/content/rancher/v2.5/en/monitoring-alerting/configuration/alertmanager/_index.md
@@ -215,6 +215,10 @@ The SMS receiver is not a native receiver and must be enabled before it can be u
 The SMS receiver can be configured by updating its ConfigMap. For example, the following is a minimal SMS receiver configuration.
 
 ```yaml
+providers:
+  telegram:
+    token: 'your-token-from-telegram'
+
 receivers:
 - name: 'telegram-receiver-1'
   provider: 'telegram'


### PR DESCRIPTION
Add the  `providers` section which is another required field in Sachet's config file 

issue: https://github.com/rancher/docs/issues/3173