### PR TITLE
corrected the image address

### DIFF
--- a/content/rancher/v2.5/en/troubleshooting/networking/_index.md
+++ b/content/rancher/v2.5/en/troubleshooting/networking/_index.md
@@ -35,7 +35,7 @@ To test the overlay network, you can launch the following `DaemonSet` definition
           tolerations:
           - operator: Exists
           containers:
-          - image: rancher/swiss-army-knife
+          - image: rancherlabs/swiss-army-knife
             imagePullPolicy: Always
             name: overlaytest
             command: ["sh", "-c", "tail -f /dev/null"]


### PR DESCRIPTION
When contributing to docs, please don't update the content in the v2.x folder.
It's better to update the versioned docs, for example, the v2.5 or v2.6 docs.

This content in v2.x was separated into versioned documentation during the v2.5.8
release. The content relevant to Rancher versions before v2.5 went into the v2.0-v2.4
folder, while the content related to Rancher v2.5 went into the v2.5 folder.

We are trying to get the 2.x content to be removed from Google search results. The only
reason we haven't deleted it is because Google search results would lead to 404
errors if we deleted it.
