### PR TITLE
Disable nm-cloud-setup service in RHEL

### DIFF
--- a/content/k3s/latest/en/advanced/_index.md
+++ b/content/k3s/latest/en/advanced/_index.md
@@ -388,3 +388,9 @@ It is recommended to turn off firewalld:
 ```
 systemctl disable firewalld --now
 ```
+
+If enabled, it is required to disable nm-cloud-setup and reboot the node:
+```
+systemctl disable nm-cloud-setup.service nm-cloud-setup.timer
+reboot
+```


### PR DESCRIPTION
Disable that service as it breaks the connectivity in the cluster and makes it fail to start  (both k3s and rke2). This was investigated in this issue:

https://github.com/rancher/rke2/issues/1053

Signed-off-by: Manuel Buil <mbuil@suse.com>