### PR TITLE
Fix image upgrade plan

### DIFF
--- a/content/k3s/latest/en/upgrades/automated/_index.md
+++ b/content/k3s/latest/en/upgrades/automated/_index.md
@@ -78,7 +78,7 @@ spec:
     args:
     - prepare
     - server-plan
-    image: rancher/k3s-upgrade:v1.17.4-k3s1
+    image: rancher/k3s-upgrade
   serviceAccountName: system-upgrade
   upgrade:
     image: rancher/k3s-upgrade


### PR DESCRIPTION
Hi,
For the agent plan, there's no need to specify the rancher/k3s-upgrade version