### PR TITLE
Added missing parenthesis

### DIFF
--- a/content/rancher/v2.x/en/admin-settings/pod-security-policies/_index.md
+++ b/content/rancher/v2.x/en/admin-settings/pod-security-policies/_index.md
@@ -45,7 +45,7 @@ Rancher ships with two default Pod Security Policies (PSPs): the `restricted` an
 This policy is based on the Kubernetes [example restricted policy](https://raw.githubusercontent.com/kubernetes/website/master/content/en/examples/policy/restricted-psp.yaml). It significantly restricts what types of pods can be deployed to a cluster or project. This policy:
 
 - Prevents pods from running as a privileged user and prevents escalation of privileges.
-- Validates that server-required security mechanisms are in place (such as restricting what volumes can be mounted to only the core volume types and preventing root supplemental groups from being added.
+- Validates that server-required security mechanisms are in place (such as restricting what volumes can be mounted to only the core volume types and preventing root supplemental groups from being added).
 
 ### Unrestricted
 


### PR DESCRIPTION
When contributing to docs, please don't update the content in the v2.x folder.
It's better to update the versioned docs, for example, the v2.5 or v2.6 docs.

This content in v2.x was separated into versioned documentation during the v2.5.8
release. The content relevant to Rancher versions before v2.5 went into the v2.0-v2.4
folder, while the content related to Rancher v2.5 went into the v2.5 folder.

We are trying to get the 2.x content to be removed from Google search results. The only
reason we haven't deleted it is because Google search results would lead to 404
errors if we deleted it.
