### PR TITLE
k3s: fix markdown rendering

### DIFF
--- a/content/k3s/latest/en/advanced/_index.md
+++ b/content/k3s/latest/en/advanced/_index.md
@@ -209,10 +209,7 @@ See also https://rootlesscontaine.rs/ to learn about Rootless mode.
 > **Note:** Don't try to run `k3s server --rootless` on a terminal, as it doesn't enable cgroup v2 delegation.
 > If you really need to try it on a terminal, prepend `systemd-run --user -p Delegate=yes --tty` to create a systemd scope.
 >
-> i.e.,
-> ```console
-> $ systemd-run --user -p Delegate=yes --tty k3s server --rootless
-> ```
+> i.e., `systemd-run --user -p Delegate=yes --tty k3s server --rootless`
 
 ### Troubleshooting
 


### PR DESCRIPTION
https://rancher.com/docs/k3s/latest/en/advanced was broken in #3243

# Before

![image](https://user-images.githubusercontent.com/9248427/120426992-0e801b80-c3ac-11eb-8fa3-f59db72f08ad.png)


# After

![image](https://user-images.githubusercontent.com/9248427/120427074-396a6f80-c3ac-11eb-96f2-ced8c7a5e105.png)
