### PR TITLE
Apply PR #3416 to 2.6: update cluster capabilities table descriptions

### DIFF
--- a/content/rancher/v2.6/en/cluster-provisioning/cluster-capabilities-table/index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/cluster-capabilities-table/index.md
@@ -3,26 +3,27 @@ headless: true
 ---
 
 
-| Action | Rancher Launched Kubernetes Clusters |  EKS, GKE and AKS Clusters* | Other Hosted Kubernetes Clusters | Non-EKS or GKE Registered Clusters |
+| Action | Rancher Launched Kubernetes Clusters |  EKS, GKE and AKS Clusters<sup>1</sup> | Other Hosted Kubernetes Clusters | Non-EKS or GKE Registered Clusters |
 | --- | --- | ---| ---|----|
 | [Using kubectl and a kubeconfig file to Access a Cluster]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/cluster-access/kubectl/) | ✓ | ✓ | ✓ | ✓ |
 | [Managing Cluster Members]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/cluster-access/cluster-members/) | ✓ | ✓ | ✓ | ✓ |
-| [Editing and Upgrading Clusters]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/editing-clusters/) | ✓ | ✓ | ✓ | ** |
-| [Managing Nodes]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/nodes) | ✓ | ✓ | ✓ | ✓ *** |
+| [Editing and Upgrading Clusters]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/editing-clusters/) | ✓ | ✓ | ✓ | ✓<sup>2</sup> |
+| [Managing Nodes]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/nodes) | ✓ | ✓ | ✓ | ✓<sup>3</sup> |
 | [Managing Persistent Volumes and Storage Classes]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/volumes-and-storage/) | ✓ | ✓ | ✓ | ✓ |
 | [Managing Projects, Namespaces and Workloads]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/projects-and-namespaces/) | ✓ | ✓ | ✓ | ✓ |
 | [Using App Catalogs]({{<baseurl>}}/rancher/v2.6/en/catalog/) | ✓ | ✓ | ✓ | ✓ |
 | [Configuring Tools (Alerts, Notifiers, Logging, Monitoring, Istio)]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/tools/) | ✓ | ✓ | ✓ | ✓ |
 | [Running Security Scans]({{<baseurl>}}/rancher/v2.6/en/security/security-scan/) | ✓ | ✓ | ✓ | ✓ |
-| [Cloning Clusters]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/cloning-clusters/)| ✓ | ✓ |✓ | |
+| [Use existing configuration to create additional clusters]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/cloning-clusters/)| ✓ | ✓ | ✓ | |
 | [Ability to rotate certificates]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/certificate-rotation/) | ✓ | ✓  |  | |
-| [Ability to back up your Kubernetes Clusters]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/backing-up-etcd/) | ✓ | ✓ |  | |
-| [Ability to recover and restore etcd]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/restoring-etcd/) | ✓ |  ✓ |  | |
+| [Ability to [backup]({{<baseurl>}}/rancher/v2.5/en/cluster-admin/backing-up-etcd/) and [restore]({{<baseurl>}}/rancher/v2.5/en/cluster-admin/restoring-etcd/) Rancher-launched clusters | ✓ | ✓ |  | ✓<sup>4</sup> |
 | [Cleaning Kubernetes components when clusters are no longer reachable from Rancher]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/cleaning-cluster-nodes/) | ✓ | | | |
 | [Configuring Pod Security Policies]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/pod-security-policy/) | ✓ | ✓ |  ||
 
-\* Registered GKE, EKS and AKS clusters have the same options available as GKE, EKS and AKS clusters created from the Rancher UI. The key difference is that when a registered cluster is deleted from the Rancher UI, [it is not destroyed.]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/registered-clusters/#additional-features-for-registered-eks-and-gke-clusters)
+1. Registered GKE and EKS clusters have the same options available as GKE and EKS clusters created from the Rancher UI. The  difference is that when a registered cluster is deleted from the Rancher UI, [it is not destroyed.]({{<baseurl>}}/rancher/v2.5/en/cluster-provisioning/registered-clusters/#additional-features-for-registered-eks-and-gke-clusters)
 
-\* \* Cluster configuration options can't be edited for imported clusters, except for [K3s and RKE2 clusters.]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/imported-clusters/)
+2. Cluster configuration options can't be edited for registered clusters, except for [K3s and RKE2 clusters.]({{<baseurl>}}/rancher/v2.5/en/cluster-provisioning/imported-clusters/)
 
-\* \* \* For registered cluster nodes, the Rancher UI exposes the ability to cordon drain, and edit the node.
+3. For registered cluster nodes, the Rancher UI exposes the ability to cordon, drain, and edit the node.
+
+4. For registered clusters using etcd as a control plane, snapshots must be taken manually outside of the Rancher UI to use for backup and recovery.


### PR DESCRIPTION
When contributing to docs, please don't update the content in the v2.x folder.
It's better to update the versioned docs, for example, the v2.5 or v2.6 docs.

This content in v2.x was separated into versioned documentation during the v2.5.8
release. The content relevant to Rancher versions before v2.5 went into the v2.0-v2.4
folder, while the content related to Rancher v2.5 went into the v2.5 folder.

We are trying to get the 2.x content to be removed from Google search results. The only
reason we haven't deleted it is because Google search results would lead to 404
errors if we deleted it.
