### PR TITLE
Add docs for how to use Fleet with a proxy

### DIFF
--- a/content/rancher/v2.5/en/deploy-across-clusters/fleet/_index.md
+++ b/content/rancher/v2.5/en/deploy-across-clusters/fleet/_index.md
@@ -9,38 +9,38 @@ Fleet is GitOps at scale. Fleet is designed to manage up to a million clusters. 
 
 Fleet is a separate project from Rancher, and can be installed on any Kubernetes cluster with Helm.
 
-![Architecture]({{<baseurl>}}/img/rancher/fleet-architecture.png)
+- [Architecture](#architecture)
+- [Accessing Fleet in the Rancher UI](#accessing-fleet-in-the-rancher-ui)
+- [Windows Support](#windows-support)
+- [GitHub Repository](#github-repository)
+- [Documentation](#documentation)
 
-Fleet can manage deployments from git of raw Kubernetes YAML, Helm charts, or Kustomize or any combination of the three. Regardless of the source, all resources are dynamically turned into Helm charts, and Helm is used as the engine to deploy everything in the cluster. This gives you a high degree of control, consistency, and auditability. Fleet focuses not only on the ability to scale, but to give one a high degree of control and visibility to exactly what is installed on the cluster.
+# Architecture
 
-### Accessing Fleet in the Rancher UI
+For information about how Fleet works, see [this page.](./architecture)
+
+# Accessing Fleet in the Rancher UI
 
 Fleet comes preinstalled in Rancher v2.5. To access it, go to the **Cluster Explorer** in the Rancher UI. In the top left dropdown menu, click **Cluster Explorer > Continuous Delivery.** On this page, you can edit Kubernetes resources and cluster groups managed by Fleet.
 
-### Windows Support
+# Windows Support
 
-Prior to Rancher v2.5.6, the `agent` did not have native Windows manifests on downstream clusters with Windows nodes.
-This would result in a failing `agent` pod for the cluster.
-If you are upgrading from an older version of Rancher to v2.5.6+, you can deploy a working `agent` with the following workflow *in the downstream cluster*:
+_Available as of v2.5.6_
 
-1. Cordon all Windows nodes.
-1. Apply the below toleration to the `agent` workload.
-1. Uncordon all Windows nodes.
-1. Delete all `agent` pods. New pods should be created with the new toleration.
-1. Once the `agent` pods are running, and auto-update is enabled for Fleet, they should be updated to a Windows-compatible `agent` version.
+For details on support for clusters with Windows nodes, see [this page.](./windows)
 
-```yaml
-tolerations:
-- effect: NoSchedule
-  key: cattle.io/os
-  operator: Equal
-  value: linux
-```
 
-### GitHub Repository
+# GitHub Repository
 
 The Fleet Helm charts are available [here.](https://github.com/rancher/fleet/releases/latest)
 
-### Documentation
+
+# Using Fleet Behind a Proxy
+
+_Available as of v2.5.8_
+
+For details on using Fleet behind a proxy, see [this page.](./proxy)
+
+# Documentation
 
 The Fleet documentation is at [https://fleet.rancher.io/.](https://fleet.rancher.io/)

--- a/content/rancher/v2.5/en/deploy-across-clusters/fleet/architecture/_index.md
+++ b/content/rancher/v2.5/en/deploy-across-clusters/fleet/architecture/_index.md
@@ -1,0 +1,9 @@
+---
+title: Architecture
+weight: 1
+---
+
+Fleet can manage deployments from git of raw Kubernetes YAML, Helm charts, or Kustomize or any combination of the three. Regardless of the source, all resources are dynamically turned into Helm charts, and Helm is used as the engine to deploy everything in the cluster. This gives you a high degree of control, consistency, and auditability. Fleet focuses not only on the ability to scale, but to give one a high degree of control and visibility to exactly what is installed on the cluster.
+
+![Architecture]({{<baseurl>}}/img/rancher/fleet-architecture.png)
+

--- a/content/rancher/v2.5/en/deploy-across-clusters/fleet/proxy/_index.md
+++ b/content/rancher/v2.5/en/deploy-across-clusters/fleet/proxy/_index.md
@@ -1,0 +1,33 @@
+---
+title: Using Fleet Behind a Proxy
+weight: 3
+---
+
+_Available as of v2.5.8_
+
+In this sections, you'll learn how to enable Fleet in a setup that has a Rancher server with a public IP and a registered K3s cluster that has no public IP, but is configured to use a proxy.
+
+Rancher does not establish connections with registered downstream clusters. The Rancher agent deployed on the downstream cluster must be able to establish the connection with Rancher.
+
+To set up Fleet to work behind a proxy, you will need to set the **Agent Environment Variables* * for the downstream cluster. These are cluster-level configuration options.
+
+To add the environment variable,
+
+1. In the Rancher UI, go to the cluster view for the registered K3s cluster that needs to use a proxy.
+1. Click **&#8942; > Edit**.
+1. Click **Advanced Options.**
+1. Click **Add Environment Variable.**
+1. Enter environment variables according to the table below.
+1. Click **Save.**
+
+**Result:** The Fleet agent works behind a proxy.
+
+### Required Environment Variables
+
+When adding Fleet agent environment variables for the proxy, replace <PROXY_IP> with your private proxy IP.
+
+| Variable Name | Value |
+|------------------|--------|
+| `HTTP_PROXY` | http://<PROXY_IP>:8888 |
+| `HTTPS_PROXY | http://<PROXY_IP>:8888
+| `NO_PROXY`     | 127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local |

--- a/content/rancher/v2.5/en/deploy-across-clusters/fleet/windows/_index.md
+++ b/content/rancher/v2.5/en/deploy-across-clusters/fleet/windows/_index.md
@@ -1,0 +1,23 @@
+---
+title: Windows Support
+weight: 2
+---
+
+
+Prior to Rancher v2.5.6, the `agent` did not have native Windows manifests on downstream clusters with Windows nodes. This would result in a failing `agent` pod for the cluster.
+
+If you are upgrading from an older version of Rancher to v2.5.6+, you can deploy a working `agent` with the following workflow *in the downstream cluster*:
+
+1. Cordon all Windows nodes.
+1. Apply the below toleration to the `agent` workload.
+1. Uncordon all Windows nodes.
+1. Delete all `agent` pods. New pods should be created with the new toleration.
+1. Once the `agent` pods are running, and auto-update is enabled for Fleet, they should be updated to a Windows-compatible `agent` version.
+
+```yaml
+tolerations:
+- effect: NoSchedule
+  key: cattle.io/os
+  operator: Equal
+  value: linux
+```


### PR DESCRIPTION
https://github.com/rancher/docs/issues/3145

Slight reorganization of the Fleet docs as well. We're going to add more content soon, so the main page should be a landing page for the other sections.