### PR TITLE
[fix] logging docu: splunk config and indentation of example code

### DIFF
--- a/content/rancher/v2.5/en/logging/custom-resource-config/outputs/_index.md
+++ b/content/rancher/v2.5/en/logging/custom-resource-config/outputs/_index.md
@@ -122,13 +122,13 @@ Let's say you wanted to send all logs in your cluster to an `elasticsearch` clus
 apiVersion: logging.banzaicloud.io/v1beta1
 kind: ClusterOutput
 metadata:
-    name: "example-es"
-    namespace: "cattle-logging-system"
+  name: "example-es"
+  namespace: "cattle-logging-system"
 spec:
-    elasticsearch:
-      host: elasticsearch.example.com
-      port: 9200
-      scheme: http
+  elasticsearch:
+    host: elasticsearch.example.com
+    port: 9200
+    scheme: http
 ```
 
 We have created this `ClusterOutput`, without elasticsearch configuration, in the same namespace as our operator: `cattle-logging-system.`. Any time we create a `ClusterFlow` or `ClusterOutput`, we have to put it in the `cattle-logging-system` namespace.
@@ -139,8 +139,8 @@ Now that we have configured where we want the logs to go, let's configure all lo
 apiVersion: logging.banzaicloud.io/v1beta1
 kind: ClusterFlow
 metadata:
-    name: "all-logs"
-    namespace: "cattle-logging-system"
+  name: "all-logs"
+  namespace: "cattle-logging-system"
 spec:
   globalOutputRefs:
     - "example-es"
@@ -189,13 +189,13 @@ With `coolapp` running, we will follow a similar path as when we created a `Clus
 apiVersion: logging.banzaicloud.io/v1beta1
 kind: Output
 metadata:
-    name: "devteam-splunk"
-    namespace: "devteam"
+  name: "devteam-splunk"
+  namespace: "devteam"
 spec:
-    SplunkHec:
-        host: splunk.example.com
-        port: 8088
-        protocol: http
+  splunkHec:
+    hec_host: splunk.example.com
+    hec_port: 8088
+    protocol: http
 ```
 
 Once again, let's feed our `Output` some logs:
@@ -204,8 +204,8 @@ Once again, let's feed our `Output` some logs:
 apiVersion: logging.banzaicloud.io/v1beta1
 kind: Flow
 metadata:
-    name: "devteam-logs"
-    namespace: "devteam"
+  name: "devteam-logs"
+  namespace: "devteam"
 spec:
   localOutputRefs:
     - "devteam-splunk"
@@ -218,37 +218,37 @@ Let's say you wanted to send all logs in your cluster to an `syslog` server. Fir
 
 ```yaml
 apiVersion: logging.banzaicloud.io/v1beta1
-    kind: ClusterOutput
-    metadata:
-      name: "example-syslog"
-      namespace: "cattle-logging-system"
-    spec:
-      syslog:
-        buffer:
-          timekey: 30s
-          timekey_use_utc: true
-          timekey_wait: 10s
-          flush_interval: 5s
-        format:
-          type: json
-          app_name_field: test
-        host: syslog.example.com
-        insecure: true
-        port: 514
-        transport: tcp
+kind: ClusterOutput
+metadata:
+  name: "example-syslog"
+  namespace: "cattle-logging-system"
+spec:
+  syslog:
+    buffer:
+      timekey: 30s
+      timekey_use_utc: true
+      timekey_wait: 10s
+      flush_interval: 5s
+    format:
+      type: json
+      app_name_field: test
+    host: syslog.example.com
+    insecure: true
+    port: 514
+    transport: tcp
 ```
 
 Now that we have configured where we want the logs to go, let's configure all logs to go to that `Output`.
 
 ```yaml
 apiVersion: logging.banzaicloud.io/v1beta1
-    kind: ClusterFlow
-    metadata:
-      name: "all-logs"
-      namespace: cattle-logging-system
-    spec:
-      globalOutputRefs:
-        - "example-syslog"
+kind: ClusterFlow
+metadata:
+  name: "all-logs"
+  namespace: cattle-logging-system
+spec:
+  globalOutputRefs:
+    - "example-syslog"
 ```
 
 ### Unsupported Outputs


### PR DESCRIPTION
The splunk configuration was wrong as `splunkHec` starts with lower `s`.
Also fields are `hec_host` and `hec_port`.

When contributing to docs, please don't update the content in the v2.x folder.
It's better to update the versioned docs, for example, the v2.5 or v2.6 docs.

This content in v2.x was separated into versioned documentation during the v2.5.8
release. The content relevant to Rancher versions before v2.5 went into the v2.0-v2.4
folder, while the content related to Rancher v2.5 went into the v2.5 folder.

We are trying to get the 2.x content to be removed from Google search results. The only
reason we haven't deleted it is because Google search results would lead to 404
errors if we deleted it.
