### PR TITLE
Include helm --force upgrade note

### DIFF
--- a/content/rancher/v2.6/en/helm-charts/_index.md
+++ b/content/rancher/v2.6/en/helm-charts/_index.md
@@ -12,9 +12,9 @@ In this section, you'll learn how to manage Helm chart repositories and applicat
 
 ### Charts
 
-From the top-left menu select _"Apps & Marketplace"_ and you will be taken to the Charts page. 
+From the top-left menu select _"Apps & Marketplace"_ and you will be taken to the Charts page.
 
-The charts page contains all Rancher, Partner, and Custom Charts. 
+The charts page contains all Rancher, Partner, and Custom Charts.
 
 * Rancher tools such as Logging or Monitoring are included under the Rancher label
 * Partner charts reside under the Partners label
@@ -26,22 +26,24 @@ All three types are deployed and managed in the same way.
 
 ### Repositories
 
-From the left sidebar select _"Repositories"_. 
+From the left sidebar select _"Repositories"_.
 
 These items represent helm repositories, and can be either traditional helm endpoints which have an index.yaml, or git repositories which will be cloned and can point to a specific branch. In order to use custom charts, simply add your repository here and they will become available in the Charts tab under the name of the repository.
 
 
 ### Helm Compatibility
 
-The Cluster Explorer only supports Helm 3 compatible charts. 
+The Cluster Explorer only supports Helm 3 compatible charts.
 
 
 ### Deployment and Upgrades
 
-From the _"Charts"_ tab select a Chart to install. Rancher and Partner charts may have extra configurations available through custom pages or questions.yaml files, but all chart installations can modify the values.yaml and other basic settings. Once you click install, a Helm operation job is deployed, and the console for the job is displayed. 
+From the _"Charts"_ tab select a Chart to install. Rancher and Partner charts may have extra configurations available through custom pages or questions.yaml files, but all chart installations can modify the values.yaml and other basic settings. Once you click install, a Helm operation job is deployed, and the console for the job is displayed.
 
 To view all recent changes, go to the _"Recent Operations"_ tab. From there you can view the call that was made, conditions, events, and logs.
 
 After installing a chart, you can find it in the _"Installed Apps"_ tab. In this section you can upgrade or delete the installation, and see further details. When choosing to upgrade, the form and values presented will be the same as installation.
 
-Most Rancher tools have additional pages located in the toolbar below the _"Apps & Marketplace"_ section to help manage and use the features. These pages include links to dashboards, forms to easily add Custom Resources, and additional information. 
+Most Rancher tools have additional pages located in the toolbar below the _"Apps & Marketplace"_ section to help manage and use the features. These pages include links to dashboards, forms to easily add Custom Resources, and additional information.
+
+> If you are upgrading your chart using _"Customize Helm options before upgrade"_ , please be aware the using the _"--force"_ option may result in errors if your chart has immutable fields. This is because some objects in kubernetes cannot be changed once they are created.


### PR DESCRIPTION
**Issues**
https://github.com/rancher/rancher/issues/33372
https://github.com/rancher/rancher/issues/33409

**Upstream related issues for more context**
https://github.com/helm/helm/issues/7082
https://github.com/helm/helm/issues/7173

**Problem**
When using the `--force` option on a helm install, the helm 3 way merge is bypassed and the kubernetes PUT api is utilized to roll out the changes. This means that fields determined immutable by kubernetes will throw an error because the PUT command is attempting to overwrite or "change" those values. 

Our chart upgrades do not use `--force` by default, it shows up if you use the "Customize helm options before upgrade" checkbox on a charts install page.

**Solution**
This has technically been accepted by a bug by upstream kubernetes, it appears that many in the community find its working expected which is why adding a note in the documentation seems like the best fit for our users at this time. 