### PR TITLE
Add required modifications to RKE templates for monitoring migration

### DIFF
--- a/content/rancher/v2.5/en/monitoring-alerting/migrating/_index.md
+++ b/content/rancher/v2.5/en/monitoring-alerting/migrating/_index.md
@@ -46,7 +46,14 @@ Before you can install Monitoring V2, Monitoring V1 needs to be uninstalled comp
 * Disable the cluster monitoring installation under Cluster -> Tools -> Monitoring
 * Ensure that the cluster-monitoring app and the monitoring-operator app in the System project have been removed and are not recreated after a few minutes
 
-If the cluster is managed using an RKE template: To prevent legacy monitoring from being re-enabled, disable Monitoring in future RKE template revisions.
+#### RKE Template Clusters
+
+To prevent v1 monitoring from being re-enabled, disable monitoring and in future RKE template revisions via modification of the RKE template yaml:
+
+```yaml
+enable_cluster_alerting: true
+enable_cluster_monitoring: true
+```
 
 #### Migrating Grafana Dashboards
 

--- a/content/rancher/v2.5/en/monitoring-alerting/migrating/_index.md
+++ b/content/rancher/v2.5/en/monitoring-alerting/migrating/_index.md
@@ -46,7 +46,7 @@ Before you can install Monitoring V2, Monitoring V1 needs to be uninstalled comp
 * Disable the cluster monitoring installation under Cluster -> Tools -> Monitoring
 * Ensure that the cluster-monitoring app and the monitoring-operator app in the System project have been removed and are not recreated after a few minutes
 
-If your cluster is managed using an RKE template: To prevent legacy monitoring from being re-enabled, disable Monitoring in future RKE template revisions.
+If the cluster is managed using an RKE template: To prevent legacy monitoring from being re-enabled, disable Monitoring in future RKE template revisions.
 
 #### Migrating Grafana Dashboards
 

--- a/content/rancher/v2.5/en/monitoring-alerting/migrating/_index.md
+++ b/content/rancher/v2.5/en/monitoring-alerting/migrating/_index.md
@@ -46,6 +46,8 @@ Before you can install Monitoring V2, Monitoring V1 needs to be uninstalled comp
 * Disable the cluster monitoring installation under Cluster -> Tools -> Monitoring
 * Ensure that the cluster-monitoring app and the monitoring-operator app in the System project have been removed and are not recreated after a few minutes
 
+If your cluster is managed using an RKE template: To prevent legacy monitoring from being re-enabled, disable Monitoring in future RKE template revisions.
+
 #### Migrating Grafana Dashboards
 
 You can migrate any dashboard added to Grafana in Monitoring V1 to Monitoring V2. In Monitoring V1 you can export an existing dashboard like this:

--- a/content/rancher/v2.5/en/monitoring-alerting/migrating/_index.md
+++ b/content/rancher/v2.5/en/monitoring-alerting/migrating/_index.md
@@ -51,8 +51,8 @@ Before you can install Monitoring V2, Monitoring V1 needs to be uninstalled comp
 To prevent v1 monitoring from being re-enabled, disable monitoring and in future RKE template revisions via modification of the RKE template yaml:
 
 ```yaml
-enable_cluster_alerting: true
-enable_cluster_monitoring: true
+enable_cluster_alerting: false
+enable_cluster_monitoring: false
 ```
 
 #### Migrating Grafana Dashboards


### PR DESCRIPTION
closes: https://github.com/rancher/docs/issues/3234

The migration documentation does not cover cases where RKE templates are used in a cluster. The lack of this info will cause the monitoring-operator app to redeploy indefinitely, preventing migration.

Also ref: https://github.com/rancher/rancher/issues/32416
Also ref: https://github.com/bashofmann/rancher-monitoring-v1-to-v2#check-why-monitoring-v1-is-not-disabled