### PR TITLE
Fix typos

### DIFF
--- a/content/rancher/v2.5/en/faq/_index.md
+++ b/content/rancher/v2.5/en/faq/_index.md
@@ -5,7 +5,7 @@ aliases:
   - /rancher/v2.5/en/about/
 ---
 
-This FAQ is a work in progress designed to answers the questions our users most frequently ask about Rancher v2.x.
+This FAQ is a work in progress designed to answer the questions our users most frequently ask about Rancher v2.x.
 
 See [Technical FAQ]({{<baseurl>}}/rancher/v2.5/en/faq/technical/), for frequently asked technical questions.
 

--- a/content/rancher/v2.5/en/istio/resources/_index.md
+++ b/content/rancher/v2.5/en/istio/resources/_index.md
@@ -59,7 +59,7 @@ You can find more information about Istio configuration in the [official Istio d
 To configure the resources allocated to an Istio component,
 
 1. In the Rancher **Cluster Explorer**, navigate to your Istio installation in **Apps & Marketplace**
-1. Click **Upgrade** to edit the base components via changes the values.yaml or add an [overlay file]({{<baseurl>}}/rancher/v2.5/en/istio/v2.5/configuration-reference/#overlay-file). For more information about editing the overlay file, see [this section.](./#editing-the-overlay-file)
+1. Click **Upgrade** to edit the base components via changes to the values.yaml or add an [overlay file]({{<baseurl>}}/rancher/v2.5/en/istio/v2.5/configuration-reference/#overlay-file). For more information about editing the overlay file, see [this section.](./#editing-the-overlay-file)
 1. Change the CPU or memory allocations, the nodes where each component will be scheduled to, or the node tolerations.
 1. Click **Upgrade.** to rollout changes
 


### PR DESCRIPTION
When contributing to docs, please don't update the content in the v2.x folder.
It's better to update the versioned docs, for example, the v2.5 or v2.6 docs.

This content in v2.x was separated into versioned documentation during the v2.5.8
release. The content relevant to Rancher versions before v2.5 went into the v2.0-v2.4
folder, while the content related to Rancher v2.5 went into the v2.5 folder.

We are trying to get the 2.x content to be removed from Google search results. The only
reason we haven't deleted it is because Google search results would lead to 404
errors if we deleted it.
