### PR TITLE
Fix wrong deployment name of cattle-cluster-agent

### DIFF
--- a/content/rancher/v2.5/en/installation/resources/update-ca-cert/_index.md
+++ b/content/rancher/v2.5/en/installation/resources/update-ca-cert/_index.md
@@ -132,7 +132,7 @@ Using a Kubeconfig for each downstream cluster update the environment variable f
 
 ```
 $ kubectl edit -n cattle-system ds/cattle-node-agent
-$ kubectl edit -n cattle-system deployment/cluster-agent
+$ kubectl edit -n cattle-system deployment/cattle-cluster-agent
 ```
 
 ### Method 3: Recreate Rancher agents


### PR DESCRIPTION
In a v2.5.8 rancher environment. 
> kubectl get deployment -n cattle-system
NAME                   READY   UP-TO-DATE   AVAILABLE   AGE
cattle-cluster-agent   1/1     1            1           36h

The deploy name is wrong in the following URL.
https://rancher.com/docs/rancher/v2.5/en/installation/resources/update-ca-cert/#method-2-manually-update-checksum

When contributing to docs, please don't update the content in the v2.x folder.
It's better to update the versioned docs, for example, the v2.5 or v2.6 docs.

This content in v2.x was separated into versioned documentation during the v2.5.8
release. The content relevant to Rancher versions before v2.5 went into the v2.0-v2.4
folder, while the content related to Rancher v2.5 went into the v2.5 folder.

We are trying to get the 2.x content to be removed from Google search results. The only
reason we haven't deleted it is because Google search results would lead to 404
errors if we deleted it.
