### PR TITLE
Document Rancher image vulnerability scanning

### DIFF
--- a/content/rancher/v2.5/_index.md
+++ b/content/rancher/v2.5/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Rancher v2.5.7+
+title: Rancher v2.5
 weight: 1
 showBreadcrumb: false
 ---

--- a/content/rancher/v2.6/en/istio/_index.md
+++ b/content/rancher/v2.6/en/istio/_index.md
@@ -7,6 +7,20 @@ aliases:
 
 [Istio](https://istio.io/) is an open-source tool that makes it easier for DevOps teams to observe, secure, control, and troubleshoot the traffic within a complex network of microservices.
 
+> If you are still using Istio v1, installed with the legacy Cluster Manager, we recommend migrating to Istio v2 by following [these steps.](./migrating/#migrating-istio) Istio v1 (1.5.920) will receive limited security updates should no longer be used. The images for Istio 1.5.920 should not be downloaded unless upgrading Istio is not feasible.
+
+- [Overview](#overview)
+- [Tools Bundled with Istio](#tools-bundled-with-istio)
+- [Prerequisites](#prerequisites)
+- [Setup Guide](#setup-guide)
+- [Remove Istio](#remove-istio)
+- [Migrate from Previous Istio Version](#migrate-from-previous-istio-version)
+- [Accessing Visualizations](#accessing-visualizations)
+- [Architecture](#architecture)
+- [Additional steps for installing Istio on an RKE2 cluster](#additional-steps-for-installing-istio-on-an-rke2-cluster)
+
+# Overview
+
 As a network of microservices changes and grows, the interactions between them can become increasingly difficult to manage and understand. In such a situation, it is useful to have a service mesh as a separate infrastructure layer. Istio's service mesh lets you manipulate traffic between microservices without changing the microservices directly.
 
 Our integration of Istio is designed so that a Rancher operator, such as an administrator or cluster owner, can deliver Istio to a team of developers. Then developers can use Istio to enforce security policies, troubleshoot problems, or manage traffic for green/blue deployments, canary deployments, or A/B testing.
@@ -20,28 +34,6 @@ This core service mesh provides features that include but are not limited to the
 After [setting up istio]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/tools/istio/setup) you can leverage Istio's control plane functionality through the Cluster Explorer, `kubectl`, or `istioctl`.
 
 Istio needs to be set up by a `cluster-admin` before it can be used in a project.
-
-- [What's New in Rancher v2.5](#what-s-new-in-rancher-v2-5)
-- [Tools Bundled with Istio](#tools-bundled-with-istio)
-- [Prerequisites](#prerequisites)
-- [Setup Guide](#setup-guide)
-- [Remove Istio](#remove-istio)
-- [Migrate from Previous Istio Version](#migrate-from-previous-istio-version)
-- [Accessing Visualizations](#accessing-visualizations)
-- [Architecture](#architecture)
-- [Additional steps for installing Istio on an RKE2 cluster](#additional-steps-for-installing-istio-on-an-rke2-cluster)
-
-# What's New in Rancher v2.5
-
-The overall architecture of Istio has been simplified. A single component, Istiod, has been created by combining Pilot, Citadel, Galley and the sidecar injector. Node Agent functionality has also been merged into istio-agent.
-
-Addons that were previously installed by Istio (cert-manager, Grafana, Jaeger, Kiali, Prometheus, Zipkin) will now need to be installed separately. Istio will support installation of integrations that are from the Istio Project and will maintain compatibility with those that are not.
-
-A Prometheus integration will still be available through an installation of [Rancher Monitoring]({{<baseurl>}}/rancher/v2.6/en/monitoring-alerting/), or by installing your own Prometheus operator. Rancher's Istio chart will also install Kiali by default to ensure you can get a full picture of your microservices out of the box.
-
-Istio has migrated away from Helm as a way to install Istio and now provides installation through the istioctl binary or Istio Operator. To ensure the easiest interaction with Istio, Rancher's Istio will maintain a Helm chart that utilizes the istioctl binary to manage your Istio installation.
-
-This Helm chart will be available via the Apps and Marketplace in the UI. A user that has access to the Rancher Chart's catalog will need to set up Istio before it can be used in the project.
 
 # Tools Bundled with Istio
 
@@ -77,11 +69,7 @@ To remove Istio components from a cluster, namespace, or workload, refer to the 
 
 # Migrate From Previous Istio Version
 
-There is no upgrade path for Istio versions less than 1.7.x. To successfully install Istio in the **Cluster Explorer**, you will need to disable your existing Istio in the **Cluster Manager**.
-
-If you have a significant amount of additional Istio CRDs you might consider manually migrating CRDs that are supported in both versions of Istio. You can do this by running `kubectl get <resource> -n istio-system -o yaml`, save the output yaml and re-apply in the new version. 
-
-Another option is to manually uninstall istio resources one at a time, but leave the resources that are supported in both versions of Istio and that will not be installed by the newest version. This method is more likely to result in issues installing the new version, but could be a good option depending on your situation.
+For details on migrating from Istio v1 installed with the legacy Cluster Manager, see [this page.](./migrating)
 
 # Accessing Visualizations
 

--- a/content/rancher/v2.6/en/istio/migrating/_index.md
+++ b/content/rancher/v2.6/en/istio/migrating/_index.md
@@ -1,0 +1,27 @@
+---
+title: Migrating from Previous Istio Version
+weight: 7
+---
+
+- [New in Rancher v2.5](#new-in-rancher-v2-5)
+- [Migrating Istio](#migrating-istio)
+
+# New in Rancher v2.5
+
+The overall architecture of Istio has been simplified. A single component, Istiod, has been created by combining Pilot, Citadel, Galley and the sidecar injector. Node Agent functionality has also been merged into istio-agent.
+
+Addons that were previously installed by Istio (cert-manager, Grafana, Jaeger, Kiali, Prometheus, Zipkin) will now need to be installed separately. Istio will support installation of integrations that are from the Istio Project and will maintain compatibility with those that are not.
+
+A Prometheus integration will still be available through an installation of [Rancher Monitoring]({{<baseurl>}}/rancher/v2.6/en/monitoring-alerting/), or by installing your own Prometheus operator. Rancher's Istio chart will also install Kiali by default to ensure you can get a full picture of your microservices out of the box.
+
+Istio has migrated away from Helm as a way to install Istio and now provides installation through the istioctl binary or Istio Operator. To ensure the easiest interaction with Istio, Rancher's Istio will maintain a Helm chart that utilizes the istioctl binary to manage your Istio installation.
+
+This Helm chart will be available via the Apps and Marketplace in the UI. A user that has access to the Rancher Chart's catalog will need to set up Istio before it can be used in the project.
+
+# Migrating Istio
+
+There is no upgrade path for Istio versions less than 1.7.x. To successfully install Istio in the **Cluster Explorer**, you will need to disable your existing Istio in the **Cluster Manager**.
+
+If you have a significant amount of additional Istio CRDs you might consider manually migrating CRDs that are supported in both versions of Istio. You can do this by running `kubectl get <resource> -n istio-system -o yaml`, save the output yaml and re-apply in the new version. 
+
+Another option is to manually uninstall istio resources one at a time, but leave the resources that are supported in both versions of Istio and that will not be installed by the newest version. This method is more likely to result in issues installing the new version, but could be a good option depending on your situation.

--- a/content/rancher/v2.6/en/pipelines/_index.md
+++ b/content/rancher/v2.6/en/pipelines/_index.md
@@ -5,7 +5,7 @@ aliases:
   - /rancher/v2.6/en/k8s-in-rancher/pipelines  
 ---
 
-> As of Rancher v2.5, Git-based deployment pipelines are now recommended to be handled with Rancher Continuous Delivery powered by [Fleet,]({{<baseurl>}}/rancher/v2.6/en/deploy-across-clusters/fleet) available in Cluster Explorer. Pipelines will receive limited to no security updates, and should be used only if migrating to Fleet is not feasible.
+> As of Rancher v2.5, Git-based deployment pipelines are now recommended to be handled with Rancher Continuous Delivery powered by [Fleet,]({{<baseurl>}}/rancher/v2.6/en/deploy-across-clusters/fleet) available in Cluster Explorer. Pipelines will receive only critical CVE fixes. They should be used only if migrating to Fleet is not feasible.
 
 Rancher's pipeline provides a simple CI/CD experience. Use it to automatically checkout code, run builds or scripts, publish Docker images or catalog applications, and deploy the updated software to users.
 

--- a/content/rancher/v2.6/en/pipelines/_index.md
+++ b/content/rancher/v2.6/en/pipelines/_index.md
@@ -5,7 +5,7 @@ aliases:
   - /rancher/v2.6/en/k8s-in-rancher/pipelines  
 ---
 
-> As of Rancher v2.5, Git-based deployment pipelines are now recommended to be handled with Rancher Continuous Delivery powered by [Fleet,]({{<baseurl>}}/rancher/v2.6/en/deploy-across-clusters/fleet) available in Cluster Explorer.
+> As of Rancher v2.5, Git-based deployment pipelines are now recommended to be handled with Rancher Continuous Delivery powered by [Fleet,]({{<baseurl>}}/rancher/v2.6/en/deploy-across-clusters/fleet) available in Cluster Explorer. Pipelines will receive limited to no security updates, and should be used only if migrating to Fleet is not feasible.
 
 Rancher's pipeline provides a simple CI/CD experience. Use it to automatically checkout code, run builds or scripts, publish Docker images or catalog applications, and deploy the updated software to users.
 

--- a/content/rancher/v2.6/en/security/_index.md
+++ b/content/rancher/v2.6/en/security/_index.md
@@ -30,6 +30,7 @@ On this page, we provide security-related documentation along with resources to 
 - [The CIS Benchmark and self-assessment](#the-cis-benchmark-and-self-assessment)
 - [Third-party penetration test reports](#third-party-penetration-test-reports)
 - [Rancher CVEs and resolutions](#rancher-cves-and-resolutions)
+- [Rancher image vulnerability scanning](#rancher-image-vulnerability-scanning)
 
 ### Running a CIS Security Scan on a Kubernetes Cluster
 
@@ -83,3 +84,7 @@ Results:
 ### Rancher CVEs and Resolutions
 
 Rancher is committed to informing the community of security issues in our products. For the list of CVEs (Common Vulnerabilities and Exposures) for issues we have resolved, refer to [this page.](./cve)
+
+### Rancher Image Vulnerability Scanning
+
+Rancher shares security scan results for the images in a Rancher release. This information includes CVE (Common Vulnerabilities and Exposures) IDs, status, notes or remediation plans where available. For more information, see [this page.](./cve-scans)

--- a/content/rancher/v2.6/en/security/cve-scans/_index.md
+++ b/content/rancher/v2.6/en/security/cve-scans/_index.md
@@ -14,7 +14,9 @@ The CVE scanning process, introduced in Rancher v2.6, reduces the patching cycle
 
 # Scope
 
-The CVE scan includes all images shipped with Rancher releases, which are listed in the `images.txt` file included with every release. This list includes all core Rancher components and features.
+The CVE scan includes all images shipped with Rancher releases, which are listed in the `rancher-images.txt` file included with every release. This list includes all core Rancher components and features.
+
+The `rancher-images-sources.txt` file also includes the images, along with an annotation indicating what Rancher feature uses the image.
 
 # Scanning Tool
 

--- a/content/rancher/v2.6/en/security/cve-scans/_index.md
+++ b/content/rancher/v2.6/en/security/cve-scans/_index.md
@@ -22,7 +22,7 @@ Rancher images are scanned with [Trivy,](https://github.com/aquasecurity/trivy) 
 
 # Scan Results
 
-The CVE scan report lists any image containing a CVE that is ranked by our scanning tool with a rating of `high` or above.
+The CVE scan report lists any image containing a CVE that is ranked by our scanning tool with a rating of `HIGH` or above.
 
 The report is provided in CSV format with each Rancher release. It is also available on a publicly accessible web page. This web page is updated weekly.
 

--- a/content/rancher/v2.6/en/security/cve-scans/_index.md
+++ b/content/rancher/v2.6/en/security/cve-scans/_index.md
@@ -24,7 +24,7 @@ Rancher images are scanned with [Trivy,](https://github.com/aquasecurity/trivy) 
 
 The CVE scan report lists any image containing a CVE that is ranked by our scanning tool with a rating of `HIGH` or above.
 
-The report is provided in CSV format with each Rancher release. It is also available on a publicly accessible web page. This web page is updated weekly.
+The report is provided in CSV format with each Rancher release. It is also available on a publicly accessible web page. This web page is updated daily.
 
 For each image listed in the scan report, the following information is listed:
 

--- a/content/rancher/v2.6/en/security/cve-scans/_index.md
+++ b/content/rancher/v2.6/en/security/cve-scans/_index.md
@@ -1,0 +1,66 @@
+---
+title: Rancher Image Vulnerability Scanning
+weight: 5
+---
+
+Rancher shares security scan results for the images in a Rancher release. This information includes CVE (Common Vulnerabilities and Exposures) IDs, status, notes or remediation plans where available.
+
+The CVE scanning process, introduced in Rancher v2.6, reduces the patching cycle time of Rancher images.
+
+- [Scope](#scope)
+- [Scanning Tool](#scanning-tool)
+- [Reporting Scan Results](#reporting-scan-results)
+- [Addressing Vulnerabilities](#addressing-vulnerabilities)
+
+# Scope
+
+The CVE scan includes all images shipped with Rancher releases, which are listed in the `images.txt` file included with every release. This list includes all core Rancher components and features.
+
+# Scanning Tool
+
+Rancher images are scanned with [Trivy,](https://github.com/aquasecurity/trivy) tool from Aqua Security. Other image scanning tools may yield different results.
+
+# Scan Results
+
+The CVE scan report lists any image containing a CVE that is ranked by our scanning tool with a rating of `high` or above.
+
+The report is provided in CSV format with each Rancher release. It is also available on a publicly accessible web page. This web page is updated weekly.
+
+For each image listed in the scan report, the following information is listed:
+
+- Image name
+- CVE ID
+- Severity level
+- Package name
+- Status of patch
+  - For mirrored images, the current upstream state is used
+  - For Rancher images, the status in the Rancher pipeline is used
+
+# Addressing Vulnerabilities
+
+As new CVEs are reported, or new images with high-level CVEs are brought into the pipeline, the Rancher team is automatically alerted and triages each vulnerability.
+
+Rancher addresses vulnerabilities differently depending on whether the image is mirrored from a community project or maintained by Rancher.
+
+Some Rancher features will not receive security updates, or will receive limited ones. For details, see [this section](#features-with-limited-security-updates)
+
+### Images Mirrored from Community Projects
+
+If the upstream project has addressed and released a fix, the images are upgraded when possible in future Rancher releases.
+
+If the upstream project has not released a fix, an issue explaining the situation is created and tracked by Rancher's engineering team.
+
+### Images Maintained by Rancher
+
+CVEs for images maintained by Rancher fall into one of the following categories:
+
+- **False-positive:** We document these results and provide an explanation.
+- **Vulnerabilities that will not be fixed:** We document these results and provide an explanation.For example, we may decide not to fix vulnerabilities caused by an upstream project that is no longer maintained, or a vulnerability that has a low attack surface.
+- **Vulnerabilities that can be fixed:** These results include vulnerabilities in Rancher projects or upstream packages that need to be updated, and that are within our ability to fix. They are addressed an released in the same way as any other issue within Rancher.
+
+### Features with Limited Security Updates
+
+The following features will receive limited or no security updates:
+
+- Istio v1 (1.5.920) should no longer be used. We recommend using Istio v2. The images for Istio 1.5.920 should not be downloaded unless upgrading Istio is not feasible.
+- Pipelines were deprecated as of Rancher v2.5 and should no longer be used. We recommend handling Git-based deployment pipelines with  [Fleet.]({{<baseurl>}}/rancher/v2.6/en/deploy-across-clusters/fleet)

--- a/content/rancher/v2.6/en/security/cve-scans/_index.md
+++ b/content/rancher/v2.6/en/security/cve-scans/_index.md
@@ -14,7 +14,7 @@ The CVE scanning process, introduced in Rancher v2.6, reduces the patching cycle
 
 # Scope
 
-The CVE scan includes all images shipped with Rancher releases, which are listed in the `rancher-images.txt` file included with every release. This list includes all core Rancher components and features.
+The CVE scan includes all images shipped with Rancher releases, which are listed in the `rancher-images.txt` file included with every release. This list includes all core Rancher components and features. The published list of CVEs covers the latest development version of Rancher v2.6 and the catalog charts for the Rancher version.
 
 The `rancher-images-sources.txt` file also includes the images, along with an annotation indicating what Rancher feature uses the image.
 
@@ -22,7 +22,7 @@ The `rancher-images-sources.txt` file also includes the images, along with an an
 
 Rancher images are scanned with [Trivy,](https://github.com/aquasecurity/trivy) tool from Aqua Security. Other image scanning tools may yield different results.
 
-# Scan Results
+# Reporting Scan Results
 
 The CVE scan report lists any image containing a CVE that is ranked by our scanning tool with a rating of `HIGH` or above.
 
@@ -42,27 +42,13 @@ For each image listed in the scan report, the following information is listed:
 
 As new CVEs are reported, or new images with high or critical severity CVEs are brought into the pipeline, the Rancher team is automatically alerted and triages each vulnerability.
 
-Rancher addresses vulnerabilities differently depending on whether the image is mirrored from a community project or maintained by Rancher.
+Rancher addresses vulnerabilities differently depending on whether the image is mirrored from a community project or maintained by Rancher. Depending on the context and the situation, the vulnerabilities will either be fixed, or will be noted as false positives, or will be noted as not able to be fixed.
 
 Some Rancher features will not receive security updates, or will receive limited ones. For details, see [this section](#features-with-limited-security-updates)
-
-### Images Mirrored from Community Projects
-
-If the upstream project has addressed and released a fix, the images are upgraded when possible in future Rancher releases.
-
-If the upstream project has not released a fix, an issue explaining the situation is created and tracked by Rancher's engineering team.
-
-### Images Maintained by Rancher
-
-CVEs for images maintained by Rancher fall into one of the following categories:
-
-- **False-positive:** We document these results and provide an explanation.
-- **Vulnerabilities that will not be fixed:** We document these results and provide an explanation.For example, we may decide not to fix vulnerabilities caused by an upstream project that is no longer maintained, or a vulnerability that has a low attack surface.
-- **Vulnerabilities that can be fixed:** These results include vulnerabilities in Rancher projects or upstream packages that need to be updated, and that are within our ability to fix. They are addressed an released in the same way as any other issue within Rancher.
 
 ### Features with Limited Security Updates
 
 The following features will receive limited or no security updates:
 
 - Cluster Manager's Istio, which ended with upstream version 1.5, should no longer be used as it hit end-of-life on August 21 2020. We recommend using the newer versions of Istio from the Cluster Explorer. The images for Istio 1.5 should not be downloaded unless upgrading Istio is not feasible.
-- Pipelines were deprecated as of Rancher v2.5 and should no longer be used. We recommend handling Git-based deployment pipelines with  [Fleet.]({{<baseurl>}}/rancher/v2.6/en/deploy-across-clusters/fleet)
+- Pipelines were deprecated as of Rancher v2.5 and should no longer be used. The pipelines feature will receive only critical CVE fixes. We recommend handling Git-based deployment pipelines with  [Fleet.]({{<baseurl>}}/rancher/v2.6/en/deploy-across-clusters/fleet)

--- a/content/rancher/v2.6/en/security/cve-scans/_index.md
+++ b/content/rancher/v2.6/en/security/cve-scans/_index.md
@@ -38,7 +38,7 @@ For each image listed in the scan report, the following information is listed:
 
 # Addressing Vulnerabilities
 
-As new CVEs are reported, or new images with high-level CVEs are brought into the pipeline, the Rancher team is automatically alerted and triages each vulnerability.
+As new CVEs are reported, or new images with high or critical severity CVEs are brought into the pipeline, the Rancher team is automatically alerted and triages each vulnerability.
 
 Rancher addresses vulnerabilities differently depending on whether the image is mirrored from a community project or maintained by Rancher.
 

--- a/content/rancher/v2.6/en/security/cve-scans/_index.md
+++ b/content/rancher/v2.6/en/security/cve-scans/_index.md
@@ -64,5 +64,5 @@ CVEs for images maintained by Rancher fall into one of the following categories:
 
 The following features will receive limited or no security updates:
 
-- Istio v1 (1.5.920) should no longer be used. We recommend using Istio v2. The images for Istio 1.5.920 should not be downloaded unless upgrading Istio is not feasible.
+- Cluster Manager's Istio, which ended with upstream version 1.5, should no longer be used as it hit end-of-life on August 21 2020. We recommend using the newer versions of Istio from the Cluster Explorer. The images for Istio 1.5 should not be downloaded unless upgrading Istio is not feasible.
 - Pipelines were deprecated as of Rancher v2.5 and should no longer be used. We recommend handling Git-based deployment pipelines with  [Fleet.]({{<baseurl>}}/rancher/v2.6/en/deploy-across-clusters/fleet)


### PR DESCRIPTION
Includes information from https://support.rancher.com/hc/en-us/articles/360062517271#how-will-vulnerabilities-be-addressed--0-3

Ricky to provide link to CVE scan results page.

Caleb's blog post said the scan result page will be updated weekly. Is that still the plan?

https://github.com/rancher/docs/issues/3138
https://github.com/rancher/docs/issues/3354