### PR TITLE
Make the placements of the env vars clear

### DIFF
--- a/content/k3s/latest/en/installation/install-options/_index.md
+++ b/content/k3s/latest/en/installation/install-options/_index.md
@@ -46,6 +46,10 @@ When using this method to install K3s, the following environment variables can b
 | `INSTALL_K3S_CHANNEL_URL` | Channel URL for fetching K3s download URL. Defaults to https://update.k3s.io/v1-release/channels. |
 | `INSTALL_K3S_CHANNEL` | Channel to use for fetching K3s download URL. Defaults to "stable". Options include: `stable`, `latest`, `testing`. |
 
+An example follows where to place aformentioned environment variables as options (after the pipe!):
+```
+curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=latest sh -
+```
 
 Environment variables which begin with `K3S_` will be preserved for the systemd and openrc services to use.
 

--- a/content/k3s/latest/en/installation/install-options/_index.md
+++ b/content/k3s/latest/en/installation/install-options/_index.md
@@ -46,7 +46,8 @@ When using this method to install K3s, the following environment variables can b
 | `INSTALL_K3S_CHANNEL_URL` | Channel URL for fetching K3s download URL. Defaults to https://update.k3s.io/v1-release/channels. |
 | `INSTALL_K3S_CHANNEL` | Channel to use for fetching K3s download URL. Defaults to "stable". Options include: `stable`, `latest`, `testing`. |
 
-An example follows where to place aformentioned environment variables as options (after the pipe!):
+This example shows where to place aformentioned environment variables as options (after the pipe):
+
 ```
 curl -sfL https://get.k3s.io | INSTALL_K3S_CHANNEL=latest sh -
 ```


### PR DESCRIPTION
Such an example is mentioned two pages earlier in the docs but it's not in the context of all the env vars/options and people might miss is (like I did, check https://github.com/k3s-io/k3s/issues/3260)