### PR TITLE
Append --no-hooks flag for air gap Helm template commands #3226

### DIFF
--- a/content/rancher/v2.5/en/installation/install-rancher-on-k8s/upgrades/_index.md
+++ b/content/rancher/v2.5/en/installation/install-rancher-on-k8s/upgrades/_index.md
@@ -53,7 +53,7 @@ For migration of installs started with Helm 2, refer to the official [Helm 2 to 
 
 ### For air gap installs: Populate private registry
 
--For [air gap installs only,]({{<baseurl>}}/rancher/v2.5/en/installation/other-installation-methods/air-gap) collect and populate images for the new Rancher server version. Follow the guide to [populate your private registry]({{<baseurl>}}/rancher/v2.5/en/installation/other-installation-methods/air-gap/populate-private-registry/) with the images for the Rancher version that you want to upgrade to.
+For [air gap installs only,]({{<baseurl>}}/rancher/v2.5/en/installation/other-installation-methods/air-gap) collect and populate images for the new Rancher server version. Follow the guide to [populate your private registry]({{<baseurl>}}/rancher/v2.5/en/installation/other-installation-methods/air-gap/populate-private-registry/) with the images for the Rancher version that you want to upgrade to.
 
 ### For upgrades from a Rancher server with a hidden local cluster
 
@@ -120,8 +120,8 @@ You'll use the backup as a restoration point if something goes wrong during upgr
 
 This section describes how to upgrade normal (Internet-connected) or air gap installations of Rancher with Helm.
 
-{{% tabs %}}
-{{% tab "Kubernetes Upgrade" %}}
+> **Air Gap Instructions:** If you are installing Rancher in an air gapped environment, skip the rest of this page and render the Helm template by following the instructions on [this page.](./air-gap-upgrade)
+
 
 Get the values, which were passed with `--set`, from the current Rancher Helm chart that is installed.
 
@@ -181,74 +181,6 @@ If you are currently running the cert-manger whose version is older than v0.11, 
     --namespace cattle-system \
     --set hostname=rancher.my.org
     ```
-
-{{% /tab %}}
-{{% tab "Kubernetes Air Gap Upgrade" %}}
-
-Render the Rancher template using the same chosen options that were used when installing Rancher. Use the reference table below to replace each placeholder. Rancher needs to be configured to use the private registry in order to provision any Rancher launched Kubernetes clusters or Rancher tools.
-
-Based on the choice you made during installation, complete one of the procedures below.
-
-Placeholder | Description
-------------|-------------
-`<VERSION>` | The version number of the output tarball.
-`<RANCHER.YOURDOMAIN.COM>` | The DNS name you pointed at your load balancer.
-`<REGISTRY.YOURDOMAIN.COM:PORT>` | The DNS name for your private registry.
-`<CERTMANAGER_VERSION>` | Cert-manager version running on k8s cluster.
-
-
-### Option A: Default Self-signed Certificate
-
- ```plain
-helm template ./rancher-<VERSION>.tgz --output-dir . \
- --name rancher \
- --namespace cattle-system \
- --set hostname=<RANCHER.YOURDOMAIN.COM> \
- --set certmanager.version=<CERTMANAGER_VERSION> \
- --set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \
- --set systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT> \ # Set a default private registry to be used in Rancher
- --set useBundledSystemChart=true # Use the packaged Rancher system charts
-```
-
-### Option B: Certificates from Files using Kubernetes Secrets
-
-```plain
-helm template ./rancher-<VERSION>.tgz --output-dir . \
---name rancher \
---namespace cattle-system \
---set hostname=<RANCHER.YOURDOMAIN.COM> \
---set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \
---set ingress.tls.source=secret \
---set systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT> \ # Set a default private registry to be used in Rancher
---set useBundledSystemChart=true # Use the packaged Rancher system charts
-```
-
-If you are using a Private CA signed cert, add `--set privateCA=true` following `--set ingress.tls.source=secret`:
-
-```plain
-helm template ./rancher-<VERSION>.tgz --output-dir . \
---name rancher \
---namespace cattle-system \
---set hostname=<RANCHER.YOURDOMAIN.COM> \
---set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \
---set ingress.tls.source=secret \
---set privateCA=true \
---set systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT> \ # Set a default private registry to be used in Rancher
---set useBundledSystemChart=true # Use the packaged Rancher system charts
-```
-
-### Apply the Rendered Templates
-
-Copy the rendered manifest directories to a system with access to the Rancher server cluster and apply the rendered templates.
-
-Use `kubectl` to apply the rendered manifests.
-
-```plain
-kubectl -n cattle-system apply -R -f ./rancher
-```
-
-{{% /tab %}}
-{{% /tabs %}}
 
 # 4. Verify the Upgrade
 

--- a/content/rancher/v2.5/en/installation/install-rancher-on-k8s/upgrades/air-gap-upgrade/_index.md
+++ b/content/rancher/v2.5/en/installation/install-rancher-on-k8s/upgrades/air-gap-upgrade/_index.md
@@ -1,0 +1,144 @@
+---
+title: Rendering the Helm Template in an Air Gapped Environment
+shortTitle: Air Gap Upgrade
+weight: 1
+---
+
+> These instructions assume you have already followed the instructions for a Kubernetes upgrade on [this page,]({{<baseurl>}}/rancher/v2.5/en/installation/install-rancher-on-k8s/upgrades/) including the prerequisites, up until step 3. Upgrade Rancher.
+
+### Rancher Helm Template Options
+
+Render the Rancher template using the same chosen options that were used when installing Rancher. Use the reference table below to replace each placeholder. Rancher needs to be configured to use the private registry in order to provision any Rancher launched Kubernetes clusters or Rancher tools.
+
+Based on the choice you made during installation, complete one of the procedures below.
+
+Placeholder | Description
+------------|-------------
+`<VERSION>` | The version number of the output tarball.
+`<RANCHER.YOURDOMAIN.COM>` | The DNS name you pointed at your load balancer.
+`<REGISTRY.YOURDOMAIN.COM:PORT>` | The DNS name for your private registry.
+`<CERTMANAGER_VERSION>` | Cert-manager version running on k8s cluster.
+
+
+### Option A: Default Self-signed Certificate
+
+{{% tabs %}}
+{{% tab "Rancher v2.5.8+" %}}
+
+```
+helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
+    --no-hooks \ # prevent files for Helm hooks from being generated
+	--namespace cattle-system \
+	--set hostname=<RANCHER.YOURDOMAIN.COM> \
+	--set certmanager.version=<CERTMANAGER_VERSION> \
+	--set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \
+	--set systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT> \ # Set a default private registry to be used in Rancher
+	--set useBundledSystemChart=true # Use the packaged Rancher system charts
+```
+
+{{% /tab %}}
+{{% tab "Rancher before v2.5.8" %}}
+
+ ```plain
+helm template ./rancher-<VERSION>.tgz --output-dir . \
+ --name rancher \
+ --namespace cattle-system \
+ --set hostname=<RANCHER.YOURDOMAIN.COM> \
+ --set certmanager.version=<CERTMANAGER_VERSION> \
+ --set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \
+ --set systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT> \ # Set a default private registry to be used in Rancher
+ --set useBundledSystemChart=true # Use the packaged Rancher system charts
+```
+
+{{% /tab %}}
+{{% /tabs %}}
+
+
+
+### Option B: Certificates from Files using Kubernetes Secrets
+
+
+{{% tabs %}}
+{{% tab "Rancher v2.5.8+" %}}
+
+
+```plain
+helm template ./rancher-<VERSION>.tgz --output-dir . \
+--name rancher \
+--no-hooks \ # prevent files for Helm hooks from being generated
+--namespace cattle-system \
+--set hostname=<RANCHER.YOURDOMAIN.COM> \
+--set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \
+--set ingress.tls.source=secret \
+--set systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT> \ # Set a default private registry to be used in Rancher
+--set useBundledSystemChart=true # Use the packaged Rancher system charts
+```
+
+If you are using a Private CA signed cert, add `--set privateCA=true` following `--set ingress.tls.source=secret`:
+
+```plain
+helm template ./rancher-<VERSION>.tgz --output-dir . \
+--name rancher \
+--no-hooks \ # prevent files for Helm hooks from being generated
+--namespace cattle-system \
+--set hostname=<RANCHER.YOURDOMAIN.COM> \
+--set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \
+--set ingress.tls.source=secret \
+--set privateCA=true \
+--set systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT> \ # Set a default private registry to be used in Rancher
+--set useBundledSystemChart=true # Use the packaged Rancher system charts
+```
+
+{{% /tab %}}
+{{% tab "Rancher before v2.5.8" %}}
+
+
+```plain
+helm template ./rancher-<VERSION>.tgz --output-dir . \
+--name rancher \
+--namespace cattle-system \
+--set hostname=<RANCHER.YOURDOMAIN.COM> \
+--set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \
+--set ingress.tls.source=secret \
+--set systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT> \ # Set a default private registry to be used in Rancher
+--set useBundledSystemChart=true # Use the packaged Rancher system charts
+```
+
+If you are using a Private CA signed cert, add `--set privateCA=true` following `--set ingress.tls.source=secret`:
+
+```plain
+helm template ./rancher-<VERSION>.tgz --output-dir . \
+--name rancher \
+--namespace cattle-system \
+--set hostname=<RANCHER.YOURDOMAIN.COM> \
+--set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \
+--set ingress.tls.source=secret \
+--set privateCA=true \
+--set systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT> \ # Set a default private registry to be used in Rancher
+--set useBundledSystemChart=true # Use the packaged Rancher system charts
+```
+{{% /tab %}}
+{{% /tabs %}}
+
+
+### Apply the Rendered Templates
+
+Copy the rendered manifest directories to a system with access to the Rancher server cluster and apply the rendered templates.
+
+Use `kubectl` to apply the rendered manifests.
+
+```plain
+kubectl -n cattle-system apply -R -f ./rancher
+```
+
+# Verify the Upgrade
+
+Log into Rancher to confirm that the upgrade succeeded.
+
+>**Having network issues following upgrade?**
+>
+> See [Restoring Cluster Networking]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/install-rancher-on-k8s/upgrades/namespace-migration).
+
+# Known Upgrade Issues
+
+A list of known issues for each Rancher version can be found in the release notes on [GitHub](https://github.com/rancher/rancher/releases) and on the [Rancher forums.](https://forums.rancher.com/c/announcements/12)

--- a/content/rancher/v2.5/en/installation/other-installation-methods/air-gap/install-rancher/_index.md
+++ b/content/rancher/v2.5/en/installation/other-installation-methods/air-gap/install-rancher/_index.md
@@ -10,18 +10,21 @@ aliases:
   - /rancher/v2.5/en/installation/air-gap-high-availability/install-rancher/
 ---
 
-This section is about how to deploy Rancher for your air gapped environment. An air gapped environment could be where Rancher server will be installed offline, behind a firewall, or behind a proxy. There are _tabs_ for either a high availability (recommended) or a Docker installation.
+This section is about how to deploy Rancher for your air gapped environment in a high-availability Kubernetes installation. An air gapped environment could be where Rancher server will be installed offline, behind a firewall, or behind a proxy.
 
 ### Privileged Access for Rancher v2.5+
 
 When the Rancher server is deployed in the Docker container, a local Kubernetes cluster is installed within the container for Rancher to use. Because many features of Rancher run as deployments, and privileged mode is required to run containers within containers, you will need to install Rancher with the `--privileged` option.
 
-{{% tabs %}}
-{{% tab "Kubernetes Install (Recommended)" %}}
+# Docker Instructions 
+
+If you want to continue the air gapped installation using Docker commands, skip the rest of this page and follow the instructions on [this page.](./docker-install-commands)
+
+# Kubernetes Instructions
 
 Rancher recommends installing Rancher on a Kubernetes cluster. A highly available Kubernetes install is comprised of three nodes running the Rancher server components on a Kubernetes cluster. The persistence layer (etcd) is also replicated on these three nodes, providing redundancy and data duplication in case one of the nodes fails.
 
-This section describes installing Rancher in five parts:
+This section describes installing Rancher:
 
 - [1. Add the Helm Chart Repository](#1-add-the-helm-chart-repository)
 - [2. Choose your SSL Configuration](#2-choose-your-ssl-configuration)
@@ -63,7 +66,7 @@ When Rancher is installed on an air gapped Kubernetes cluster, there are two rec
 | Rancher Generated Self-Signed Certificates | `ingress.tls.source=rancher` | Use certificates issued by Rancher's generated CA (self signed)<br> This is the **default** and does not need to be added when rendering the Helm template. | yes                   |
 | Certificates from Files                    | `ingress.tls.source=secret`  | Use your own certificate files by creating Kubernetes Secret(s). <br> This option must be passed when rendering the Rancher Helm template.                  | no                    |
 
-# 3. Render the Rancher Helm Template
+# Helm Chart Options for Air Gap Installations
 
 When setting up the Rancher Helm template, there are several options in the Helm chart that are designed specifically for air gap installations.
 
@@ -73,72 +76,107 @@ When setting up the Rancher Helm template, there are several options in the Helm
 | `systemDefaultRegistry` | `<REGISTRY.YOURDOMAIN.COM:PORT>` | Configure Rancher server to always pull from your private registry when provisioning clusters.  |
 | `useBundledSystemChart` | `true`                           | Configure Rancher server to use the packaged copy of Helm system charts. The [system charts](https://github.com/rancher/system-charts) repository contains all the catalog items required for features such as monitoring, logging, alerting and global DNS. These [Helm charts](https://github.com/rancher/system-charts) are located in GitHub, but since you are in an air gapped environment, using the charts that are bundled within Rancher is much easier than setting up a Git mirror. |
 
-Based on the choice your made in [B. Choose your SSL Configuration](#b-choose-your-ssl-configuration), complete one of the procedures below.
+# 3. Render the Rancher Helm Template
 
-### Option A: Default Self-Signed Certificate
+Based on the choice your made in [2. Choose your SSL Configuration](#2-choose-your-ssl-configuration), complete one of the procedures below.
 
-{{% accordion id="k8s-1" label="Click to expand" %}}
+# Option A: Default Self-Signed Certificate
+
 
 By default, Rancher generates a CA and uses cert-manager to issue the certificate for access to the Rancher server interface.
 
 > **Note:**
 > Recent changes to cert-manager require an upgrade. If you are upgrading Rancher and using a version of cert-manager older than v0.11.0, please see our [upgrade cert-manager documentation]({{<baseurl>}}/rancher/v2.5/en/installation/options/upgrading-cert-manager/).
 
-1. From a system connected to the internet, add the cert-manager repo to Helm.
-    ```plain
-    helm repo add jetstack https://charts.jetstack.io
-    helm repo update
-    ```
+### 1. Add the cert-manager repo
 
-1. Fetch the latest cert-manager chart available from the [Helm chart repository](https://hub.helm.sh/charts/jetstack/cert-manager).
+From a system connected to the internet, add the cert-manager repo to Helm:
 
-    ```plain
-    helm fetch jetstack/cert-manager --version v1.0.4
-    ```
+```plain
+helm repo add jetstack https://charts.jetstack.io
+helm repo update
+```
 
-1. Render the cert manager template with the options you would like to use to install the chart. Remember to set the `image.repository` option to pull the image from your private registry. This will create a `cert-manager` directory with the Kubernetes manifest files.
-   ```plain
-   helm template cert-manager ./cert-manager-v1.0.4.tgz --output-dir . \
-       --namespace cert-manager \
-       --set image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-controller \
-       --set webhook.image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-webhook \
-       --set cainjector.image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-cainjector
-   ```
+### 2. Fetch the cert-manager chart
 
-1. Download the required CRD file for cert-manager
+Fetch the latest cert-manager chart available from the [Helm chart repository](https://hub.helm.sh/charts/jetstack/cert-manager).
+
+```plain
+helm fetch jetstack/cert-manager --version v1.0.4
+```
+
+### 3. Render the cert-manager template
+
+Render the cert-manager template with the options you would like to use to install the chart. Remember to set the `image.repository` option to pull the image from your private registry. This will create a `cert-manager` directory with the Kubernetes manifest files.
+
+```plain
+helm template cert-manager ./cert-manager-v1.0.4.tgz --output-dir . \
+    --namespace cert-manager \
+    --set image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-controller \
+    --set webhook.image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-webhook \
+    --set cainjector.image.repository=<REGISTRY.YOURDOMAIN.COM:PORT>/quay.io/jetstack/cert-manager-cainjector
+```
+
+### 4. Download the cert-manager CRD
+
+Download the required CRD file for cert-manager:
    ```plain
    curl -L -o cert-manager/cert-manager-crd.yaml https://github.com/jetstack/cert-manager/releases/download/v1.0.4/cert-manager.crds.yaml
    ```
 
-1. Render the Rancher template, declaring your chosen options. Use the reference table below to replace each placeholder. Rancher needs to be configured to use the private registry in order to provision any Rancher launched Kubernetes clusters or Rancher tools.
+### 5. Render the Rancher template
+
+Render the Rancher template, declaring your chosen options. Use the reference table below to replace each placeholder. Rancher needs to be configured to use the private registry in order to provision any Rancher launched Kubernetes clusters or Rancher tools.
 
 
-    Placeholder | Description
-    ------------|-------------
-    `<VERSION>` | The version number of the output tarball.
-    `<RANCHER.YOURDOMAIN.COM>` | The DNS name you pointed at your load balancer.
-    `<REGISTRY.YOURDOMAIN.COM:PORT>` | The DNS name for your private registry.
-    `<CERTMANAGER_VERSION>` | Cert-manager version running on k8s cluster.
+Placeholder | Description
+------------|-------------
+`<VERSION>` | The version number of the output tarball.
+`<RANCHER.YOURDOMAIN.COM>` | The DNS name you pointed at your load balancer.
+`<REGISTRY.YOURDOMAIN.COM:PORT>` | The DNS name for your private registry.
+`<CERTMANAGER_VERSION>` | Cert-manager version running on k8s cluster.
 
-     ```plain
-    helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
-     --namespace cattle-system \
-     --set hostname=<RANCHER.YOURDOMAIN.COM> \
-     --set certmanager.version=<CERTMANAGER_VERSION> \
-     --set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \
-     --set systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT> \ # Set a default private registry to be used in Rancher
-     --set useBundledSystemChart=true # Use the packaged Rancher system charts
+{{% tabs %}}
+{{% tab "Rancher v2.5.8" %}}
+```plain
+helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
+    --no-hooks \ # prevent files for Helm hooks from being generated
+    --namespace cattle-system \
+    --set hostname=<RANCHER.YOURDOMAIN.COM> \
+    --set certmanager.version=<CERTMANAGER_VERSION> \
+    --set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \
+    --set systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT> \ # Set a default private registry to be used in Rancher
+    --set useBundledSystemChart=true # Use the packaged Rancher system charts
 ```
 
-**Optional**: To install a specific Rancher version, set the `rancherImageTag` value, example: `--set rancherImageTag=v2.3.6`
+**Optional**: To install a specific Rancher version, set the `rancherImageTag` value, example: `--set rancherImageTag=v2.5.8`
+{{% /tab %}}
+{{% tab "Rancher before v2.5.8" %}}
 
-{{% /accordion %}}
+```plain
+helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
+    --namespace cattle-system \
+    --set hostname=<RANCHER.YOURDOMAIN.COM> \
+    --set certmanager.version=<CERTMANAGER_VERSION> \
+    --set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \
+    --set systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT> \ # Set a default private registry to be used in Rancher
+    --set useBundledSystemChart=true # Use the packaged Rancher system charts
+```
 
-### Option B: Certificates From Files using Kubernetes Secrets
+**Optional**: To install a specific Rancher version, set the `rancherImageTag` value, example: `--set rancherImageTag=v2.5.6`
+{{% /tab %}}
+{{% /tabs %}}
 
-{{% accordion id="k8s-2" label="Click to expand" %}}
+
+
+# Option B: Certificates From Files using Kubernetes Secrets
+
+
+### 1. Create secrets
 
 Create Kubernetes secrets from your own certificates for Rancher to use. The common name for the cert will need to match the `hostname` option in the command below, or the ingress controller will fail to provision the site for Rancher.
+
+### 2. Render the Rancher template
 
 Render the Rancher template, declaring your chosen options. Use the reference table below to replace each placeholder. Rancher needs to be configured to use the private registry in order to provision any Rancher launched Kubernetes clusters or Rancher tools.
 
@@ -147,6 +185,41 @@ Render the Rancher template, declaring your chosen options. Use the reference ta
 | `<VERSION>`                      | The version number of the output tarball.       |
 | `<RANCHER.YOURDOMAIN.COM>`       | The DNS name you pointed at your load balancer. |
 | `<REGISTRY.YOURDOMAIN.COM:PORT>` | The DNS name for your private registry.         |
+
+{{% tabs %}}
+{{% tab "Rancher v2.5.8+" %}}
+
+```plain
+   helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
+     --no-hooks \ # prevent files for Helm hooks from being generated
+    --namespace cattle-system \
+    --set hostname=<RANCHER.YOURDOMAIN.COM> \
+    --set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \
+    --set ingress.tls.source=secret \
+    --set systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT> \ # Set a default private registry to be used in Rancher
+    --set useBundledSystemChart=true # Use the packaged Rancher system charts
+```
+
+If you are using a Private CA signed cert, add `--set privateCA=true` following `--set ingress.tls.source=secret`:
+
+```plain
+   helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
+    --no-hooks \ # prevent files for Helm hooks from being generated
+    --namespace cattle-system \
+    --set hostname=<RANCHER.YOURDOMAIN.COM> \
+    --set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \
+    --set ingress.tls.source=secret \
+    --set privateCA=true \
+    --set systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT> \ # Set a default private registry to be used in Rancher
+    --set useBundledSystemChart=true # Use the packaged Rancher system charts
+```
+
+**Optional**: To install a specific Rancher version, set the `rancherImageTag` value, example: `--set rancherImageTag=v2.3.6`
+
+Then refer to [Adding TLS Secrets]({{<baseurl>}}/rancher/v2.5/en/installation/resources/encryption/tls-secrets/) to publish the certificate files so Rancher and the ingress controller can use them.
+{{% /tab %}}
+{{% tab "Rancher before v2.5.8" %}}
+
 
 ```plain
    helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
@@ -174,8 +247,10 @@ If you are using a Private CA signed cert, add `--set privateCA=true` following 
 **Optional**: To install a specific Rancher version, set the `rancherImageTag` value, example: `--set rancherImageTag=v2.3.6`
 
 Then refer to [Adding TLS Secrets]({{<baseurl>}}/rancher/v2.5/en/installation/resources/encryption/tls-secrets/) to publish the certificate files so Rancher and the ingress controller can use them.
+{{% /tab %}}
+{{% /tabs %}}
 
-{{% /accordion %}}
+
 
 # 4. Install Rancher
 
@@ -228,135 +303,3 @@ These resources could be helpful when installing Rancher:
 - [Rancher Helm chart options]({{<baseurl>}}/rancher/v2.5/en/installation/resources/chart-options/)
 - [Adding TLS secrets]({{<baseurl>}}/rancher/v2.5/en/installation/resources/encryption/tls-secrets/)
 - [Troubleshooting Rancher Kubernetes Installations]({{<baseurl>}}/rancher/v2.5/en/installation/options/troubleshooting/)
-
-{{% /tab %}}
-{{% tab "Docker Install" %}}
-
-The Docker installation is for Rancher users who want to test out Rancher. 
-
-Instead of running on a Kubernetes cluster, you install the Rancher server component on a single node using a `docker run` command. Since there is only one node and a single Docker container, if the node goes down, there is no copy of the etcd data available on other nodes and you will lose all the data of your Rancher server. 
-
-For Rancher v2.5+, the backup application can be used to migrate the Rancher server from a Docker install to a Kubernetes install using [these steps.]({{<baseurl>}}/rancher/v2.5/en/backups/migrating-rancher)
-
-For security purposes, SSL (Secure Sockets Layer) is required when using Rancher. SSL secures all Rancher network communication, like when you login or interact with a cluster.
-
-| Environment Variable Key         | Environment Variable Value       | Description     |
-| -------------------------------- | -------------------------------- | ---- |
-| `CATTLE_SYSTEM_DEFAULT_REGISTRY` | `<REGISTRY.YOURDOMAIN.COM:PORT>` | Configure Rancher server to always pull from your private registry when provisioning clusters.  |
-| `CATTLE_SYSTEM_CATALOG`          | `bundled`                        | Configure Rancher server to use the packaged copy of Helm system charts. The [system charts](https://github.com/rancher/system-charts) repository contains all the catalog items required for features such as monitoring, logging, alerting and global DNS. These [Helm charts](https://github.com/rancher/system-charts) are located in GitHub, but since you are in an air gapped environment, using the charts that are bundled within Rancher is much easier than setting up a Git mirror. |
-
-> **Do you want to...**
->
-> - Configure custom CA root certificate to access your services? See [Custom CA root certificate]({{<baseurl>}}/rancher/v2.5/en/installation/options/custom-ca-root-certificate/).
-> - Record all transactions with the Rancher API? See [API Auditing]({{<baseurl>}}/rancher/v2.5/en/installation/other-installation-methods/single-node-docker/advanced/#api-audit-log).
-
-Choose from the following options:
-
-### Option A: Default Self-Signed Certificate
-
-{{% accordion id="option-a" label="Click to expand" %}}
-
-If you are installing Rancher in a development or testing environment where identity verification isn't a concern, install Rancher using the self-signed certificate that it generates. This installation option omits the hassle of generating a certificate yourself.
-
-Log into your Linux host, and then run the installation command below. When entering the command, use the table below to replace each placeholder.
-
-| Placeholder                      | Description                                                                                                                   |
-| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `<REGISTRY.YOURDOMAIN.COM:PORT>` | Your private registry URL and port.                                                                                           |
-| `<RANCHER_VERSION_TAG>`          | The release tag of the [Rancher version]({{<baseurl>}}/rancher/v2.5/en/installation/resources/chart-options/) that you want to install. |
-
-As of Rancher v2.5, privileged access is [required.](#privileged-access-for-rancher-v2-5)
-
-```
-docker run -d --restart=unless-stopped \
-    -p 80:80 -p 443:443 \
-    -e CATTLE_SYSTEM_DEFAULT_REGISTRY=<REGISTRY.YOURDOMAIN.COM:PORT> \ # Set a default private registry to be used in Rancher
-    -e CATTLE_SYSTEM_CATALOG=bundled \ # Use the packaged Rancher system charts
-    --privileged \
-    <REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher:<RANCHER_VERSION_TAG>
-```
-
-{{% /accordion %}}
-
-### Option B: Bring Your Own Certificate: Self-Signed
-
-{{% accordion id="option-b" label="Click to expand" %}}
-
-In development or testing environments where your team will access your Rancher server, create a self-signed certificate for use with your install so that your team can verify they're connecting to your instance of Rancher.
-
-> **Prerequisites:**
-> From a computer with an internet connection, create a self-signed certificate using [OpenSSL](https://www.openssl.org/) or another method of your choice.
->
-> - The certificate files must be in PEM format.
-> - In your certificate file, include all intermediate certificates in the chain. Order your certificates with your certificate first, followed by the intermediates. For an example, see [Certificate Troubleshooting.]({{<baseurl>}}/rancher/v2.5/en/installation/other-installation-methods/single-node-docker/troubleshooting)
-
-After creating your certificate, log into your Linux host, and then run the installation command below. When entering the command, use the table below to replace each placeholder. Use the `-v` flag and provide the path to your certificates to mount them in your container.
-
-| Placeholder                      | Description                                                                                                                   |
-| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `<CERT_DIRECTORY>`               | The path to the directory containing your certificate files.                                                                  |
-| `<FULL_CHAIN.pem>`               | The path to your full certificate chain.                                                                                      |
-| `<PRIVATE_KEY.pem>`              | The path to the private key for your certificate.                                                                             |
-| `<CA_CERTS.pem>`                     | The path to the certificate authority's certificate.                                                                          |
-| `<REGISTRY.YOURDOMAIN.COM:PORT>` | Your private registry URL and port.                                                                                           |
-| `<RANCHER_VERSION_TAG>`          | The release tag of the [Rancher version]({{<baseurl>}}/rancher/v2.5/en/installation/resources/chart-options/) that you want to install. |
-
-As of Rancher v2.5, privileged access is [required.](#privileged-access-for-rancher-v2-5)
-
-```
-docker run -d --restart=unless-stopped \
-    -p 80:80 -p 443:443 \
-    -v /<CERT_DIRECTORY>/<FULL_CHAIN.pem>:/etc/rancher/ssl/cert.pem \
-    -v /<CERT_DIRECTORY>/<PRIVATE_KEY.pem>:/etc/rancher/ssl/key.pem \
-    -v /<CERT_DIRECTORY>/<CA_CERTS.pem>:/etc/rancher/ssl/cacerts.pem \
-    -e CATTLE_SYSTEM_DEFAULT_REGISTRY=<REGISTRY.YOURDOMAIN.COM:PORT> \ # Set a default private registry to be used in Rancher
-    -e CATTLE_SYSTEM_CATALOG=bundled \ # Use the packaged Rancher system charts
-    --privileged \
-    <REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher:<RANCHER_VERSION_TAG>
-```
-
-{{% /accordion %}}
-
-### Option C: Bring Your Own Certificate: Signed by Recognized CA
-
-{{% accordion id="option-c" label="Click to expand" %}}
-
-In development or testing environments where you're exposing an app publicly, use a certificate signed by a recognized CA so that your user base doesn't encounter security warnings.
-
-> **Prerequisite:** The certificate files must be in PEM format.
-
-After obtaining your certificate, log into your Linux host, and then run the installation command below. When entering the command, use the table below to replace each placeholder. Because your certificate is signed by a recognized CA, mounting an additional CA certificate file is unnecessary.
-
-| Placeholder                      | Description                                                                                                                   |
-| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `<CERT_DIRECTORY>`               | The path to the directory containing your certificate files.                                                                  |
-| `<FULL_CHAIN.pem>`               | The path to your full certificate chain.                                                                                      |
-| `<PRIVATE_KEY.pem>`              | The path to the private key for your certificate.                                                                             |
-| `<REGISTRY.YOURDOMAIN.COM:PORT>` | Your private registry URL and port.                                                                                           |
-| `<RANCHER_VERSION_TAG>`          | The release tag of the [Rancher version]({{<baseurl>}}/rancher/v2.5/en/installation/resources/chart-options/) that you want to install. |
-
-> **Note:** Use the `--no-cacerts` as argument to the container to disable the default CA certificate generated by Rancher.
-
-As of Rancher v2.5, privileged access is [required.](#privileged-access-for-rancher-v2-5)
-
-```
-docker run -d --restart=unless-stopped \
-    -p 80:80 -p 443:443 \
-    --no-cacerts \
-    -v /<CERT_DIRECTORY>/<FULL_CHAIN.pem>:/etc/rancher/ssl/cert.pem \
-    -v /<CERT_DIRECTORY>/<PRIVATE_KEY.pem>:/etc/rancher/ssl/key.pem \
-    -e CATTLE_SYSTEM_DEFAULT_REGISTRY=<REGISTRY.YOURDOMAIN.COM:PORT> \ # Set a default private registry to be used in Rancher
-    -e CATTLE_SYSTEM_CATALOG=bundled \ # Use the packaged Rancher system charts
-    --privileged
-    <REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher:<RANCHER_VERSION_TAG>
-```
-
-{{% /accordion %}}
-
-
-
-> **Note:** If you don't intend to send telemetry data, opt out [telemetry]({{<baseurl>}}/rancher/v2.5/en/faq/telemetry/) during the initial login.
-
-
-{{% /tab %}}
-{{% /tabs %}}

--- a/content/rancher/v2.5/en/installation/other-installation-methods/air-gap/install-rancher/docker-install-commands/_index.md
+++ b/content/rancher/v2.5/en/installation/other-installation-methods/air-gap/install-rancher/docker-install-commands/_index.md
@@ -1,0 +1,130 @@
+---
+title: Docker Install Commands
+weight: 1
+---
+
+The Docker installation is for Rancher users who want to test out Rancher. 
+
+Instead of running on a Kubernetes cluster, you install the Rancher server component on a single node using a `docker run` command. Since there is only one node and a single Docker container, if the node goes down, there is no copy of the etcd data available on other nodes and you will lose all the data of your Rancher server. 
+
+For Rancher v2.5+, the backup application can be used to migrate the Rancher server from a Docker install to a Kubernetes install using [these steps.]({{<baseurl>}}/rancher/v2.5/en/backups/migrating-rancher)
+
+For security purposes, SSL (Secure Sockets Layer) is required when using Rancher. SSL secures all Rancher network communication, like when you login or interact with a cluster.
+
+| Environment Variable Key         | Environment Variable Value       | Description     |
+| -------------------------------- | -------------------------------- | ---- |
+| `CATTLE_SYSTEM_DEFAULT_REGISTRY` | `<REGISTRY.YOURDOMAIN.COM:PORT>` | Configure Rancher server to always pull from your private registry when provisioning clusters.  |
+| `CATTLE_SYSTEM_CATALOG`          | `bundled`                        | Configure Rancher server to use the packaged copy of Helm system charts. The [system charts](https://github.com/rancher/system-charts) repository contains all the catalog items required for features such as monitoring, logging, alerting and global DNS. These [Helm charts](https://github.com/rancher/system-charts) are located in GitHub, but since you are in an air gapped environment, using the charts that are bundled within Rancher is much easier than setting up a Git mirror. |
+
+> **Do you want to...**
+>
+> - Configure custom CA root certificate to access your services? See [Custom CA root certificate]({{<baseurl>}}/rancher/v2.5/en/installation/options/custom-ca-root-certificate/).
+> - Record all transactions with the Rancher API? See [API Auditing]({{<baseurl>}}/rancher/v2.5/en/installation/other-installation-methods/single-node-docker/advanced/#api-audit-log).
+
+Choose from the following options:
+
+### Option A: Default Self-Signed Certificate
+
+{{% accordion id="option-a" label="Click to expand" %}}
+
+If you are installing Rancher in a development or testing environment where identity verification isn't a concern, install Rancher using the self-signed certificate that it generates. This installation option omits the hassle of generating a certificate yourself.
+
+Log into your Linux host, and then run the installation command below. When entering the command, use the table below to replace each placeholder.
+
+| Placeholder                      | Description                                                                                                                   |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `<REGISTRY.YOURDOMAIN.COM:PORT>` | Your private registry URL and port.                                                                                           |
+| `<RANCHER_VERSION_TAG>`          | The release tag of the [Rancher version]({{<baseurl>}}/rancher/v2.5/en/installation/resources/chart-options/) that you want to install. |
+
+As of Rancher v2.5, privileged access is [required.](#privileged-access-for-rancher-v2-5)
+
+```
+docker run -d --restart=unless-stopped \
+    -p 80:80 -p 443:443 \
+    -e CATTLE_SYSTEM_DEFAULT_REGISTRY=<REGISTRY.YOURDOMAIN.COM:PORT> \ # Set a default private registry to be used in Rancher
+    -e CATTLE_SYSTEM_CATALOG=bundled \ # Use the packaged Rancher system charts
+    --privileged \
+    <REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher:<RANCHER_VERSION_TAG>
+```
+
+{{% /accordion %}}
+
+### Option B: Bring Your Own Certificate: Self-Signed
+
+{{% accordion id="option-b" label="Click to expand" %}}
+
+In development or testing environments where your team will access your Rancher server, create a self-signed certificate for use with your install so that your team can verify they're connecting to your instance of Rancher.
+
+> **Prerequisites:**
+> From a computer with an internet connection, create a self-signed certificate using [OpenSSL](https://www.openssl.org/) or another method of your choice.
+>
+> - The certificate files must be in PEM format.
+> - In your certificate file, include all intermediate certificates in the chain. Order your certificates with your certificate first, followed by the intermediates. For an example, see [Certificate Troubleshooting.]({{<baseurl>}}/rancher/v2.5/en/installation/other-installation-methods/single-node-docker/troubleshooting)
+
+After creating your certificate, log into your Linux host, and then run the installation command below. When entering the command, use the table below to replace each placeholder. Use the `-v` flag and provide the path to your certificates to mount them in your container.
+
+| Placeholder                      | Description                                                                                                                   |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `<CERT_DIRECTORY>`               | The path to the directory containing your certificate files.                                                                  |
+| `<FULL_CHAIN.pem>`               | The path to your full certificate chain.                                                                                      |
+| `<PRIVATE_KEY.pem>`              | The path to the private key for your certificate.                                                                             |
+| `<CA_CERTS.pem>`                     | The path to the certificate authority's certificate.                                                                          |
+| `<REGISTRY.YOURDOMAIN.COM:PORT>` | Your private registry URL and port.                                                                                           |
+| `<RANCHER_VERSION_TAG>`          | The release tag of the [Rancher version]({{<baseurl>}}/rancher/v2.5/en/installation/resources/chart-options/) that you want to install. |
+
+As of Rancher v2.5, privileged access is [required.](#privileged-access-for-rancher-v2-5)
+
+```
+docker run -d --restart=unless-stopped \
+    -p 80:80 -p 443:443 \
+    -v /<CERT_DIRECTORY>/<FULL_CHAIN.pem>:/etc/rancher/ssl/cert.pem \
+    -v /<CERT_DIRECTORY>/<PRIVATE_KEY.pem>:/etc/rancher/ssl/key.pem \
+    -v /<CERT_DIRECTORY>/<CA_CERTS.pem>:/etc/rancher/ssl/cacerts.pem \
+    -e CATTLE_SYSTEM_DEFAULT_REGISTRY=<REGISTRY.YOURDOMAIN.COM:PORT> \ # Set a default private registry to be used in Rancher
+    -e CATTLE_SYSTEM_CATALOG=bundled \ # Use the packaged Rancher system charts
+    --privileged \
+    <REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher:<RANCHER_VERSION_TAG>
+```
+
+{{% /accordion %}}
+
+### Option C: Bring Your Own Certificate: Signed by Recognized CA
+
+{{% accordion id="option-c" label="Click to expand" %}}
+
+In development or testing environments where you're exposing an app publicly, use a certificate signed by a recognized CA so that your user base doesn't encounter security warnings.
+
+> **Prerequisite:** The certificate files must be in PEM format.
+
+After obtaining your certificate, log into your Linux host, and then run the installation command below. When entering the command, use the table below to replace each placeholder. Because your certificate is signed by a recognized CA, mounting an additional CA certificate file is unnecessary.
+
+| Placeholder                      | Description                                                                                                                   |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `<CERT_DIRECTORY>`               | The path to the directory containing your certificate files.                                                                  |
+| `<FULL_CHAIN.pem>`               | The path to your full certificate chain.                                                                                      |
+| `<PRIVATE_KEY.pem>`              | The path to the private key for your certificate.                                                                             |
+| `<REGISTRY.YOURDOMAIN.COM:PORT>` | Your private registry URL and port.                                                                                           |
+| `<RANCHER_VERSION_TAG>`          | The release tag of the [Rancher version]({{<baseurl>}}/rancher/v2.5/en/installation/resources/chart-options/) that you want to install. |
+
+> **Note:** Use the `--no-cacerts` as argument to the container to disable the default CA certificate generated by Rancher.
+
+As of Rancher v2.5, privileged access is [required.](#privileged-access-for-rancher-v2-5)
+
+```
+docker run -d --restart=unless-stopped \
+    -p 80:80 -p 443:443 \
+    --no-cacerts \
+    -v /<CERT_DIRECTORY>/<FULL_CHAIN.pem>:/etc/rancher/ssl/cert.pem \
+    -v /<CERT_DIRECTORY>/<PRIVATE_KEY.pem>:/etc/rancher/ssl/key.pem \
+    -e CATTLE_SYSTEM_DEFAULT_REGISTRY=<REGISTRY.YOURDOMAIN.COM:PORT> \ # Set a default private registry to be used in Rancher
+    -e CATTLE_SYSTEM_CATALOG=bundled \ # Use the packaged Rancher system charts
+    --privileged
+    <REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher:<RANCHER_VERSION_TAG>
+```
+
+{{% /accordion %}}
+
+
+
+> **Note:** If you don't intend to send telemetry data, opt out [telemetry]({{<baseurl>}}/rancher/v2.5/en/faq/telemetry/) during the initial login.
+

--- a/content/rancher/v2.5/en/installation/resources/feature-flags/_index.md
+++ b/content/rancher/v2.5/en/installation/resources/feature-flags/_index.md
@@ -76,6 +76,24 @@ Here is an example of a command for passing in the feature flag names when rende
 
 The Helm 3 command is as follows:
 
+{{% tabs %}}
+{{% tab "Rancher v2.5.8" %}}
+
+```
+helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
+  --no-hooks \ # prevent files for Helm hooks from being generated
+  --namespace cattle-system \
+  --set hostname=<RANCHER.YOURDOMAIN.COM> \
+  --set rancherImage=<REGISTRY.YOURDOMAIN.COM:PORT>/rancher/rancher \
+  --set ingress.tls.source=secret \
+  --set systemDefaultRegistry=<REGISTRY.YOURDOMAIN.COM:PORT> \ # Set a default private registry to be used in Rancher
+  --set useBundledSystemChart=true # Use the packaged Rancher system charts
+  --set 'extraEnv[0].name=CATTLE_FEATURES'
+  --set 'extraEnv[0].value=<FEATURE-FLAG-NAME-1>=true,<FEATURE-FLAG-NAME-2>=true'
+```
+{{% /tab %}}
+{{% tab "Rancher before v2.5.8" %}}
+
 ```
 helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
   --namespace cattle-system \
@@ -87,6 +105,8 @@ helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
   --set 'extraEnv[0].name=CATTLE_FEATURES'
   --set 'extraEnv[0].value=<FEATURE-FLAG-NAME-1>=true,<FEATURE-FLAG-NAME-2>=true'
 ```
+{{% /tab %}}
+{{% /tabs %}}
 
 The Helm 2 command is as follows:
 


### PR DESCRIPTION
This PR adds an option to the helm template commands for air gap installs. https://github.com/rancher/docs/issues/3226

Even though we're just adding one option to the command, this change required a lot of reorganization because our website theme doesn't allow tabs within accordions. So I had to get rid of several accordions and create new pages to make space for the tabs showing the differences between each Rancher version.

The pages with changes to the commands are:

- docs on upgrading Rancher on Kubernetes in an air gap environment https://staging.rancher.com/docs/rancher/v2.5/en/installation/install-rancher-on-k8s/upgrades/#3-upgrade-rancher
- air gapped Helm CLI install docs https://staging.rancher.com/docs/rancher/v2.5/en/installation/other-installation-methods/air-gap/install-rancher/#3-render-the-rancher-helm-template
- The feature flag docs https://staging.rancher.com/docs/rancher/v2.5/en/installation/resources/feature-flags/#rendering-the-helm-chart-for-air-gap-installations