### PR TITLE
Update k8s versions in firewalld note

### DIFF
--- a/content/rancher/v2.5/en/installation/requirements/_index.md
+++ b/content/rancher/v2.5/en/installation/requirements/_index.md
@@ -42,7 +42,7 @@ All supported operating systems are 64-bit x86.
 
 The `ntp` (Network Time Protocol) package should be installed. This prevents errors with certificate validation that can occur when the time is not synchronized between the client and server.
 
-Some distributions of Linux may have default firewall rules that block communication with Helm. We recommend disabling firewalld. For Kubernetes 1.19, firewalld must be turned off.
+Some distributions of Linux may have default firewall rules that block communication with Helm. We recommend disabling firewalld. For Kubernetes 1.19 and 1.20, firewalld must be turned off.
 
 If you plan to run Rancher on ARM64, see [Running on ARM64 (Experimental).]({{<baseurl>}}/rancher/v2.5/en/installation/options/arm64-platform/)
 


### PR DESCRIPTION
Update firewalld should be disabled note to include k8s v1.20 (https://github.com/rancher/rancher/issues/28840)
