### PR TITLE
Should dissable IPv6

### DIFF
--- a/content/rancher/v2.5/en/cluster-provisioning/node-requirements/_index.md
+++ b/content/rancher/v2.5/en/cluster-provisioning/node-requirements/_index.md
@@ -102,6 +102,8 @@ For hardware recommendations for etcd clusters in production, refer to the offic
 
 For a production cluster, we recommend that you restrict traffic by opening only the ports defined in the port requirements below.
 
+IPv6 should be dissabled at the OS level.  Unless you specifically intend to utilize IPv6, you should dissable it on you rnodes.  IPv6 is not yet fully supported and often times it is not enough to dissable ipv6 on the NICs to avoid complications.
+
 The ports required to be open are different depending on how the user cluster is launched. Each of the sections below list the ports that need to be opened for different [cluster creation options]({{<baseurl>}}/rancher/v2.5/en/cluster-provisioning/).
 
 For a breakdown of the port requirements for etcd nodes, controlplane nodes, and worker nodes in a Kubernetes cluster, refer to the [port requirements for the Rancher Kubernetes Engine.]({{<baseurl>}}/rke/latest/en/os/#ports)

--- a/content/rancher/v2.5/en/cluster-provisioning/node-requirements/_index.md
+++ b/content/rancher/v2.5/en/cluster-provisioning/node-requirements/_index.md
@@ -102,7 +102,7 @@ For hardware recommendations for etcd clusters in production, refer to the offic
 
 For a production cluster, we recommend that you restrict traffic by opening only the ports defined in the port requirements below.
 
-IPv6 should be dissabled at the OS level.  Unless you specifically intend to utilize IPv6, you should dissable it on you rnodes.  IPv6 is not yet fully supported and often times it is not enough to dissable ipv6 on the NICs to avoid complications.
+IPv6 should be disabled at the OS level. Unless you specifically intend to utilize IPv6, you should disable it on your nodes.  IPv6 is not yet fully supported and often times it is not enough to disable iPv6 on the NICs to avoid complications.
 
 The ports required to be open are different depending on how the user cluster is launched. Each of the sections below list the ports that need to be opened for different [cluster creation options]({{<baseurl>}}/rancher/v2.5/en/cluster-provisioning/).
 

--- a/content/rancher/v2.5/en/cluster-provisioning/node-requirements/_index.md
+++ b/content/rancher/v2.5/en/cluster-provisioning/node-requirements/_index.md
@@ -102,7 +102,7 @@ For hardware recommendations for etcd clusters in production, refer to the offic
 
 For a production cluster, we recommend that you restrict traffic by opening only the ports defined in the port requirements below.
 
-IPv6 should be disabled at the OS level. Unless you specifically intend to utilize IPv6, you should disable it on your nodes.  IPv6 is not yet fully supported and often times it is not enough to disable iPv6 on the NICs to avoid complications.
+IPv6 should be disabled at the OS level. Unless you specifically intend to utilize IPv6, you should disable it on your nodes.  IPv6 is not yet fully supported and often times it is not enough to disable IPv6 on the NICs to avoid complications.
 
 The ports required to be open are different depending on how the user cluster is launched. Each of the sections below list the ports that need to be opened for different [cluster creation options]({{<baseurl>}}/rancher/v2.5/en/cluster-provisioning/).
 


### PR DESCRIPTION
When contributing to docs, please don't update the content in the v2.x folder.
It's better to update the versioned docs, for example, the v2.5 or v2.6 docs.

This content in v2.x was separated into versioned documentation during the v2.5.8
release. The content relevant to Rancher versions before v2.5 went into the v2.0-v2.4
folder, while the content related to Rancher v2.5 went into the v2.5 folder.

We are trying to get the 2.x content to be removed from Google search results. The only
reason we haven't deleted it is because Google search results would lead to 404
errors if we deleted it.
