### PR TITLE
Update version labels

### DIFF
--- a/content/rancher/v2.5/_index.md
+++ b/content/rancher/v2.5/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Rancher 2.5.7-2.5.8+ (Latest)
+title: Rancher 2.5.7-2.5.9 (Latest)
 weight: 1
 showBreadcrumb: false
 ---

--- a/content/rancher/v2.5/en/_index.md
+++ b/content/rancher/v2.5/en/_index.md
@@ -1,8 +1,8 @@
 ---
-title: "Rancher 2.5.7-2.5.8+ (Latest)"
-shortTitle: "Rancher 2.5.7-2.5.8+  (Latest)"
+title: "Rancher 2.5.7-2.5.9 (Latest)"
+shortTitle: "Rancher 2.5.7-2.5.9  (Latest)"
 description: "Rancher adds significant value on top of Kubernetes: managing hundreds of clusters from one interface, centralizing RBAC, enabling monitoring and alerting. Read more."
-metaTitle: "Rancher 2.x Docs: What is New?"
+metaTitle: "Rancher 2.5.7-2.5.9 Docs: What is New?"
 metaDescription: "Rancher 2 adds significant value on top of Kubernetes: managing hundreds of clusters from one interface, centralizing RBAC, enabling monitoring and alerting. Read more."
 insertOneSix: false
 weight: 1

--- a/content/rancher/v2.5/en/cluster-admin/editing-clusters/gke-config-reference/_index.md
+++ b/content/rancher/v2.5/en/cluster-admin/editing-clusters/gke-config-reference/_index.md
@@ -5,7 +5,7 @@ weight: 3
 ---
 
 {{% tabs %}}
-{{% tab "v2.5.8" %}}
+{{% tab "Rancher v2.5.8+" %}}
 
 # Changes in v2.5.8
 

--- a/content/rancher/v2.5/en/cluster-provisioning/cluster-capabilities-table/index.md
+++ b/content/rancher/v2.5/en/cluster-provisioning/cluster-capabilities-table/index.md
@@ -3,7 +3,7 @@ headless: true
 ---
 
 {{% tabs %}}
-{{% tab "Rancher v2.5.8" %}}
+{{% tab "Rancher v2.5.8+" %}}
 
 | Action | Rancher Launched Kubernetes Clusters |  EKS and GKE Clusters* | Other Hosted Kubernetes Clusters | Non-EKS or GKE Registered Clusters |
 | --- | --- | ---| ---|----|
@@ -30,7 +30,7 @@ headless: true
 \* \* \* For registered cluster nodes, the Rancher UI exposes the ability to cordon drain, and edit the node.
 
 {{% /tab %}}
-{{% tab "Rancher v2.5.0-v2.5.7" %}}
+{{% tab "Rancher before v2.5.8" %}}
 
 | Action | Rancher Launched Kubernetes Clusters | Hosted Kubernetes Clusters | Registered EKS Clusters | All Other Registered Clusters |
 | --- | --- | ---| ---|----|

--- a/content/rancher/v2.5/en/cluster-provisioning/registered-clusters/_index.md
+++ b/content/rancher/v2.5/en/cluster-provisioning/registered-clusters/_index.md
@@ -125,7 +125,7 @@ The capabilities for registered clusters are listed in the table on [this page.]
 
 
 {{% /tab %}}
