### PR TITLE
Make versioning notice appear on every page of v2.x docs

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -25,7 +25,7 @@
       {{ $product := index $path 1 }}
       {{ $version := index $path 2 }}
       {{ $productVersion := printf "%s/%s" $product $version}}
-      {{ if eq $productVersion "rancher/v2.x" }}
+      {{ if in .Dir "rancher/v2.x" }}
       <div class="alert alert-notice">
           <strong>We are transitioning to versioned documentation.</strong> The v2.x docs will no longer be maintained. For Rancher v2.5 docs, go <a href="https://rancher.com/docs/rancher/v2.5/en/">here.</a> For Rancher v2.0-v2.4 docs, go <a href="https://rancher.com/docs/rancher/v2.0-v2.4/en/">here.</a>
       </div>


### PR DESCRIPTION
@jrcreative Through some experimentation I found out that this change makes the notice appear on all 2.x pages, but not the other pages, so it's the desired result. On the other hand, I still don't know why the .Dir variable worked but the product version didn't.