### PR TITLE
Add clusterRole and binding to use restricted psp

### DIFF
--- a/content/rancher/v2.x/en/security/rancher-2.5/1.6-hardening-2.5/_index.md
+++ b/content/rancher/v2.x/en/security/rancher-2.5/1.6-hardening-2.5/_index.md
@@ -287,6 +287,36 @@ addons: |
     - configMap
     - projected
   ---
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    name: psp:restricted
+  rules:
+  - apiGroups:
+    - extensions
+    resourceNames:
+    - restricted
+    resources:
+    - podsecuritypolicies
+    verbs:
+    - use
+  ---
+  apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRoleBinding
+  metadata:
+    name: psp:restricted
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: psp:restricted
+  subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:serviceaccounts
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated
+  ---
   apiVersion: networking.k8s.io/v1
   kind: NetworkPolicy
   metadata:


### PR DESCRIPTION
In [cis-1.6](https://github.com/rancher/docs/pull/2939), we removed clusterRole and clusterRoleBinding that uses restricted PSP. This will cause any pod failed to be created since there is no psp attached to it.

>Pod security policy control is implemented as an optional (but recommended) admission controller. PodSecurityPolicies are enforced by enabling the admission controller, but doing so without authorizing any policies will prevent any pods from being created in the cluster.

We need to figure out why the change was made and what's the implication of it before merging this PR.

Related issue:
https://github.com/rancher/rancher/issues/32825
https://github.com/rancher/rancher/issues/32823
https://github.com/rancher/rancher/issues/32547
