### PR TITLE
Refer to upstream for CNI requirements

### DIFF
--- a/content/rke/latest/en/os/_index.md
+++ b/content/rke/latest/en/os/_index.md
@@ -52,54 +52,13 @@ RKE runs on almost any Linux OS with Docker installed. For details on which OS a
 
 - Swap should be disabled on any worker nodes
 
-- Following kernel modules should be present. This can be checked using:
-   * `modprobe module_name`
-   * `lsmod | grep module_name`
-   * `grep module_name /lib/modules/$(uname -r)/modules.builtin`, if it's a built-in module
-   * The following bash script
+- Please check the network plugin documentation for any additional requirements (for example, kernel modules)
+  - [Calico](https://docs.projectcalico.org/getting-started/kubernetes/requirements#kernel-dependencies)
+  - [Flannel](https://github.com/flannel-io/flannel/tree/master/Documentation)
+  - Canal (Combination Calico and Flannel)
+  - [Weave](https://www.weave.works/docs/net/latest/install/installing-weave/)
 
-```bash
-     for module in br_netfilter ip6_udp_tunnel ip_set ip_set_hash_ip ip_set_hash_net iptable_filter iptable_nat iptable_mangle iptable_raw nf_conntrack_netlink nf_conntrack nf_conntrack_ipv4   nf_defrag_ipv4 nf_nat nf_nat_ipv4 nf_nat_masquerade_ipv4 nfnetlink udp_tunnel veth vxlan x_tables xt_addrtype xt_conntrack xt_comment xt_mark xt_multiport xt_nat xt_recent xt_set  xt_statistic xt_tcpudp;
-     do
-       if ! lsmod | grep -q $module; then
-         echo "module $module is not present";
-       fi;
-     done
-```
-
-Module name |
-------------|
-br_netfilter |
-ip6_udp_tunnel |
-ip_set |
-ip_set_hash_ip |
-ip_set_hash_net |
-iptable_filter |
-iptable_nat |
-iptable_mangle |
-iptable_raw |
-nf_conntrack_netlink |
-nf_conntrack |
-nf_conntrack_ipv4 |
-nf_defrag_ipv4 |
-nf_nat |
-nf_nat_ipv4 |
-nf_nat_masquerade_ipv4 |
-nfnetlink |
-udp_tunnel |
-veth |
-vxlan |
-x_tables |
-xt_addrtype |
-xt_conntrack |
-xt_comment |
-xt_mark |
-xt_multiport |
-xt_nat |
-xt_recent |
-xt_set |
-xt_statistic |
-xt_tcpudp |
+> **Note:** If you or your cloud provider are using a custom minimal kernel, some required (network) kernel modules might not be present.
 
 - Following sysctl settings must be applied
 
@@ -309,22 +268,11 @@ Each Kubernetes version supports different Docker versions. The Kubernetes relea
 
 ### Installing Docker
 
-You can either follow the [Docker installation](https://docs.docker.com/install/) instructions or use one of Rancher's [install scripts](https://github.com/rancher/install-docker) to install Docker. For RHEL, please see [How to install Docker on Red Hat Enterprise Linux 7](https://access.redhat.com/solutions/3727511).
-
-Docker Version   | Install Script |
-----------|------------------
-18.09.2 |  <code>curl https://releases.rancher.com/install-docker/18.09.2.sh &#124; sh</code> |
-18.06.2 |  <code>curl https://releases.rancher.com/install-docker/18.06.2.sh &#124; sh</code> |
-17.03.2 |  <code>curl https://releases.rancher.com/install-docker/17.03.2.sh &#124; sh</code> |
+Refer to [Installing Docker]({{<baseurl>}}/rancher/v2.5/en/installation/requirements/installing-docker/)
 
 ### Checking the Installed Docker Version
 
 Confirm that a Kubernetes supported version of Docker is installed on your machine, by running `docker version --format '{{.Server.Version}}'`.
-
-```
-docker version --format '{{.Server.Version}}'
-17.03.2-ce
-```
 
 ## Ports
 {{< ports-rke-nodes >}}


### PR DESCRIPTION
Also directed `Installing Docker` to Rancher and removed check output to avoid out-of-date info