### PR TITLE
Fix backup restore secret creation

### DIFF
--- a/content/rancher/v2.5/en/backups/migrating-rancher/_index.md
+++ b/content/rancher/v2.5/en/backups/migrating-rancher/_index.md
@@ -36,7 +36,7 @@ kind: Secret
 metadata:
   name: s3-creds
 type: Opaque
-data:
+stringData:
   accessKey: <Enter your access key>
   secretKey: <Enter your secret key>
 ```


### PR DESCRIPTION
The credentials for the secret need to either go into `stringData` or be base64-encoded or they will be garbage when sent to S3.