### PR TITLE
remove single quotes from 'EOF' here doc delimiter

### DIFF
--- a/content/rancher/v2.5/en/installation/other-installation-methods/behind-proxy/launch-kubernetes/_index.md
+++ b/content/rancher/v2.5/en/installation/other-installation-methods/behind-proxy/launch-kubernetes/_index.md
@@ -21,7 +21,7 @@ export NO_PROXY=127.0.0.0/8,10.0.0.0/8,cattle-system.svc,172.16.0.0/12,192.168.0
 Next configure apt to use this proxy when installing packages. If you are not using Ubuntu, you have to adapt this step accordingly:
 
 ```
-cat <<'EOF' | sudo tee /etc/apt/apt.conf.d/proxy.conf > /dev/null
+cat <<EOF | sudo tee /etc/apt/apt.conf.d/proxy.conf > /dev/null
 Acquire::http::Proxy "http://${proxy_host}/";
 Acquire::https::Proxy "http://${proxy_host}/";
 EOF

--- a/content/rancher/v2.5/en/installation/other-installation-methods/behind-proxy/launch-kubernetes/_index.md
+++ b/content/rancher/v2.5/en/installation/other-installation-methods/behind-proxy/launch-kubernetes/_index.md
@@ -43,7 +43,7 @@ And configure the Docker daemon to use the proxy to pull images:
 
 ```
 sudo mkdir -p /etc/systemd/system/docker.service.d
-cat <<'EOF' | sudo tee /etc/systemd/system/docker.service.d/http-proxy.conf > /dev/null
+cat <<EOF | sudo tee /etc/systemd/system/docker.service.d/http-proxy.conf > /dev/null
 [Service]
 Environment="HTTP_PROXY=http://${proxy_host}"
 Environment="HTTPS_PROXY=http://${proxy_host}"


### PR DESCRIPTION
Removing single quotes from EOF here doc delimiter for command creating docker.service.d/http-proxy.conf.  With the quotes present, the variable ${proxy_host} is not substituted.

When contributing to docs, please don't update the content in the v2.x folder.
It's better to update the versioned docs, for example, the v2.5 or v2.6 docs.

This content in v2.x was separated into versioned documentation during the v2.5.8
release. The content relevant to Rancher versions before v2.5 went into the v2.0-v2.4
folder, while the content related to Rancher v2.5 went into the v2.5 folder.

We are trying to get the 2.x content to be removed from Google search results. The only
reason we haven't deleted it is because Google search results would lead to 404
errors if we deleted it.
