### PR TITLE
update missing kube-controller args from the reference cluster.yaml

### DIFF
--- a/content/rancher/v2.x/en/security/rancher-2.5/1.6-hardening-2.5/_index.md
+++ b/content/rancher/v2.x/en/security/rancher-2.5/1.6-hardening-2.5/_index.md
@@ -482,6 +482,9 @@ rancher_kubernetes_engine_config:
         feature-gates: RotateKubeletServerCertificate=true
     kubelet:
       extra_args:
+        profiling: "false"
+        address: "127.0.0.1"
+        terminated-pod-gc-threshold: "1000"
         feature-gates: RotateKubeletServerCertificate=true
         protect-kernel-defaults: 'true'
         tls-cipher-suites: >-


### PR DESCRIPTION
…cluster.yaml configuration

Some of the kube-controller arguments are missing from the reference hardened cluster.yaml configuration even though they are detailed in the [Self-Assessment Guide](https://rancher.com/docs/rancher/v2.x/en/security/rancher-2.5/1.6-benchmark-2.5/#1-3-controller-manager) and also show up in the [previous guides ](https://rancher.com/docs/rancher/v2.x/en/security/rancher-2.3.x/rancher-v2.3.3/hardening-2.3.3/#appendix-b-complete-rke-cluster-yml-example)

```
kube-controller:
extra_args:
profiling: "false"
address: "127.0.0.1"
terminated-pod-gc-threshold: "1000"
feature-gates: "RotateKubeletServerCertificate=true"
```
where https://rancher.com/docs/rancher/v2.x/en/security/rancher-2.5/1.6-hardening-2.5/#reference-hardened-rke-cluster-yml-configuration  has only:
```
extra_args:
feature-gates: RotateKubeletServerCertificate=true
```