### PR TITLE
Fix openssl certificate generation command in ADFS docs

### DIFF
--- a/content/rancher/v2.5/en/admin-settings/authentication/microsoft-adfs/rancher-adfs-setup/_index.md
+++ b/content/rancher/v2.5/en/admin-settings/authentication/microsoft-adfs/rancher-adfs-setup/_index.md
@@ -51,5 +51,5 @@ After you complete [Configuring Microsoft AD FS for Rancher]({{<baseurl>}}/ranch
 **Tip:** You can generate a certificate using an openssl command. For example:
 
 ```
-openssl req -x509 -newkey rsa:2048 -keyout myservice.key -out myservice.cert -days 365 -nodes -subj "/CN=https://myservice.example.com"
+openssl req -x509 -newkey rsa:2048 -keyout myservice.key -out myservice.cert -days 365 -nodes -subj "/CN=myservice.example.com"
 ```

--- a/content/rancher/v2.x/en/admin-settings/authentication/microsoft-adfs/rancher-adfs-setup/_index.md
+++ b/content/rancher/v2.x/en/admin-settings/authentication/microsoft-adfs/rancher-adfs-setup/_index.md
@@ -52,5 +52,5 @@ After you complete [Configuring Microsoft AD FS for Rancher]({{<baseurl>}}/ranch
 **Tip:** You can generate a certificate using an openssl command. For example:
 
 ```
-openssl req -x509 -newkey rsa:2048 -keyout myservice.key -out myservice.cert -days 365 -nodes -subj "/CN=https://myservice.example.com"
+openssl req -x509 -newkey rsa:2048 -keyout myservice.key -out myservice.cert -days 365 -nodes -subj "/CN=myservice.example.com"
 ```


### PR DESCRIPTION
Fix openssl certificate generation command in ADFS docs

The CN must be a hostname without a protocol.

With the protocol the command even fails because of the missing escaping of the forward slashes:

```
openssl req -x509 -newkey rsa:2048 -keyout myservice.key -out myservice.cert -days 365 -nodes -subj '/CN=https://myservice.example.com'
Generating a 2048 bit RSA private key
..+++
...........................+++
writing new private key to 'myservice.key'
-----
end of string encountered while processing type of subject name element  #1
problems making Certificate Request
```