-{{% tab "Rancher v2.5.0-v2.5.8" %}}
+{{% tab "Rancher before v2.5.8" %}}
 
 - [Features for All Registered Clusters](#before-2-5-8-features-for-all-registered-clusters)
 - [Additional Features for Registered K3s Clusters](#before-2-5-8-additional-features-for-registered-k3s-clusters)

--- a/content/rancher/v2.5/en/installation/other-installation-methods/air-gap/install-rancher/_index.md
+++ b/content/rancher/v2.5/en/installation/other-installation-methods/air-gap/install-rancher/_index.md
@@ -137,7 +137,7 @@ Placeholder | Description
 `<CERTMANAGER_VERSION>` | Cert-manager version running on k8s cluster.
 
 {{% tabs %}}
-{{% tab "Rancher v2.5.8" %}}
+{{% tab "Rancher v2.5.8+" %}}
 ```plain
 helm template rancher ./rancher-<VERSION>.tgz --output-dir . \
     --no-hooks \ # prevent files for Helm hooks from being generated

--- a/content/rancher/v2.5/en/installation/resources/feature-flags/_index.md
+++ b/content/rancher/v2.5/en/installation/resources/feature-flags/_index.md
@@ -77,7 +77,7 @@ Here is an example of a command for passing in the feature flag names when rende
 The Helm 3 command is as follows:
 
 {{% tabs %}}
-{{% tab "Rancher v2.5.8" %}}
+{{% tab "Rancher v2.5.8+" %}}
 
 ```
 helm template rancher ./rancher-<VERSION>.tgz --output-dir . \

--- a/content/rancher/v2.5/en/logging/_index.md
+++ b/content/rancher/v2.5/en/logging/_index.md
@@ -79,13 +79,13 @@ For a list of options that can be configured when the logging application is ins
 ### Windows Support
 
 {{% tabs %}}
-{{% tab "Rancher v2.5.8" %}}
+{{% tab "Rancher v2.5.8+" %}}
 As of Rancher v2.5.8, logging support for Windows clusters has been added and logs can be collected from Windows nodes.
 
 For details on how to enable or disable Windows node logging, see [this section.](./helm-chart-options/#enable-disable-windows-node-logging)
 
 {{% /tab %}}
-{{% tab "Rancher v2.5.0-2.5.7" %}}
+{{% tab "Rancher before v2.5.8" %}}
 Clusters with Windows workers support exporting logs from Linux nodes, but Windows node logs are currently unable to be exported.
 Only Linux node logs are able to be exported.
 

--- a/content/rancher/v2.5/en/logging/custom-resource-config/flows/_index.md
+++ b/content/rancher/v2.5/en/logging/custom-resource-config/flows/_index.md
@@ -74,7 +74,7 @@ Matches, filters and `Outputs` are configured for `ClusterFlows` in the same way
 After `ClusterFlow` selects logs from all namespaces in the cluster, logs from the cluster will be collected and logged to the selected `ClusterOutput`.
 
 {{% /tab %}}
-{{% tab "Rancher v2.5.0-v2.5.7" %}}
+{{% tab "Rancher before v2.5.8" %}}
 
 - [Flows](#flows-2-5-0)
   - [Matches](#matches-2-5-0)

--- a/content/rancher/v2.5/en/logging/custom-resource-config/outputs/_index.md
+++ b/content/rancher/v2.5/en/logging/custom-resource-config/outputs/_index.md
@@ -69,7 +69,7 @@ For example configuration for each logging plugin supported by the logging opera
 For the details of the `ClusterOutput` custom resource, see [ClusterOutput.](https://banzaicloud.com/docs/one-eye/logging-operator/configuration/crds/v1beta1/clusteroutput_types/)
 
 {{% /tab %}}
-{{% tab "v2.5.0-v2.5.7" %}}
+{{% tab "Rancher before v2.5.8" %}}
 
 
 - [Outputs](#outputs-2-5-0)

--- a/content/rancher/v2.5/en/logging/taints-tolerations/_index.md
+++ b/content/rancher/v2.5/en/logging/taints-tolerations/_index.md
@@ -20,13 +20,13 @@ Both provide choice for the what node(s) the pod will run on.
 ### Default Implementation in Rancher's Logging Stack
 
 {{% tabs %}}
-{{% tab "Rancher v2.5.8" %}}
+{{% tab "Rancher v2.5.8+" %}}
 By default, Rancher taints all Linux nodes with `cattle.io/os=linux`, and does not taint Windows nodes.
 The logging stack pods have `tolerations` for this taint, which enables them to run on Linux nodes.
 Moreover, most logging stack pods run on Linux only and have a `nodeSelector` added to ensure they run on Linux nodes.
 
 {{% /tab %}}
-{{% tab "Rancher v2.5.0-2.5.7" %}}
+{{% tab "Rancher before v2.5.8" %}}
 By default, Rancher taints all Linux nodes with `cattle.io/os=linux`, and does not taint Windows nodes.
 The logging stack pods have `tolerations` for this taint, which enables them to run on Linux nodes.
 Moreover, we can populate the `nodeSelector` to ensure that our pods *only* run on Linux nodes.

--- a/content/rancher/v2.5/en/monitoring-alerting/_index.md
+++ b/content/rancher/v2.5/en/monitoring-alerting/_index.md
@@ -63,7 +63,7 @@ As an [administrator]({{<baseurl>}}/rancher/v2.5/en/admin-settings/rbac/global-p
 > - When installing monitoring on an RKE cluster using RancherOS or Flatcar Linux nodes, change the etcd node certificate directory to `/opt/rke/etc/kubernetes/ssl`.
 
 {{% tabs %}}
-{{% tab "Rancher v2.5.8" %}}
+{{% tab "Rancher v2.5.8+" %}}
 
 ### Enable Monitoring for use without SSL
 
@@ -101,7 +101,7 @@ key.pfx=`base64-content`
 Then **Cert File Path** would be set to `/etc/alertmanager/secrets/cert.pem`.
 
 {{% /tab %}}
-{{% tab "Rancher v2.5.0-2.5.7" %}}
+{{% tab "Rancher before v2.5.8" %}}
 
 1. In the Rancher UI, go to the cluster where you want to install monitoring and click **Cluster Explorer.**
 1. Click **Apps.**

--- a/content/rancher/v2.5/en/monitoring-alerting/configuration/alertmanager/_index.md
+++ b/content/rancher/v2.5/en/monitoring-alerting/configuration/alertmanager/_index.md
@@ -91,7 +91,7 @@ Rancher v2.5.8 added Microsoft Teams and SMS as configurable receivers in the Ra
 Rancher v2.5.4 introduced the capability to configure receivers by filling out forms in the Rancher UI.
 
 {{% tabs %}}
-{{% tab "Rancher v2.5.8" %}}
+{{% tab "Rancher v2.5.8+" %}}
 
 The following types of receivers can be configured in the Rancher UI:
 

--- a/content/rancher/v2.5/en/monitoring-alerting/persist-grafana/_index.md
+++ b/content/rancher/v2.5/en/monitoring-alerting/persist-grafana/_index.md
@@ -84,7 +84,7 @@ grafana.sidecar.dashboards.searchNamespace=ALL
 Note that the RBAC roles exposed by the Monitoring chart to add Grafana Dashboards are still restricted to giving permissions for users to add dashboards in the namespace defined in `grafana.dashboards.namespace`, which defaults to `cattle-dashboards`.
 
 {{% /tab %}}
-{{% tab "Rancher v2.5.0-v2.5.8" %}}
+{{% tab "Rancher before v2.5.8" %}}
 > **Prerequisites:**
 > 
 > - The monitoring application needs to be installed.


### PR DESCRIPTION
Updates some tabs from "Rancher v2.5.8" to "Rancher v2.5.8+" to account for 2.5.9.

Also changed some labels, e.g. "Rancher v2.5.0-v2.5.7", to "Rancher before v2.5.8" since those specific ranges no longer make sense after the headings for the versioned docs were updated.
