### PR TITLE
Add network policy for traefik ingress

### DIFF
--- a/content/k3s/latest/en/security/hardening_guide/_index.md
+++ b/content/k3s/latest/en/security/hardening_guide/_index.md
@@ -302,7 +302,7 @@ spec:
   - Ingress
 ```
 
-If you are using the default traefik ingress controller with k3s, it will also be blocked by default, so the following network policies must be added to allow traffic to both traefik pods and svclb pods in the traefik namespace:
+If you are using the default traefik ingress controller with k3s, it will also be blocked by default, so the following network policy must be added to allow traffic to both traefik pods and svclb pods in the kube-system namespace:
 
 ```yaml
 apiVersion: networking.k8s.io/v1

--- a/content/k3s/latest/en/security/hardening_guide/_index.md
+++ b/content/k3s/latest/en/security/hardening_guide/_index.md
@@ -302,6 +302,28 @@ spec:
   - Ingress
 ```
 
+If you are using the default traefik ingress controller with k3s, it will also be blocked by default, so the following network policies must be added to allow traffic to both traefik pods and svclb pods in the traefik namespace:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-network-traefik-policy
+  namespace: kube-system
+spec:
+  ingress:
+  - ports:
+    - port: 80
+      protocol: TCP
+    - port: 443
+      protocol: TCP
+  podSelector:
+    matchExpressions:
+    - {key: app, operator: In, values: [traefik,svclb-traefik]}
+  policyTypes:
+  - Ingress
+```
+
 > **Note:** Operators must manage network policies as normal for additional namespaces that are created.
 
 ## Known Issues


### PR DESCRIPTION
Adding network policy in the hardening guide for both traefik and traefik-svclb to allow ingress traefik in hardened k3s

https://github.com/k3s-io/k3s/issues/3583