### PR TITLE
Update repo/tag to reflect latest image location and version

### DIFF
--- a/content/rancher/v2.x/en/backups/v2.5/configuration/storage-config/_index.md
+++ b/content/rancher/v2.x/en/backups/v2.5/configuration/storage-config/_index.md
@@ -63,8 +63,8 @@ For more information about `values.yaml` files and configuring Helm charts durin
 
 ```yaml
 image:
-  repository: rancher/rancher-backup
-  tag: v0.0.1-rc10
+  repository: rancher/backup-restore-operator
+  tag: v1.0.3
 
 ## Default s3 bucket for storing all backup files created by the rancher-backup operator
 s3:


### PR DESCRIPTION
This image no longer exists, updated to reflect [the chart values](https://github.com/rancher/backup-restore-operator/blob/master/charts/rancher-backup/values.yaml)