### PR TITLE
Update snapshot to false for RKE cluster.yml example

### DIFF
--- a/content/rancher/v2.x/en/security/rancher-2.5/1.6-hardening-2.5/_index.md
+++ b/content/rancher/v2.x/en/security/rancher-2.5/1.6-hardening-2.5/_index.md
@@ -181,7 +181,7 @@ services:
     path: ""
     uid: 52034
     gid: 52034
-    snapshot: true
+    snapshot: false
     retention: ""
     creation: ""
     backup_config: null


### PR DESCRIPTION
The snapshot: true refers to the legacy recurring snapshot syntax (pre RKE v0.2.0)
  * https://rancher.com/docs/rke/latest/en/etcd-snapshots/recurring-snapshots/