### PR TITLE
Capture navigation changes in v2.6

### DIFF
--- a/content/rancher/v2.5/en/cluster-admin/nodes/_index.md
+++ b/content/rancher/v2.5/en/cluster-admin/nodes/_index.md
@@ -175,19 +175,6 @@ You can label nodes to be ignored by using a setting in the Rancher UI, or by us
 
 > **Note:** There is an [open issue](https://github.com/rancher/rancher/issues/24172) in which nodes labeled to be ignored can get stuck in an updating state.
 
-### Labeling Nodes to be Ignored with the Rancher UI
-
-To add a node that is ignored by Rancher,
-
-1. From the **Global** view, click the **Settings** tab.
-1. Go to the `ignore-node-name` setting and click **&#8942; > Edit.**
-1. Enter a name that Rancher will use to ignore nodes. All nodes with this name will be ignored.
-1. Click **Save.**
-
-**Result:** Rancher will not wait to register nodes with this name. In the UI, the node will displayed with a grayed-out status. The node is still part of the cluster and can be listed with `kubectl`.
-
-If the setting is changed afterward, the ignored nodes will continue to be hidden.
-
 ### Labeling Nodes to be Ignored with kubectl
 
 To add a node that will be ignored by Rancher, use `kubectl` to create a node that has the following label:
@@ -202,4 +189,4 @@ If the label is added before the node is added to the cluster, the node will not
 
 If the label is added after the node is added to a Rancher cluster, the node will not be removed from the UI.
 
-If you delete the node from the Rancher server using the Rancher UI or API, the node will not be removed from the cluster if the `nodeName` is listed in the Rancher settings under `ignore-node-name`.
+If you delete the node from the Rancher server using the Rancher UI or API, the node will not be removed from the cluster if the `nodeName` is listed in the Rancher settings in the Rancher API under `v3/settings/ignore-node-name`.

--- a/content/rancher/v2.5/en/cluster-provisioning/hosted-kubernetes-clusters/aks/_index.md
+++ b/content/rancher/v2.5/en/cluster-provisioning/hosted-kubernetes-clusters/aks/_index.md
@@ -114,16 +114,18 @@ To give role-based access to your service principal,
 
 Use Rancher to set up and configure your Kubernetes cluster.
 
-1. From the **Clusters** page, click **Add Cluster**.
+1. In the upper left corner, click **≡ > Cluster Management.**
 
-1. Choose **Azure Kubernetes Service**.
+1. From the **Clusters** page, click **Create**.
+
+1. Choose **Azure AKS**.
 
 1. Enter a **Cluster Name**.
 
 1. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
 
-1. Use your subscription ID, tenant ID, app ID, and client secret to give your cluster access to AKS. If you don't have all of that information, you can retrieve it using these instructions:
-  - **App ID and tenant ID:** To get the app ID and tenant ID, you can go to the Azure Portal, then click **Azure Active Directory**, then click **App registrations,** then click the name of the service principal. The app ID and tenant ID are both on the app registration detail page. 
+1. Use your subscription ID, client ID, and client secret to give your cluster access to AKS. If you don't have all of that information, you can retrieve it using these instructions:
+  - **Client ID:** To get the Client ID, you can go to the Azure Portal, then click **Azure Active Directory**, then click **Enterprise applications.** Click **All applications.** Select your application, click **Properties,** and copy the application ID.
   - **Client secret:** If you didn't copy the client secret when creating the service principal, you can get a new one if you go to the app registration detail page, then click **Certificates & secrets**, then click **New client secret.** 
   - **Subscription ID:** You can get the subscription ID is available in the portal from **All services > Subscriptions.**
 

--- a/content/rancher/v2.5/en/cluster-provisioning/hosted-kubernetes-clusters/eks/_index.md
+++ b/content/rancher/v2.5/en/cluster-provisioning/hosted-kubernetes-clusters/eks/_index.md
@@ -49,7 +49,9 @@ For more detailed information on IAM policies for EKS, refer to the official [do
 
 Use Rancher to set up and configure your Kubernetes cluster.
 
-1. From the **Clusters** page, click **Add Cluster**.
+1. In the upper left corner, click **≡ > Cluster Management.**
+
+1. From the **Clusters** page, click **Create**.
 
 1. Choose **Amazon EKS**.
 

--- a/content/rancher/v2.5/en/cluster-provisioning/hosted-kubernetes-clusters/gke/_index.md
+++ b/content/rancher/v2.5/en/cluster-provisioning/hosted-kubernetes-clusters/gke/_index.md
@@ -63,8 +63,9 @@ To get the project ID of an existing project, refer to the Google cloud document
 ### 2. Create the GKE Cluster
 Use Rancher to set up and configure your Kubernetes cluster.
 
-1. From the **Clusters** page, click **Add Cluster**.
-1. Under **With a hosted Kubernetes provider,** click **Google GKE**.
+1. In the upper left corner, click **≡ > Cluster Management.**
+1. From the **Clusters** page, click **Create**.
+1. Click **Google GKE**.
 1. Enter a **Cluster Name**.
 1. Optional: Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
 1. Optional: Add Kubernetes [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) or [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) to the cluster.

--- a/content/rancher/v2.5/en/cluster-provisioning/registered-clusters/_index.md
+++ b/content/rancher/v2.5/en/cluster-provisioning/registered-clusters/_index.md
@@ -36,8 +36,9 @@ If you are registering a K3s cluster, make sure the `cluster.yml` is readable. I
 
 # Registering a Cluster
 
-1. From the **Clusters** page, click **Add Cluster**.
-2. Choose **Register**.
+1. In the upper left corner, click **≡ > Cluster Management.**
+1. From the **Clusters** page, click **Import Existing**.
+2. Click the type of Kubernetes cluster you want to import.
 3. Enter a **Cluster Name**.
 4. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
 5. For Rancher v2.5.6+, use **Agent Environment Variables** under **Cluster Options** to set environment variables for [rancher cluster agent]({{<baseurl>}}/rancher/v2.5/en/cluster-provisioning/rke-clusters/rancher-agents/). The environment variables can be set using key value pairs. If rancher agent requires use of proxy to communicate with Rancher server, `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment variables can be set using agent environment variables.

--- a/content/rancher/v2.5/en/cluster-provisioning/rke-clusters/cloud-providers/vsphere/out-of-tree/_index.md
+++ b/content/rancher/v2.5/en/cluster-provisioning/rke-clusters/cloud-providers/vsphere/out-of-tree/_index.md
@@ -23,8 +23,10 @@ The Cloud Provider Interface (CPI) should be installed first before installing t
 
 ### 1. Create a vSphere cluster
 
-1. On the Clusters page, click on **Add Cluster** and select the **vSphere** option or **Existing Nodes** option.
-1. Under **Cluster Options > Cloud Provider** select **External (Out-of-tree)**. This sets the cloud provider option on the Kubernetes cluster to `external` which sets your Kubernetes cluster up to be configured with an out-of-tree cloud provider. 
+1. In the upper left corner, click **≡ > Cluster Management.**
+1. From the **Clusters** page, click **Create.**
+1. Click **VMWare vSphere.**
+1. Under **Cluster Options** in the **Cloud Provider** section, select **External (Out-of-tree)**. This sets the cloud provider option on the Kubernetes cluster to `external` which sets your Kubernetes cluster up to be configured with an out-of-tree cloud provider. 
 1. Finish creating your cluster.
 
 ### 2. Install the CPI plugin

--- a/content/rancher/v2.5/en/cluster-provisioning/rke-clusters/custom-nodes/_index.md
+++ b/content/rancher/v2.5/en/cluster-provisioning/rke-clusters/custom-nodes/_index.md
@@ -44,38 +44,40 @@ Provision the host according to the [installation requirements]({{<baseurl>}}/ra
 
 Clusters won't begin provisioning until all three node roles (worker, etcd and controlplane) are present.
 
-1. From the **Clusters** page, click **Add Cluster**.
+1. In the upper left corner, click **≡ > Cluster Management.**
 
-2. Choose **Custom**.
+1. From the **Clusters** page, click **Create.**
 
-3. Enter a **Cluster Name**.
+1. Click **Custom.**
 
-4. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
+1. Enter a **Cluster Name**.
 
-5. Use **Cluster Options** to choose the version of Kubernetes, what network provider will be used and if you want to enable project network isolation. To see more cluster options, click on **Show advanced options.**
+1. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
+
+1. Use **Cluster Options** to choose the version of Kubernetes, what network provider will be used and if you want to enable project network isolation. To see more cluster options, click on **Show advanced options.**
 
     >**Using Windows nodes as Kubernetes workers?**
     >
     >- See [Enable the Windows Support Option]({{<baseurl>}}/rancher/v2.5/en/cluster-provisioning/rke-clusters/windows-clusters/).
     >- The only Network Provider available for clusters with Windows support is Flannel.
-6.	<a id="step-6"></a>Click **Next**.
+1.	<a id="step-6"></a>Click **Next**.
 
-7.	From **Node Role**, choose the roles that you want filled by a cluster node. You must provision at least one node for each role: `etcd`, `worker`, and `control plane`. All three roles are required for a custom cluster to finish provisioning. For more information on roles, see [this section.]({{<baseurl>}}/rancher/v2.5/en/overview/concepts/#roles-for-nodes-in-kubernetes-clusters)
+1.	From **Node Role**, choose the roles that you want filled by a cluster node. You must provision at least one node for each role: `etcd`, `worker`, and `control plane`. All three roles are required for a custom cluster to finish provisioning. For more information on roles, see [this section.]({{<baseurl>}}/rancher/v2.5/en/overview/concepts/#roles-for-nodes-in-kubernetes-clusters)
 
 	>**Notes:**
 	>
     >- Using Windows nodes as Kubernetes workers? See [this section]({{<baseurl>}}/rancher/v2.5/en/cluster-provisioning/rke-clusters/windows-clusters/).
 	>- Bare-Metal Server Reminder: If you plan on dedicating bare-metal servers to each role, you must provision a bare-metal server for each role (i.e. provision multiple bare-metal servers).
 
-8.	<a id="step-8"></a>**Optional**: Click **[Show advanced options]({{<baseurl>}}/rancher/v2.5/en/admin-settings/agent-options/)** to specify IP address(es) to use when registering the node, override the hostname of the node, or to add [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) or [taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) to the node.
+1.	<a id="step-8"></a>**Optional**: Click **[Show advanced options]({{<baseurl>}}/rancher/v2.5/en/admin-settings/agent-options/)** to specify IP address(es) to use when registering the node, override the hostname of the node, or to add [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) or [taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) to the node.
 
-9. Copy the command displayed on screen to your clipboard.
+1. Copy the command displayed on screen to your clipboard.
 
-10. Log in to your Linux host using your preferred shell, such as PuTTy or a remote Terminal connection. Run the command copied to your clipboard.
+1. Log in to your Linux host using your preferred shell, such as PuTTy or a remote Terminal connection. Run the command copied to your clipboard.
 
 	>**Note:** Repeat steps 7-10 if you want to dedicate specific hosts to specific node roles. Repeat the steps as many times as needed.
 
-11. When you finish running the command(s) on your Linux host(s), click **Done**.
+1. When you finish running the command(s) on your Linux host(s), click **Done**.
 
 **Result:** 
 

--- a/content/rancher/v2.5/en/cluster-provisioning/rke-clusters/node-pools/_index.md
+++ b/content/rancher/v2.5/en/cluster-provisioning/rke-clusters/node-pools/_index.md
@@ -100,8 +100,8 @@ When you create the node pool, you can specify the amount of time in minutes tha
 
 You can also enable node auto-replace after the cluster is created with the following steps:
 
-1. From the Global view, click the Clusters tab.
-1. Go to the cluster where you want to enable node auto-replace, click the vertical &#8942; **(…)**, and click **Edit.**
+1. In the upper left corner, click **≡ > Cluster Management.**
+1. In the list of clusters, go to the cluster where you want to enable node auto-replace. Click the vertical &#8942; **(…)**, and click **Edit Config.**
 1. In the **Node Pools** section, go to the node pool where you want to enable node auto-replace. In the **Recreate Unreachable After** field, enter the number of minutes that Rancher should wait for a node to respond before replacing the node.
 1. Click **Save.**
 
@@ -111,8 +111,8 @@ You can also enable node auto-replace after the cluster is created with the foll
 
 You can disable node auto-replace from the Rancher UI with the following steps:
 
-1. From the Global view, click the Clusters tab.
-1. Go to the cluster where you want to enable node auto-replace, click the vertical &#8942; **(…)**, and click **Edit.**
+1. In the upper left corner, click **≡ > Cluster Management.**
+1. In the list of clusters, go to the cluster where you want to enable node auto-replace. Click the vertical &#8942; **(…)**, and click **Edit Config.**
 1. In the **Node Pools** section, go to the node pool where you want to enable node auto-replace. In the **Recreate Unreachable After** field, enter 0.
 1. Click **Save.**
 

--- a/content/rancher/v2.5/en/cluster-provisioning/rke-clusters/node-pools/azure/_index.md
+++ b/content/rancher/v2.5/en/cluster-provisioning/rke-clusters/node-pools/azure/_index.md
@@ -45,10 +45,11 @@ The creation of this service principal returns three pieces of identification in
  
 ### 1. Create your cloud credentials
 
-1. In the Rancher UI, click the user profile button in the upper right corner, and click **Cloud Credentials.**
-1. Click **Add Cloud Credential.**
+1. In the upper left corner, click **≡ > Cluster Management.**
+1. In the left navigation menu, click **Cloud Credentials.**
+1. Click **Create.**
+1. Click **Azure.**
 1. Enter a name for the cloud credential.
-1. In the **Cloud Credential Type** field, select **Azure**.
 1. Enter your Azure credentials.
 1. Click **Create.**
 
@@ -58,7 +59,8 @@ The creation of this service principal returns three pieces of identification in
 
 Creating a [node template]({{<baseurl>}}/rancher/v2.5/en/cluster-provisioning/rke-clusters/node-pools/#node-templates) for Azure will allow Rancher to provision new nodes in Azure. Node templates can be reused for other clusters.
 
-1. In the Rancher UI, click the user profile button in the upper right corner, and click **Node Templates.**
+1. In the upper left corner, click **≡ > Cluster Management.**
+1. In the left navigation menu, click **Node Templates.**
 1. Click **Add Template.**
 1. Fill out a node template for Azure. For help filling out the form, refer to [Azure Node Template Configuration.](./azure-node-template-config)
 
@@ -68,7 +70,8 @@ Use Rancher to create a Kubernetes cluster in Azure.
 
 Clusters won't begin provisioning until all three node roles (worker, etcd and controlplane) are present.
 
-1. From the **Clusters** page, click **Add Cluster**.
+1. In the upper left corner, click **≡ > Cluster Management**.
+1. Click **Create**.
 1. Choose **Azure**.
 1. Enter a **Cluster Name**.
 1. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.

--- a/content/rancher/v2.5/en/cluster-provisioning/rke-clusters/node-pools/digital-ocean/_index.md
+++ b/content/rancher/v2.5/en/cluster-provisioning/rke-clusters/node-pools/digital-ocean/_index.md
@@ -18,10 +18,11 @@ Then you will create a DigitalOcean cluster in Rancher, and when configuring the
 
 ### 1. Create your cloud credentials
 
-1. In the Rancher UI, click the user profile button in the upper right corner, and click **Cloud Credentials.**
-1. Click **Add Cloud Credential.**
+1. In the upper left corner, click **≡ > Cluster Management.**
+1. In the left navigation menu, click **Cloud Credentials.**
+1. Click **Create.**
+1. Click **Digital Ocean.**
 1. Enter a name for the cloud credential.
-1. In the **Cloud Credential Type** field, select **DigitalOcean**.
 1. Enter your Digital Ocean credentials.
 1. Click **Create.**
 
@@ -31,15 +32,16 @@ Then you will create a DigitalOcean cluster in Rancher, and when configuring the
 
 Creating a [node template]({{<baseurl>}}/rancher/v2.5/en/cluster-provisioning/rke-clusters/node-pools/#node-templates) for DigitalOcean will allow Rancher to provision new nodes in DigitalOcean. Node templates can be reused for other clusters.
 
-1. In the Rancher UI, click the user profile button in the upper right corner, and click **Node Templates.**
-1. Click **Add Template.**
+1. In the upper left corner, click **≡ > Cluster Management.**
+1. In the left navigation menu, click **Node Templates.**
 1. Fill out a node template for DigitalOcean. For help filling out the form, refer to [DigitalOcean Node Template Configuration.](./do-node-template-config)
 
 ### 3. Create a cluster with node pools using the node template
 
 Clusters won't begin provisioning until all three node roles (worker, etcd and controlplane) are present.
 
-1. From the **Clusters** page, click **Add Cluster**.
+1. In the upper left corner, click **≡ > Cluster Management**.
+1. Click **Create**.
 1. Choose **DigitalOcean**.
 1. Enter a **Cluster Name**.
 1. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.

--- a/content/rancher/v2.5/en/cluster-provisioning/rke-clusters/node-pools/ec2/_index.md
+++ b/content/rancher/v2.5/en/cluster-provisioning/rke-clusters/node-pools/ec2/_index.md
@@ -29,12 +29,13 @@ The steps to create a cluster differ based on your Rancher version.
 
 ### 1. Create your cloud credentials
 
-1. In the Rancher UI, click the user profile button in the upper right corner, and click **Cloud Credentials.**
-1. Click **Add Cloud Credential.**
+1. In the upper left corner, click **≡ > Cluster Management.**
+1. In the left navigation menu, click **Cloud Credentials.**
+1. Click **Create.**
+1. Click **Amazon.**
 1. Enter a name for the cloud credential.
-1. In the **Cloud Credential Type** field, select **Amazon.**
-1. In the **Region** field, select the AWS region where your cluster nodes will be located.
 1. Enter your AWS EC2 **Access Key** and **Secret Key.**
+1. In the **Default Region** field, select the AWS region where your cluster nodes will be located.
 1. Click **Create.**
 
 **Result:** You have created the cloud credentials that will be used to provision nodes in your cluster. You can reuse these credentials for other node templates, or in other clusters. 
@@ -43,8 +44,8 @@ The steps to create a cluster differ based on your Rancher version.
 
 Creating a [node template]({{<baseurl>}}/rancher/v2.5/en/cluster-provisioning/rke-clusters/node-pools/#node-templates) for EC2 will allow Rancher to provision new nodes in EC2. Node templates can be reused for other clusters.
 
-1. In the Rancher UI, click the user profile button in the upper right corner, and click **Node Templates.**
-1. Click **Add Template.**
+1. In the upper left corner, click **≡ > Cluster Management.**
+1. In the left navigation menu, click **Node Templates.**
 1. Fill out a node template for EC2. For help filling out the form, refer to [EC2 Node Template Configuration.](./ec2-node-template-config)
 
 ### 3. Create a cluster with node pools using the node template
@@ -53,7 +54,8 @@ Add one or more node pools to your cluster. For more information about node pool
 
 Clusters won't begin provisioning until all three node roles (worker, etcd and controlplane) are present.
 
-1. From the **Clusters** page, click **Add Cluster**.
+1. In the upper left corner, click **≡ > Cluster Management**.
+1. Click **Create**.
 1. Choose **Amazon EC2**.
 1. Enter a **Cluster Name**.
 1. Create a node pool for each Kubernetes role. For each node pool, choose a node template that you created. For more information about node pools, including best practices for assigning Kubernetes roles to them, see [this section.]({{<baseurl>}}/rancher/v2.5/en/cluster-provisioning/rke-clusters/node-pools) 
@@ -71,6 +73,7 @@ You can access your cluster after its state is updated to **Active.**
 
 - `Default`, containing the `default` namespace
 - `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+
 ### Optional Next Steps
 
 After creating your cluster, you can access it through the Rancher UI. As a best practice, we recommend setting up these alternate ways of accessing your cluster:

--- a/content/rancher/v2.5/en/cluster-provisioning/rke-clusters/node-pools/vsphere/provisioning-vsphere-clusters/_index.md
+++ b/content/rancher/v2.5/en/cluster-provisioning/rke-clusters/node-pools/vsphere/provisioning-vsphere-clusters/_index.md
@@ -56,10 +56,10 @@ The a vSphere cluster is created in Rancher depends on the Rancher version.
 
 ### 1. Create your cloud credentials
 
-1. In the Rancher UI, click the user profile button in the upper right corner, and click **Cloud Credentials.**
-1. Click **Add Cloud Credential.**
-1. Enter a name for the cloud credential.
-1. In the **Cloud Credential Type** field, select **vSphere**.
+1. In the upper left corner, click **≡ > Cluster Management.**
+1. In the left navigation menu, click **Cloud Credentials.**
+1. Click **Create.**
+1. Click **VMware vSphere.**
 1. Enter your vSphere credentials. For help, refer to **Account Access** in the [node template configuration reference.]({{<baseurl>}}/rancher/v2.5/en/cluster-provisioning/rke-clusters/node-pools/vsphere/vsphere-node-template-config/)
 1. Click **Create.**
 
@@ -69,8 +69,8 @@ The a vSphere cluster is created in Rancher depends on the Rancher version.
 
 Creating a [node template]({{<baseurl>}}/rancher/v2.5/en/cluster-provisioning/rke-clusters/node-pools/#node-templates) for vSphere will allow Rancher to provision new nodes in vSphere. Node templates can be reused for other clusters.
 
-1. In the Rancher UI, click the user profile button in the upper right corner, and click **Node Templates.**
-1. Click **Add Template.**
+1. In the upper left corner, click **≡ > Cluster Management.**
+1. In the left navigation menu, click **Node Templates.**
 1. Fill out a node template for vSphere. For help filling out the form, refer to the vSphere node template [configuration reference.]({{<baseurl>}}/rancher/v2.5/en/cluster-provisioning/rke-clusters/node-pools/vsphere/vsphere-node-template-config/).
 
 ### 3. Create a cluster with node pools using the node template
@@ -79,8 +79,9 @@ Use Rancher to create a Kubernetes cluster in vSphere.
 
 Clusters won't begin provisioning until all three node roles (worker, etcd and controlplane) are present.
 
-1. Navigate to **Clusters** in the **Global** view.
-1. Click **Add Cluster** and select the **vSphere** infrastructure provider.
+1. In the upper left corner, click **≡ > Cluster Management**.
+1. Click **Create**.
+1. Select the **VMware vSphere** infrastructure provider.
 1. Enter a **Cluster Name.**
 1. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
 1. Use **Cluster Options** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. To see more cluster options, click on **Show advanced options.** For help configuring the cluster, refer to the [RKE cluster configuration reference.]({{<baseurl>}}/rancher/v2.5/en/cluster-provisioning/rke-clusters/options)

--- a/content/rancher/v2.6/en/admin-settings/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/_index.md
@@ -1,12 +1,6 @@
 ---
 title: Authentication, Permissions and Global Configuration
 weight: 6
-aliases:
-  - /rancher/v2.6/en/concepts/global-configuration/
-  - /rancher/v2.6/en/tasks/global-configuration/
-  - /rancher/v2.6/en/concepts/global-configuration/server-url/
-  - /rancher/v2.6/en/tasks/global-configuration/server-url/
-  - /rancher/v2.6/en/admin-settings/log-in/
 ---
 
 After installation, the [system administrator]({{<baseurl>}}/rancher/v2.6/en/admin-settings/rbac/global-permissions/) should configure Rancher to configure authentication, authorization, security, default settings, security policies, drivers and global DNS entries.

--- a/content/rancher/v2.6/en/admin-settings/authentication/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/authentication/_index.md
@@ -1,9 +1,6 @@
 ---
 title: Authentication
 weight: 10
-aliases:
-    - /rancher/v2.6/en/concepts/global-configuration/authentication/
-    - /rancher/v2.6/en/tasks/global-configuration/authentication/
 ---
 
 One of the key features that Rancher adds to Kubernetes is centralized user authentication. This feature allows your users to use one set of credentials to authenticate with any of your Kubernetes clusters.
@@ -12,7 +9,7 @@ This centralized user authentication is accomplished using the Rancher authentic
 
 ## External vs. Local Authentication
 
-The Rancher authentication proxy integrates with the following external authentication services. The following table lists the first version of Rancher each service debuted.
+The Rancher authentication proxy integrates with the following external authentication services.
 
 | Auth Service                                                                                     |
 | ------------------------------------------------------------------------------------------------ |
@@ -54,13 +51,11 @@ After you configure Rancher to allow sign on using an external authentication se
 
 To set the Rancher access level for users in the authorization service, follow these steps:
 
-1. From the **Global** view, click **Security > Authentication.**
-
-1. Use the **Site Access** options to configure the scope of user authorization. The table above explains the access level for each option.
-
+1. In the upper left corner, click **☰ > Users & Authentication**.
+1. In the left navigation bar, click **Auth Provider**.
+1. After setting up the configuration details for an auth provider, use the **Site Access** options to configure the scope of user authorization. The table above explains the access level for each option.
 1. Optional: If you choose an option other than **Allow any valid Users,** you can add users to the list of authorized users and organizations by searching for them in the text field that appears.
-
-1. Click **Save.**
+1. Click **Save**.
 
 **Result:** The Rancher access configuration settings are applied.
 

--- a/content/rancher/v2.6/en/admin-settings/authentication/ad/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/authentication/ad/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Configuring Active Directory (AD)
 weight: 1112
-aliases:
-    - /rancher/v2.6/en/tasks/global-configuration/authentication/active-directory/
 ---
 
 If your organization uses Microsoft Active Directory as central user repository, you can configure Rancher to communicate with an Active Directory server to authenticate users. This allows Rancher admins to control access to clusters and projects based on users and groups managed externally in the Active Directory, while allowing end-users to authenticate with their AD credentials when logging in to the Rancher UI.
@@ -23,14 +21,17 @@ Note however, that in some locked-down Active Directory configurations this defa
 
 > **Using TLS?**
 >
-> If the certificate used by the AD server is self-signed or not from a recognised certificate authority, make sure have at hand the CA certificate (concatenated with any intermediate certificates) in PEM format. You will have to paste in this certificate during the configuration so that Rancher is able to validate the certificate chain.
+> If the certificate used by the AD server is self-signed or not from a recognized certificate authority, make sure have at hand the CA certificate (concatenated with any intermediate certificates) in PEM format. You will have to paste in this certificate during the configuration so that Rancher is able to validate the certificate chain.
 
 ## Configuration Steps
 ### Open Active Directory Configuration
 
 1. Log into the Rancher UI using the initial local `admin` account.
-2. From the **Global** view, navigate to **Security** > **Authentication**
-3. Select **Active Directory**. The **Configure an AD server** form will be displayed.
+1.	In the top left corner, click **☰ > Users & Authentication**.
+1. In the left navigation menu, click **Auth Provider**.
+1. Click **ActiveDirectory**. The **Authentication Provider: ActiveDirectory** form will be displayed.
+1. Fill out the form. For help, refer to the details on configuration options below.
+1. Click **Enable**.
 
 ### Configure Active Directory Server Settings
 

--- a/content/rancher/v2.6/en/admin-settings/authentication/azure-ad/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/authentication/azure-ad/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Configuring Azure AD
 weight: 1115
-aliases:
-    - /rancher/v2.6/en/tasks/global-configuration/authentication/azure-ad/
 ---
 
 If you have an instance of Active Directory (AD) hosted in Azure, you can configure Rancher to allow your users to log in using their AD accounts. Configuration of Azure AD external authentication requires you to make configurations in both Azure and Rancher.
@@ -180,10 +178,10 @@ From the Rancher UI, enter information about your AD instance hosted in Azure to
 
 Enter the values that you copied to your [text file](#tip).
 
-1. Log into Rancher. From the **Global** view, select **Security > Authentication**.
-
-1. Select **Azure AD**.
-
+1. Log into Rancher.
+1.	In the top left corner, click **☰ > Users & Authentication**.
+1. In the left navigation menu, click **Auth Provider**.
+1. Click **AzureAD**.
 1. Complete the **Configure Azure AD Account** form using the information you copied while completing [Copy Azure Application Data](#5-copy-azure-application-data).
 
     >**Important:** When entering your Graph Endpoint, remove the tenant ID from the URL, like below.
@@ -202,6 +200,6 @@ Enter the values that you copied to your [text file](#tip).
     | Token Endpoint     | OAuth 2.0 Token Endpoint              |
     | Auth Endpoint      | OAuth 2.0 Authorization Endpoint      |
 
-1. Click **Authenticate with Azure**.
+1. Click **Enable**.
 
 **Result:** Azure Active Directory authentication is configured.

--- a/content/rancher/v2.6/en/admin-settings/authentication/freeipa/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/authentication/freeipa/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Configuring FreeIPA
 weight: 1114
-aliases:
-    - /rancher/v2.6/en/tasks/global-configuration/authentication/freeipa/
 ---
 
 If your organization uses FreeIPA for user authentication, you can configure Rancher to allow your users to login using their FreeIPA credentials.
@@ -14,12 +12,10 @@ If your organization uses FreeIPA for user authentication, you can configure Ran
 >- Read [External Authentication Configuration and Principal Users]({{<baseurl>}}/rancher/v2.6/en/admin-settings/authentication/#external-authentication-configuration-and-principal-users).
 
 1.  Sign into Rancher using a local user assigned the `administrator` role (i.e., the _local principal_).
-
-2.	From the **Global** view, select **Security > Authentication** from the main menu.
-
-3.	Select **FreeIPA**.
-
-4.	Complete the **Configure an FreeIPA server** form.
+1.	In the top left corner, click **☰ > Users & Authentication**.
+1. In the left navigation menu, click **Auth Provider**.
+1. Click **FreeIPA**.
+1.	Complete the **Configure an FreeIPA server** form.
 
 	You may need to log in to your domain controller to find the information requested in the form.
 
@@ -34,7 +30,7 @@ If your organization uses FreeIPA for user authentication, you can configure Ran
 	>* If your users and groups are in the same search base, complete only the User Search Base.
 	>* If your groups are in a different search base, you can optionally complete the Group Search Base. This field is dedicated to searching groups, but is not required.
 
-5.	If your FreeIPA deviates from the standard AD schema, complete the **Customize Schema** form to match it. Otherwise, skip this step.
+1.	If your FreeIPA deviates from the standard AD schema, complete the **Customize Schema** form to match it. Otherwise, skip this step.
 
 	>**Search Attribute** The Search Attribute field defaults with three specific values: `uid|sn|givenName`. After FreeIPA is configured, when a user enters text to add users or groups, Rancher automatically queries the FreeIPA server and attempts to match fields by user id, last name, or first name. Rancher specifically searches for users/groups that begin with the text entered in the search field.
 	>
@@ -46,7 +42,8 @@ If your organization uses FreeIPA for user authentication, you can configure Ran
 	>
 	> With this search attribute, Rancher creates search filters for users and groups, but you *cannot* add your own search filters in this field.
 
-6.	Enter your FreeIPA username and password in **Authenticate with FreeIPA** to confirm that Rancher is configured to use FreeIPA authentication.
+1.	Enter your FreeIPA username and password in **Authenticate with FreeIPA** to confirm that Rancher is configured to use FreeIPA authentication.
+1. Click **Enable**.
 
 **Result:**
 

--- a/content/rancher/v2.6/en/admin-settings/authentication/github/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/authentication/github/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Configuring GitHub
 weight: 1116
-aliases:
-    - /rancher/v2.6/en/tasks/global-configuration/authentication/github/
 ---
 
 In environments using GitHub, you can configure Rancher to allow sign on using GitHub credentials.
@@ -10,12 +8,10 @@ In environments using GitHub, you can configure Rancher to allow sign on using G
 >**Prerequisites:** Read [External Authentication Configuration and Principal Users]({{<baseurl>}}/rancher/v2.6/en/admin-settings/authentication/#external-authentication-configuration-and-principal-users).
 
 1.  Sign into Rancher using a local user assigned the `administrator` role (i.e., the _local principal_).
-
-2.	From the **Global** view, select **Security > Authentication** from the main menu.
-
-3.	Select **GitHub**.
-
-4.	Follow the directions displayed to **Setup a GitHub Application**. Rancher redirects you to GitHub to complete registration.
+1.	In the top left corner, click **☰ > Users & Authentication**.
+1. In the left navigation menu, click **Auth Provider**.
+1. Click **GitHub**.
+1.	Follow the directions displayed to set up a GitHub Application. Rancher redirects you to GitHub to complete registration.
 
 	>**What's an Authorization Callback URL?**
 	>
@@ -23,15 +19,15 @@ In environments using GitHub, you can configure Rancher to allow sign on using G
 
 	>When you use external authentication, authentication does not actually take place in your application. Instead, authentication takes place externally (in this case, GitHub). After this external authentication completes successfully, the Authorization Callback URL is the location where the user re-enters your application.
 
-5. From GitHub, copy the **Client ID** and **Client Secret**. Paste them into Rancher.
+1. From GitHub, copy the **Client ID** and **Client Secret**. Paste them into Rancher.
 
 	>**Where do I find the Client ID and Client Secret?**
 	>
 	>From GitHub, select Settings > Developer Settings > OAuth Apps. The Client ID and Client Secret are displayed prominently.
 
-6.	Click **Authenticate with GitHub**.
+1.	Click **Authenticate with GitHub**.
 
-7.	Use the **Site Access** options to configure the scope of user authorization.
+1.	Use the **Site Access** options to configure the scope of user authorization.
 
 	-	**Allow any valid Users**
 
@@ -45,7 +41,7 @@ In environments using GitHub, you can configure Rancher to allow sign on using G
 
 		Only GitHub users or groups added to the Authorized Users and Organizations can log in to Rancher.
 		<br/>
-8.	Click **Save**.
+1.	Click **Enable**.
 
 **Result:**
 

--- a/content/rancher/v2.6/en/admin-settings/authentication/google/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/authentication/google/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Configuring Google OAuth
+weight: 10
 ---
 
 If your organization uses G Suite for user authentication, you can configure Rancher to allow your users to log in using their G Suite credentials.
@@ -9,6 +10,7 @@ Only admins of the G Suite domain have access to the Admin SDK. Therefore, only 
 Within Rancher, only administrators or users with the **Manage Authentication** [global role]({{<baseurl>}}/rancher/v2.6/en/admin-settings/rbac/global-permissions/) can configure authentication.
 
 # Prerequisites
+
 - You must have a [G Suite admin account](https://admin.google.com) configured.
 - G Suite requires a [top private domain FQDN](https://github.com/google/guava/wiki/InternetDomainNameExplained#public-suffixes-and-private-domains) as an authorized domain. One way to get an FQDN is by creating an A-record in Route53 for your Rancher server. You do not need to update your Rancher Server URL setting with that record, because there could be clusters using that URL.
 - You must have the Admin SDK API enabled for your G Suite domain. You can enable it using the steps on [this page.](https://support.google.com/a/answer/60757?hl=en)
@@ -17,6 +19,7 @@ After the Admin SDK API is enabled, your G Suite domain's API screen should look
 ![Enable Admin APIs]({{<baseurl>}}/img/rancher/Google-Enable-APIs-Screen.png)
 
 # Setting up G Suite for OAuth with Rancher
+
 Before you can set up Google OAuth in Rancher, you need to log in to your G Suite account and do the following:
 
 1. [Add Rancher as an authorized domain in G Suite](#1-adding-rancher-as-an-authorized-domain)
@@ -25,8 +28,9 @@ Before you can set up Google OAuth in Rancher, you need to log in to your G Suit
 1. [Register the service account key as an OAuth Client](#4-register-the-service-account-key-as-an-oauth-client)
 
 ### 1. Adding Rancher as an Authorized Domain
+
 1. Click [here](https://console.developers.google.com/apis/credentials) to go to credentials page of your Google domain.
-1. Select your project and click **OAuth consent screen.**
+1. Select your project and click **OAuth consent screen**.
 ![OAuth Consent Screen]({{<baseurl>}}/img/rancher/Google-OAuth-consent-screen-tab.png)
 1. Go to **Authorized Domains** and enter the top private domain of your Rancher server URL in the list. The top private domain is the rightmost superdomain. So for example, www.foo.co.uk a top private domain of foo.co.uk. For more information on top-level domains, refer to [this article.](https://github.com/google/guava/wiki/InternetDomainNameExplained#public-suffixes-and-private-domains)
 1. Go to **Scopes for Google APIs** and make sure **email,** **profile** and **openid** are enabled.
@@ -34,16 +38,17 @@ Before you can set up Google OAuth in Rancher, you need to log in to your G Suit
 **Result:** Rancher has been added as an authorized domain for the Admin SDK API.
 
 ### 2. Creating OAuth2 Credentials for the Rancher Server
+
 1. Go to the Google API console, select your project, and go to the [credentials page.](https://console.developers.google.com/apis/credentials)
 ![Credentials]({{<baseurl>}}/img/rancher/Google-Credentials-tab.png)
-1. On the **Create Credentials** dropdown, select **OAuth client ID.**
-1. Click **Web application.**
+1. On the **Create Credentials** dropdown, select **OAuth client ID**.
+1. Click **Web application**.
 1. Provide a name.
-1. Fill out the **Authorized JavaScript origins** and **Authorized redirect URIs.** Note: The Rancher UI page for setting up Google OAuth (available from the Global view under **Security > Authentication > Google**) provides you the exact links to enter for this step.
+1. Fill out the **Authorized JavaScript origins** and **Authorized redirect URIs**. Note: The Rancher UI page for setting up Google OAuth (available from the Global view under **Security > Authentication > Google**) provides you the exact links to enter for this step.
  - Under **Authorized JavaScript origins,** enter your Rancher server URL.
  - Under **Authorized redirect URIs,** enter your Rancher server URL appended with the path `verify-auth`. For example, if your URI is `https://rancherServer`, you will enter `https://rancherServer/verify-auth`.
-1. Click on **Create.**
-1. After the credential is created, you will see a screen with a list of your credentials. Choose the credential you just created, and in that row on rightmost side, click **Download JSON.** Save the file so that you can provide these credentials to Rancher.
+1. Click on **Create**.
+1. After the credential is created, you will see a screen with a list of your credentials. Choose the credential you just created, and in that row on rightmost side, click **Download JSON**. Save the file so that you can provide these credentials to Rancher.
 
 **Result:** Your OAuth credentials have been successfully created.
 
@@ -60,8 +65,8 @@ This section describes how to:
 - Create a key for the service account and download the credentials as JSON
 
 1. Click [here](https://console.developers.google.com/iam-admin/serviceaccounts) and select your project for which you generated OAuth credentials.
-1. Click on **Create Service Account.**
-1. Enter a name and click **Create.**
+1. Click on **Create Service Account**.
+1. Enter a name and click **Create**.
 ![Service account creation Step 1]({{<baseurl>}}/img/rancher/Google-svc-acc-step1.png)
 1. Don't provide any roles on the **Service account permissions** page and click **Continue**
 ![Service account creation Step 2]({{<baseurl>}}/img/rancher/Google-svc-acc-step2.png)
@@ -76,7 +81,7 @@ You will need to grant some permissions to the service account you created in th
 
 Using the Unique ID of the service account key, register it as an Oauth Client using the following steps:
 
-1. Get the Unique ID of the key you just created. If it's not displayed in the list of keys right next to the one you created, you will have to enable it. To enable it, click **Unique ID** and click **OK.** This will add a **Unique ID** column to the list of service account keys. Save the one listed for the service account you created. NOTE: This is a numeric key, not to be confused with the alphanumeric field **Key ID.**
+1. Get the Unique ID of the key you just created. If it's not displayed in the list of keys right next to the one you created, you will have to enable it. To enable it, click **Unique ID** and click **OK**. This will add a **Unique ID** column to the list of service account keys. Save the one listed for the service account you created. NOTE: This is a numeric key, not to be confused with the alphanumeric field **Key ID**.
 
 	![Service account Unique ID]({{<baseurl>}}/img/rancher/Google-Select-UniqueID-column.png)
 1. Go to the [**Manage OAuth Client Access** page.](https://admin.google.com/AdminHome?chromeless=1#OGX:ManageOauthClients)
@@ -85,14 +90,16 @@ Using the Unique ID of the service account key, register it as an Oauth Client u
 	```
 	openid,profile,email,https://www.googleapis.com/auth/admin.directory.user.readonly,https://www.googleapis.com/auth/admin.directory.group.readonly
 	```
-1. Click **Authorize.**
+1. Click **Authorize**.
 
 **Result:** The service account is registered as an OAuth client in your G Suite account.
 
 # Configuring Google OAuth in Rancher
+
 1. Sign into Rancher using a local user assigned the [administrator]({{<baseurl>}}/rancher/v2.6/en/admin-settings/rbac/global-permissions) role. This user is also called the local principal.
-1.	From the **Global** view, click **Security > Authentication** from the main menu.
-1. Click **Google.** The instructions in the UI cover the steps to set up authentication with Google OAuth.
+1.	In the top left corner, click **☰ > Users & Authentication**.
+1. In the left navigation menu, click **Auth Provider**.
+1. Click **Google**. The instructions in the UI cover the steps to set up authentication with Google OAuth.
 	1. Admin Email: Provide the email of an administrator account from your GSuite setup. In order to perform user and group lookups, google apis require an administrator's email in conjunction with the service account key.
 	1. Domain: Provide the domain on which you have configured GSuite. Provide the exact domain and not any aliases.
 	1. Nested Group Membership: Check this box to enable nested group memberships. Rancher admins can disable this at any time after configuring auth.
@@ -100,6 +107,6 @@ Using the Unique ID of the service account key, register it as an Oauth Client u
    - For **Step Two,** provide the OAuth credentials JSON that you downloaded after completing [this section.](#2-creating-oauth2-credentials-for-the-rancher-server) You can upload the file or paste the contents into the **OAuth Credentials** field.
    - For **Step Three,** provide the service account credentials JSON that downloaded at the end of [this section.](#3-creating-service-account-credentials) The credentials will only work if you successfully [registered the service account key](#4-register-the-service-account-key-as-an-oauth-client) as an OAuth client in your G Suite account.
 1.	Click **Authenticate with Google**.
-1.	Click **Save**.
+1.	Click **Enable**.
 
 **Result:** Google authentication is successfully configured.

--- a/content/rancher/v2.6/en/admin-settings/authentication/keycloak-oidc/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/authentication/keycloak-oidc/_index.md
@@ -56,12 +56,10 @@ If you have an existing configuration using the SAML protocol and want to switch
 
 ## Configuring Keycloak in Rancher
 
-1. In the Rancher UI, click **☰ > Users & Authentication > Auth Provider**.
-
+1. In the Rancher UI, click **☰ > Users & Authentication**.
+1. In the left navigation bar, click **Auth Provider**.
 1. Select **Keycloak (OIDC)**.
-
 1. Complete the **Configure a Keycloak OIDC account** form. For help with filling the form, see the [configuration reference](#configuration-reference).
-
 1. After you complete the **Configure a Keycloak OIDC account** form, click **Enable**.
 
     Rancher redirects you to the IdP login page. Enter credentials that authenticate with Keycloak IdP to validate your Rancher Keycloak configuration.
@@ -109,10 +107,9 @@ This section describes the process to transition from using Rancher with Keycloa
 
 Before configuring Rancher to use Keycloak (OIDC), Keycloak (SAML) must be first disabled. 
 
-1. In the Rancher UI, click **☰ > Users & Authentication > Auth Provider**.
-
+1. In the Rancher UI, click **☰ > Users & Authentication**.
+1. In the left navigation bar, click **Auth Provider**.
 1. Select **Keycloak (SAML)**.
-
 1. Click **Disable**.
 
 Configure Rancher to use Keycloak (OIDC) by following the steps in [this section](#configuring-keycloak-in-rancher).

--- a/content/rancher/v2.6/en/admin-settings/authentication/keycloak-saml/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/authentication/keycloak-saml/_index.md
@@ -57,13 +57,11 @@ If your organization uses Keycloak Identity Provider (IdP) for user authenticati
 ## Configuring Keycloak in Rancher
 
 
-1.	From the **Global** view, select **Security > Authentication** from the main menu.
-
-1.	Select **Keycloak**.
-
+1.	In the top left corner, click **☰ > Users & Authentication**.
+1. In the left navigation menu, click **Auth Provider**.
+1. Click **Keycloak SAML**.
 1.	Complete the **Configure Keycloak Account** form. For help with filling the form, see the [configuration reference](#configuration-reference).
-
-1. After you complete the **Configure Keycloak Account** form, click **Authenticate with Keycloak**, which is at the bottom of the page.
+1. After you complete the **Configure a Keycloak Account** form, click **Enable**.
 
     Rancher redirects you to the IdP login page. Enter credentials that authenticate with Keycloak IdP to validate your Rancher Keycloak configuration.
 

--- a/content/rancher/v2.6/en/admin-settings/authentication/local/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/authentication/local/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Local Authentication
 weight: 1111
-aliases:
-    - /rancher/v2.6/en/tasks/global-configuration/authentication/local-authentication/
 ---
 
 Local authentication is the default until you configure an external authentication provider. Local authentication is where Rancher stores the user information, i.e. names and passwords, of who can log in to Rancher. By default, the `admin` user that logs in to Rancher for the first time is a local user.
@@ -11,6 +9,8 @@ Local authentication is the default until you configure an external authenticati
 
 Regardless of whether you use external authentication, you should create a few local authentication users so that you can continue using Rancher if your external authentication service encounters issues.
 
-1.	From the **Global** view, select **Users** from the navigation bar.
-
-2.	Click **Add User**. Then complete the **Add User** form. Click **Create** when you're done.
+1.	In the top left corner, click **☰ > Users & Authentication**.
+1. In the left navigation menu, click **Users**.
+1. Click **Create**.
+1.	Complete the **Add User** form.
+1. Click **Create**.

--- a/content/rancher/v2.6/en/admin-settings/authentication/microsoft-adfs/microsoft-adfs-setup/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/authentication/microsoft-adfs/microsoft-adfs-setup/_index.md
@@ -7,7 +7,7 @@ Before configuring Rancher to support AD FS users, you must add Rancher as a [re
 
 1. Log into your AD server as an administrative user.
 
-1. Open the **AD FS Management** console. Select **Add Relying Party Trust...** from the **Actions** menu and click **Start**.
+1. Open the **AD FS Management** console. Select **Add Relying Party Trust..**. from the **Actions** menu and click **Start**.
   
     {{< img "/img/rancher/adfs/adfs-overview.png" "">}}
 
@@ -49,11 +49,11 @@ Before configuring Rancher to support AD FS users, you must add Rancher as a [re
     {{< img "/img/rancher/adfs/adfs-add-rpt-10.png" "">}}
 
   
-1. Select **Open the Edit Claim Rules...** and click **Close**.
+1. Select **Open the Edit Claim Rules..**. and click **Close**.
   
     {{< img "/img/rancher/adfs/adfs-add-rpt-11.png" "">}}
   
-1. On the **Issuance Transform Rules** tab, click **Add Rule...**.
+1. On the **Issuance Transform Rules** tab, click **Add Rule..**..
   
     {{< img "/img/rancher/adfs/adfs-edit-cr.png" "">}}
   

--- a/content/rancher/v2.6/en/admin-settings/authentication/microsoft-adfs/rancher-adfs-setup/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/authentication/microsoft-adfs/rancher-adfs-setup/_index.md
@@ -5,27 +5,17 @@ weight: 1205
 
 After you complete [Configuring Microsoft AD FS for Rancher]({{<baseurl>}}/rancher/v2.6/en/admin-settings/authentication/microsoft-adfs/microsoft-adfs-setup/), enter your AD FS information into Rancher to allow AD FS users to authenticate with Rancher.
 
->**Important Notes For Configuring Your AD FS Server:**
+>**Important Notes For Configuring Your ADFS Server:**
 > 
 >- The SAML 2.0 WebSSO Protocol Service URL is: `https://<RANCHER_SERVER>/v1-saml/adfs/saml/acs`
 >- The Relying Party Trust identifier URL is: `https://<RANCHER_SERVER>/v1-saml/adfs/saml/metadata`
 >- You must export the `federationmetadata.xml` file from your AD FS server. This can be found at: `https://<AD_SERVER>/federationmetadata/2007-06/federationmetadata.xml`
 
-
-1.	From the **Global** view, select **Security > Authentication** from the main menu.
-
-1.	Select **Microsoft Active Directory Federation Services**.
-
+1.	In the top left corner, click **☰ > Users & Authentication**.
+1. In the left navigation menu, click **Auth Provider**.
+1. Click **ADFS**.
 1.	Complete the **Configure AD FS Account** form. Microsoft AD FS lets you specify an existing Active Directory (AD) server. The [configuration section below](#configuration) describe how you can map AD attributes to fields within Rancher.
-
-    
-    
-
-    
-
-
- 
-1. After you complete the **Configure AD FS Account** form, click **Authenticate with AD FS**, which is at the bottom of the page.
+1. After you complete the **Configure AD FS Account** form, click **Enable**.
 
     Rancher redirects you to the AD FS login page. Enter credentials that authenticate with Microsoft AD FS to validate your Rancher AD FS configuration.
 

--- a/content/rancher/v2.6/en/admin-settings/authentication/okta/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/authentication/okta/_index.md
@@ -18,10 +18,9 @@ Setting | Value
 
 ## Configuring Okta in Rancher
 
-1.	From the **Global** view, select **Security > Authentication** from the main menu.
-
-1.	Select **Okta**.
-
+1.	In the top left corner, click **☰ > Users & Authentication**.
+1. In the left navigation menu, click **Auth Provider**.
+1. Click **Okta**.
 1.	Complete the **Configure Okta Account** form. The examples below describe how you can map Okta attributes from attribute statements to fields within Rancher.
 
     | Field                     | Description                                                                   |
@@ -40,7 +39,7 @@ Setting | Value
 
 
 
-1. After you complete the **Configure Okta Account** form, click **Authenticate with Okta**, which is at the bottom of the page.
+1. After you complete the **Configure Okta Account** form, click **Enable**.
 
     Rancher redirects you to the IdP login page. Enter credentials that authenticate with Okta IdP to validate your Rancher Okta configuration.
 

--- a/content/rancher/v2.6/en/admin-settings/authentication/openldap/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/authentication/openldap/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Configuring OpenLDAP
 weight: 1113
-aliases:
-    - /rancher/v2.6/en/tasks/global-configuration/authentication/openldap/
 ---
 
 If your organization uses LDAP for user authentication, you can configure Rancher to communicate with an OpenLDAP server to authenticate users. This allows Rancher admins to control access to clusters and projects based on users and groups managed externally in the organisation's central user repository, while allowing end-users to authenticate with their LDAP credentials when logging in to the Rancher UI. 
@@ -21,9 +19,10 @@ Configure the settings for the OpenLDAP server, groups and users. For help filli
 
 > Before you proceed with the configuration, please familiarise yourself with the concepts of [External Authentication Configuration and Principal Users]({{<baseurl>}}/rancher/v2.6/en/admin-settings/authentication/#external-authentication-configuration-and-principal-users).
 
-1. Log into the Rancher UI using the initial local `admin` account.
-2. From the **Global** view, navigate to **Security** > **Authentication**
-3. Select **OpenLDAP**. The **Configure an OpenLDAP server** form will be displayed.
+1.	In the top left corner, click **☰ > Users & Authentication**.
+1. In the left navigation menu, click **Auth Provider**.
+1. Click **OpenLDAP**. Fill out the **Configure an OpenLDAP server** form.
+1. Click **Enable**.
 
 ### Test Authentication
 

--- a/content/rancher/v2.6/en/admin-settings/authentication/openldap/openldap-config/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/authentication/openldap/openldap-config/_index.md
@@ -17,9 +17,9 @@ For further details on configuring OpenLDAP, refer to the [official documentatio
 
 ## Background: OpenLDAP Authentication Flow 
  
-1. When a user attempts to login with his LDAP credentials, Rancher creates an initial bind to the LDAP server using a service account with permissions to search the directory and read user/group attributes. 
-2. Rancher then searches the directory for the user by using a search filter based on the provided username and configured attribute mappings. 
-3. Once the user has been found, he is authenticated with another LDAP bind request using the user's DN and provided password. 
+1. When a user attempts to login with LDAP credentials, Rancher creates an initial bind to the LDAP server using a service account with permissions to search the directory and read user/group attributes. 
+2. Rancher then searches the directory for the user by using a search filter based on the provided username and configured attribute mappings.
+3. Once the user has been found, they are authenticated with another LDAP bind request using the user's DN and provided password. 
 4. Once authentication succeeded, Rancher then resolves the group memberships both from the membership attribute in the user's object and by performing a group search based on the configured user mapping attribute.
 
 # OpenLDAP Server Configuration

--- a/content/rancher/v2.6/en/admin-settings/authentication/ping-federate/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/authentication/ping-federate/_index.md
@@ -14,11 +14,10 @@ Assertion Consumer Service (ACS) URL: `https://<rancher-server>/v1-saml/ping/sam
 Note that these URLs will not return valid data until the authentication configuration is saved in Rancher.
 >- Export a `metadata.xml` file from your IdP Server. For more information, see the [PingIdentity documentation](https://documentation.pingidentity.com/pingfederate/pf83/index.shtml#concept_exportingMetadata.html).
 
-1.	From the **Global** view, select **Security > Authentication** from the main menu.
-
-1.	Select **PingIdentity**.
-
-1.	Complete the **Configure Ping Account** form. Ping IdP lets you specify what data store you want to use. You can either add a database or use an existing ldap server. For example, if you select your Active Directory (AD) server, the examples below describe how you can map AD attributes to fields within Rancher.
+1.	In the top left corner, click **☰ > Users & Authentication**.
+1. In the left navigation menu, click **Auth Provider**.
+1. Click **Ping Identity**.
+1.	Complete the **Configure a Ping Account** form. Ping IdP lets you specify what data store you want to use. You can either add a database or use an existing ldap server. For example, if you select your Active Directory (AD) server, the examples below describe how you can map AD attributes to fields within Rancher.
 
     1. **Display Name Field**: Enter the AD attribute that contains the display name of users (example: `displayName`).
 
@@ -40,7 +39,7 @@ Note that these URLs will not return valid data until the authentication configu
     1. **IDP-metadata**: The `metadata.xml` file that you [exported from your IdP server](https://documentation.pingidentity.com/pingfederate/pf83/index.shtml#concept_exportingMetadata.html).
 
 
-1. After you complete the **Configure Ping Account** form, click **Authenticate with Ping**, which is at the bottom of the page.
+1. After you complete the **Configure Ping Account** form, click **Enable**.
 
     Rancher redirects you to the IdP login page. Enter credentials that authenticate with Ping IdP to validate your Rancher PingIdentity configuration.
 

--- a/content/rancher/v2.6/en/admin-settings/authentication/shibboleth/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/authentication/shibboleth/_index.md
@@ -33,12 +33,12 @@ Assertion Consumer Service (ACS) URL: `https://<rancher-server>/v1-saml/shibbole
 >- Export a `metadata.xml` file from your IdP Server. For more information, see the [Shibboleth documentation.](https://wiki.shibboleth.net/confluence/display/SP3/Home)
 
 ### Configure Shibboleth in Rancher
+
 If your organization uses Shibboleth for user authentication, you can configure Rancher to allow your users to log in using their IdP credentials.
 
-1.	From the **Global** view, select **Security > Authentication** from the main menu.
-
-1.	Select **Shibboleth**.
-
+1.	In the top left corner, click **☰ > Users & Authentication**.
+1. In the left navigation menu, click **Auth Provider**.
+1. Click **Shibboleth**.
 1.	Complete the **Configure Shibboleth Account** form. Shibboleth IdP lets you specify what data store you want to use. You can either add a database or use an existing ldap server. For example, if you select your Active Directory (AD) server, the examples below describe how you can map AD attributes to fields within Rancher.
 
     1. **Display Name Field**: Enter the AD attribute that contains the display name of users (example: `displayName`).
@@ -61,7 +61,7 @@ If your organization uses Shibboleth for user authentication, you can configure 
     1. **IDP-metadata**: The `metadata.xml` file that you exported from your IdP server.
 
 
-1. After you complete the **Configure Shibboleth Account** form, click **Authenticate with Shibboleth**, which is at the bottom of the page.
+1. After you complete the **Configure Shibboleth Account** form, click **Enable**.
 
     Rancher redirects you to the IdP login page. Enter credentials that authenticate with Shibboleth IdP to validate your Rancher Shibboleth configuration.
 
@@ -99,8 +99,9 @@ Configure the settings for the OpenLDAP server, groups and users. For help filli
 > Before you proceed with the configuration, please familiarise yourself with the concepts of [External Authentication Configuration and Principal Users]({{<baseurl>}}/rancher/v2.6/en/admin-settings/authentication/#external-authentication-configuration-and-principal-users).
 
 1. Log into the Rancher UI using the initial local `admin` account.
-2. From the **Global** view, navigate to **Security** > **Authentication**
-3. Select **OpenLDAP**. The **Configure an OpenLDAP server** form will be displayed.
+1.	In the top left corner, click **☰ > Users & Authentication**.
+1. In the left navigation menu, click **Auth Provider**.
+1. Click **OpenLDAP**. The **Configure an OpenLDAP server** form will be displayed.
 
 # Troubleshooting
 

--- a/content/rancher/v2.6/en/admin-settings/authentication/user-groups/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/authentication/user-groups/_index.md
@@ -11,7 +11,7 @@ Access to clusters, projects, multi-cluster apps, and global DNS providers and e
 
 When adding a user or group to a resource, you can search for users or groups by beginning to type their name. The Rancher server will query the authentication provider to find users and groups that match what you've entered. Searching is limited to the authentication provider that you are currently logged in with. For example, if you've enabled GitHub authentication but are logged in using a [local]({{<baseurl>}}/rancher/v2.6/en/admin-settings/authentication/local/) user account, you will not be able to search for GitHub users or groups.
 
-All users, whether they are local users or from an authentication provider, can be viewed and managed. From the **Global** view, click on **Users**.
+All users, whether they are local users or from an authentication provider, can be viewed and managed. In the upper left corner, click **☰ > Users & Authentication**. In the left navigation bar, click **Users**.
 
 {{< saml_caveats >}}
 
@@ -23,7 +23,9 @@ Whenever a user logs in to the UI using an authentication provider, Rancher auto
 
 ### Automatically Refreshing User Information
 
-Rancher will periodically refresh the user information even before a user logs in through the UI. You can control how often Rancher performs this refresh.  From the **Global** view, click on **Settings**. Two settings control this behavior:
+Rancher will periodically refresh the user information even before a user logs in through the UI. You can control how often Rancher performs this refresh. 
+
+Two settings control this behavior:
 
 - **`auth-user-info-max-age-seconds`**
 
@@ -33,6 +35,10 @@ Rancher will periodically refresh the user information even before a user logs i
 
     This setting controls a recurring schedule for resyncing authentication provider information for all users. Regardless of whether a user has logged in or used the API recently, this will cause the user to be refreshed at the specified interval. This setting defaults to `0 0 * * *`, i.e. once a day at midnight. See the [Cron documentation](https://en.wikipedia.org/wiki/Cron) for more information on valid values for this setting.
 
+To change these settings,
+
+1. In the upper left corner, click **☰ > Global Settings**.
+1. Go to the setting you want to configure and click **⋮ > Edit Setting**.
 
 > **Note:** Since SAML does not support user lookup, SAML-based authentication providers do not support periodically refreshing user information. User information will only be refreshed when the user logs into the Rancher UI.
 
@@ -40,9 +46,8 @@ Rancher will periodically refresh the user information even before a user logs i
 
 If you are not sure the last time Rancher performed an automatic refresh of user information, you can perform a manual refresh of all users.
 
-1. From the **Global** view, click on **Users** in the navigation bar.
-
-1. Click on **Refresh Group Memberships**.
+1. In the upper left corner, click **☰ > Users & Authentication**.
+1. On the **Users** page, click on **Refresh Group Memberships**.
 
 **Results:** Rancher refreshes the user information for all users. Requesting this refresh will update which users can access Rancher as well as all the groups that each user belongs to.
 
@@ -53,8 +58,8 @@ If you are not sure the last time Rancher performed an automatic refresh of user
 
 The default length (TTL) of each user session is adjustable. The default session length is 16 hours.
 
-1. From the **Global** view, click on **Settings**.
-1. In the **Settings** page, find **`auth-user-session-ttl-minutes`** and click **Edit.**
-1. Enter the amount of time in minutes a session length should last and click **Save.**
+1. In the upper left corner, click **☰ > Global Settings**.
+1. Go to **`auth-user-session-ttl-minutes`** and click **⋮ > Edit Setting**.
+1. Enter the amount of time in minutes a session length should last and click **Save**.
 
 **Result:** Users are automatically logged out of Rancher after the set number of minutes.

--- a/content/rancher/v2.6/en/admin-settings/branding/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/branding/_index.md
@@ -7,7 +7,7 @@ Rancher v2.6 introduced the ability to customize Rancher’s branding and naviga
 
 - [Changing Brand Settings](#changing-brand-settings)
 - [Brand Configuration](#brand-configuration)
-- [Custom Navigation Links in Cluster Explorer](#custom-navigation-links-in-cluster-explorer)
+- [Custom Navigation Links](#custom-navigation-links)
 - [Link Configuration](#link-configuration)
 - [Link Examples](#link-examples)
 
@@ -17,7 +17,7 @@ Rancher v2.6 introduced the ability to customize Rancher’s branding and naviga
 
 To configure the brand settings, 
 
-1. Click **≡ > Global settings**.
+1. Click **☰ > Global settings**.
 2. Click **Branding**.
 
 # Brand Configuration
@@ -42,9 +42,12 @@ You can override the primary color used throughout the UI with a custom color of
 
 Display a custom fixed banner in the header, footer, or both.
 
-# Custom Navigation Links in Cluster Explorer
+# Custom Navigation Links
 
-The links in the left navigation menu in Cluster Explorer can be customized.
+In this section, you'll learn how to configure the links in the left navigation bar of the **Cluster Dashboard**. To get to the cluster dashboard, 
+
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want custom navigation links and click **Explore**.
 
 It can be useful to add a link for quick access to services installed on a cluster. For example, you could add a link to the Kiali UI for clusters with Istio installed, or you could add a link to the Grafana UI for clusters with Rancher monitoring installed.
 
@@ -56,17 +59,18 @@ Links can be created at the top level and multiple links can be grouped together
 
 > **Prerequisite:** You will need to have at least cluster member or project member permissions.
 
-1. In Rancher, go to the Cluster Explorer view where you would like to add custom navigation links.
+1. Click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you would like to add custom navigation links and click **Explore**.
 2. In the top navigation menu, click **🔍 (Resource Search)**.
 3. Type **Nav** and click **Nav Links**.
-4. Click **Create from YAML.**
+4. Click **Create from YAML**.
 5. The simplest way to create a navigation link is to add these fields:
 
         name: linkname
         toURL: https://example.com
 
     For more details on setting up links, including optional fields, see [Link Configuration.](#link-configuration)
-6. Click **Create.**
+6. Click **Create**.
 
 # Link Configuration
 

--- a/content/rancher/v2.6/en/admin-settings/config-private-registry/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/config-private-registry/_index.md
@@ -1,10 +1,9 @@
 ---
 title: Configuring a Global Default Private Registry
 weight: 40
-aliases:
 ---
 
-You might want to use a private Docker registry to share your custom base images within your organization. With a private registry, you can keep a private, consistent, and centralized source of truth for the Docker images that are used in your clusters.
+You might want to use a private Docker registry to share your custom base images within your organization. With a private registry, you can keep a private, consistent, and centralized source of truth for the container images that are used in your clusters.
 
 There are two main ways to set up private registries in Rancher: by setting up the global default registry through the **Settings** tab in the global view, and by setting up a private registry in the advanced options in the cluster-level settings. The global default registry is intended to be used for air-gapped setups, for registries that do not require credentials. The cluster-level private registry is intended to be used in all setups in which the private registry requires credentials.
 
@@ -17,28 +16,23 @@ If your private registry requires credentials, it cannot be used as the default 
 # Setting a Private Registry with No Credentials as the Default Registry
 
 1. Log into Rancher and configure the default administrator password.
-
-1. Go into the **Settings** view.
-
-    {{< img "/img/rancher/airgap/settings.png" "Settings" >}}
-
-1. Look for the setting called `system-default-registry` and choose **Edit**.
-
-    {{< img "/img/rancher/airgap/edit-system-default-registry.png" "Edit" >}}
-
+1. Click **☰ > Global Settings**.
+1. Go to the setting called `system-default-registry` and choose **⋮ > Edit Setting**.
 1. Change the value to your registry (e.g. `registry.yourdomain.com:port`). Do not prefix the registry with `http://` or `https://`.
-
-    {{< img "/img/rancher/airgap/enter-system-default-registry.png" "Save" >}}
 
 **Result:** Rancher will use your private registry to pull system images.
 
 # Setting a Private Registry with Credentials when Deploying a Cluster
 
-You can follow these steps to configure a private registry when you provision a cluster with Rancher:
+You can follow these steps to configure a private registry when you create a cluster:
 
-1. When you create a cluster through the Rancher UI, go to the **Cluster Options** section and click **Show Advanced Options.**
-1. In the <b>Enable Private Registries</b> section, click **Enabled.**
-1. Enter the registry URL and credentials.
-1. Click **Save.**
+1. Click **☰ > Cluster Management**.
+1. On the **Clusters** page, click **Create**.
+1. Choose a cluster type.
+1. In the **Cluster Configuration** go to the **Registries** tab and click **Pull images for Rancher from a private registry**.
+1. Enter the registry hostname and credentials.
+1. Click **Create**.
 
 **Result:** The new cluster will be able to pull images from the private registry.
+
+The private registry cannot be configured after the cluster is created.

--- a/content/rancher/v2.6/en/admin-settings/drivers/cluster-drivers/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/drivers/cluster-drivers/_index.md
@@ -18,23 +18,20 @@ If there are specific cluster drivers that you do not want to show your users, y
 
 By default, Rancher only activates drivers for the most popular cloud providers, Google GKE, Amazon EKS and Azure AKS. If you want to show or hide any node driver, you can change its status.
 
-1.  From the **Global** view, choose **Tools > Drivers** in the navigation bar.
+1. In the upper left corner, click **☰ > Cluster Management**.
 
-2.  From the **Drivers** page, select the **Cluster Drivers** tab.
+2.  In the left navigation menu, click **Drivers**.
 
-3.  Select the driver that you wish to **Activate** or **Deactivate** and select the appropriate icon.
+3.  On the **Cluster Drivers** tab, select the driver that you wish to activate or deactivate and click **⋮ > Activate** or **⋮ > Deactivate**.
 
 ## Adding Custom Cluster Drivers
 
 If you want to use a cluster driver that Rancher doesn't support out-of-the-box, you can add the provider's driver in order to start using them to create _hosted_ kubernetes clusters.
 
-1.  From the **Global** view, choose **Tools > Drivers** in the navigation bar.
-
-2.  From the **Drivers** page select the **Cluster Drivers** tab.
-
-3.  Click **Add Cluster Driver**.
-
-4.  Complete the **Add Cluster Driver** form. Then click **Create**.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. In the left navigation menu, click **Drivers**.
+1.  On the **Cluster Drivers** tab, click **Add Cluster Driver**.
+1.  Complete the **Add Cluster Driver** form. Then click **Create**.
 
 
 ### Developing your own Cluster Driver

--- a/content/rancher/v2.6/en/admin-settings/drivers/node-drivers/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/drivers/node-drivers/_index.md
@@ -1,9 +1,6 @@
 ---
 title: Node Drivers
 weight: 2
-aliases:
-  - /rancher/v2.6/en/concepts/global-configuration/node-drivers/
-  - /rancher/v2.6/en/tasks/global-configuration/node-drivers/
 ---
 
 Node drivers are used to provision hosts, which Rancher uses to launch and manage Kubernetes clusters. A node driver is the same as a [Docker Machine driver](https://docs.docker.com/machine/drivers/). The availability of which node driver to display when creating node templates is defined based on the node driver's status. Only `active` node drivers will be displayed as an option for creating node templates. By default, Rancher is packaged with many existing Docker Machine drivers, but you can also create custom node drivers to add to Rancher.
@@ -21,19 +18,20 @@ If there are specific node drivers that you don't want to show to your users, yo
 
 By default, Rancher only activates drivers for the most popular cloud providers, Amazon EC2, Azure, DigitalOcean and vSphere. If you want to show or hide any node driver, you can change its status.
 
-1.  From the **Global** view, choose **Tools > Drivers** in the navigation bar. From the **Drivers** page, select the **Node Drivers** tab.
+1. In the upper left corner, click **☰ > Cluster Management**.
 
-2.	Select the driver that you wish to **Activate** or **Deactivate** and select the appropriate icon.
+2.  In the left navigation menu, click **Drivers**.
+
+2.	On the **Node Drivers** tab, select the driver that you wish to activate or deactivate and click **⋮ > Activate** or **⋮ > Deactivate**.
 
 ## Adding Custom Node Drivers
 
 If you want to use a node driver that Rancher doesn't support out-of-the-box, you can add that provider's driver in order to start using them to create node templates and eventually node pools for your Kubernetes cluster.
 
-1.  From the **Global** view, choose **Tools > Drivers** in the navigation bar. From the **Drivers** page, select the **Node Drivers** tab.
-
-2.	Click **Add Node Driver**.
-
-3.	Complete the **Add Node Driver** form. Then click **Create**.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. In the left navigation menu, click **Drivers**.
+1. On **Node Drivers** tab, click **Add Node Driver**.
+1.	Complete the **Add Node Driver** form. Then click **Create**.
 
 ### Developing your own node driver
 

--- a/content/rancher/v2.6/en/admin-settings/k8s-metadata/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/k8s-metadata/_index.md
@@ -7,7 +7,7 @@ The RKE metadata feature allows you to provision clusters with new versions of K
 
 > **Note:** The Kubernetes API can change between minor versions. Therefore, we don't support introducing minor Kubernetes versions, such as introducing v1.15 when Rancher currently supports v1.14. You would need to upgrade Rancher to add support for minor Kubernetes versions.
 
-Rancher's Kubernetes metadata contains information specific to the Kubernetes version that Rancher uses to provision [RKE clusters]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/). Rancher syncs the data periodically and creates custom resource definitions (CRDs) for **system images,** **service options** and **addon templates.** Consequently, when a new Kubernetes version is compatible with the Rancher server version, the Kubernetes metadata makes the new version available to Rancher for provisioning clusters. The metadata gives you an overview of the information that the [Rancher Kubernetes Engine]({{<baseurl>}}/rke/latest/en/) (RKE) uses for deploying various Kubernetes versions.
+Rancher's Kubernetes metadata contains information specific to the Kubernetes version that Rancher uses to provision [RKE clusters]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/). Rancher syncs the data periodically and creates custom resource definitions (CRDs) for **system images,** **service options** and **addon templates**. Consequently, when a new Kubernetes version is compatible with the Rancher server version, the Kubernetes metadata makes the new version available to Rancher for provisioning clusters. The metadata gives you an overview of the information that the [Rancher Kubernetes Engine]({{<baseurl>}}/rke/latest/en/) (RKE) uses for deploying various Kubernetes versions.
 
 This table below describes the CRDs that are affected by the periodic data sync. 
 
@@ -29,7 +29,11 @@ Administrators might configure the RKE metadata settings to do the following:
 
 The option to refresh the Kubernetes metadata is available for administrators by default, or for any user who has the **Manage Cluster Drivers** [global role.]({{<baseurl>}}/rancher/v2.6/en/admin-settings/rbac/global-permissions/)
 
-To force Rancher to refresh the Kubernetes metadata, a manual refresh action is available under **Tools > Drivers > Refresh Kubernetes Metadata** on the right side corner. 
+To force Rancher to refresh the Kubernetes metadata, a manual refresh action is available:
+
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. In the left navigation menu, click **Drivers**.
+1. Click **Refresh Kubernetes Metadata**.
 
 You can configure Rancher to only refresh metadata when desired by setting `refresh-interval-minutes` to `0` (see below) and using this button to perform the metadata refresh manually when desired.
 
@@ -43,16 +47,18 @@ The way that the metadata is configured depends on the Rancher version.
 
 To edit the metadata config in Rancher,
 
-1. Go to the **Global** view and click the **Settings** tab.
-1. Go to the **rke-metadata-config** section. Click the **&#8942;** and click **Edit.**
+1. In the upper left corner, click **☰ > Global Settings**.
+1. Go to the **rke-metadata-config** section. Click  **⋮ > Edit Setting**.
 1. You can optionally fill in the following parameters:
 
- - `refresh-interval-minutes`: This is the amount of time that Rancher waits to sync the metadata. To disable the periodic refresh, set `refresh-interval-minutes` to 0.
- - `url`: This is the HTTP path that Rancher fetches data from. The path must be a direct path to a JSON file. For example, the default URL for Rancher v2.4 is `https://releases.rancher.com/kontainer-driver-metadata/release-v2.4/data.json`.
+  - `refresh-interval-minutes`: This is the amount of time that Rancher waits to sync the metadata. To disable the periodic refresh, set `refresh-interval-minutes` to 0.
+  - `url`: This is the HTTP path that Rancher fetches data from. The path must be a direct path to a JSON file. For example, the default URL for Rancher v2.4 is `https://releases.rancher.com/kontainer-driver-metadata/release-v2.4/data.json`.
+1. Click **Save**.
 
 If you don't have an air gap setup, you don't need to specify the URL where Rancher gets the metadata, because the default setting is to pull from [Rancher's metadata Git repository.](https://github.com/rancher/kontainer-driver-metadata/blob/dev-v2.5/data/data.json)
 
 However, if you have an [air gap setup,](#air-gap-setups) you will need to mirror the Kubernetes metadata repository in a location available to Rancher. Then you need to change the URL to point to the new location of the JSON file.
+
 ### Air Gap Setups
 
 Rancher relies on a periodic refresh of the `rke-metadata-config` to download new Kubernetes version metadata if it is supported with the current version of the Rancher server. For a table of compatible Kubernetes and Rancher versions, refer to the [service terms section.](https://rancher.com/support-maintenance-terms/all-supported-versions/rancher-v2.2.8/)

--- a/content/rancher/v2.6/en/admin-settings/pod-security-policies/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/pod-security-policies/_index.md
@@ -1,10 +1,6 @@
 ---
 title: Pod Security Policies
 weight: 60
-aliases:
-    - /rancher/v2.6/en/concepts/global-configuration/pod-security-policies/
-    - /rancher/v2.6/en/tasks/global-configuration/pod-security-policies/
-    - /rancher/v2.6/en/tasks/clusters/adding-a-pod-security-policy/
 ---
 
 _Pod Security Policies_ (or PSPs) are objects that control security-sensitive aspects of pod specification (like root privileges).
@@ -65,14 +61,12 @@ We recommend adding PSPs during cluster and project creation instead of adding i
 
 ### Creating PSPs in the Rancher UI
 
-1.	From the **Global** view, select **Security** > **Pod Security Policies** from the main menu. Then click **Add Policy**.
-
-	**Step Result:** The **Add Policy** form opens.
-
-2. Name the policy.
-
-3. Complete each section of the form. Refer to the [Kubernetes documentation](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) for more information on what each policy does.
-
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. In the left navigation bar, click **Pod Security Policies**.
+1. Click **Add policy**.
+1. Name the policy.
+1. Complete each section of the form. Refer to the [Kubernetes documentation](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) for more information on what each policy does.
+1. Click **Create**.
 
 # Configuration
 

--- a/content/rancher/v2.6/en/admin-settings/rbac/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/rbac/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Role-Based Access Control (RBAC)
 weight: 20
-aliases:
-    - /rancher/v2.6/en/concepts/global-configuration/users-permissions-roles/
 ---
 
 Within Rancher, each person authenticates as a _user_, which is a login that grants you access to Rancher. As mentioned in [Authentication]({{<baseurl>}}/rancher/v2.6/en/admin-settings/authentication/), users can either be local or external.

--- a/content/rancher/v2.6/en/admin-settings/rbac/cluster-project-roles/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/rbac/cluster-project-roles/_index.md
@@ -3,7 +3,12 @@ title: Cluster and Project Roles
 weight: 1127
 ---
 
-Cluster and project roles define user authorization inside a cluster or project. You can manage these roles from the **Global > Security > Roles** page.
+Cluster and project roles define user authorization inside a cluster or project.
+
+To manage these roles, 
+
+1. Click **☰ > Users & Authentication**.
+1. In the left navigation bar, click **Roles** and go to the **Cluster** or **Project/Namespaces** tab.
 
 ### Membership and Role Assignment
 
@@ -58,7 +63,12 @@ The following table lists the permissions available for the `Manage Nodes` role 
 ***In RKE2, you must have permission to edit a cluster to be able to scale clusters up and down.**  
 <br />          
 
-For details on how each cluster role can access Kubernetes resources, you can go to the **Global** view in the Rancher UI. Then click **Security > Roles** and go to the **Clusters** tab. If you click an individual role, you can refer to the **Grant Resources** table to see all of the operations and resources that are permitted by the role.
+For details on how each cluster role can access Kubernetes resources, you can look them up in the Rancher UI:
+
+1. In the upper left corner, click **☰ > Users & Authentication**.
+1. In the left navigation bar, click **Roles**.
+1. Click the **Cluster** tab.
+1. Click the name of an individual role. The table shows all of the operations and resources that are permitted by the role.
 
 > **Note:**
 >When viewing the resources associated with default roles created by Rancher, if there are multiple Kubernetes API resources on one line item, the resource will have `(Custom)` appended to it. These are not custom resources but just an indication that there are multiple Kubernetes API resources as one resource.
@@ -71,16 +81,21 @@ To assign a custom role to a new cluster member, you can use the Rancher UI. To 
 
 To assign the role to a new cluster member,
 
-1. Go to the **Cluster** view, then go to the **Members** tab.
-1. Click **Add Member.** Then in the **Cluster Permissions** section, choose the custom cluster role that should be assigned to the member.
-1. Click **Create.**
+1. Click **☰ > Cluster Management**.
+1. Go to the cluster where you want to assign a role to a member and click **Explore**.
+1. Click **RBAC > Cluster Members**.
+1. Click **Add**.
+1. In the **Cluster Permissions** section, choose the custom cluster role that should be assigned to the member.
+1. Click **Create**.
 
 **Result:** The member has the assigned role.
 
 To assign any custom role to an existing cluster member,
 
-1. Go to the member you want to give the role to. Click the **&#8942; > View in API.**
-1. In the **roleTemplateId** field, go to the drop-down menu and choose the role you want to assign to the member. Click **Show Request** and **Send Request.**
+1. Click **☰ > Users & Authentication**.
+1. Go to the member you want to give the role to. Click the **⋮ > Edit Config**.
+1. If you have added custom roles, they will show in the **Custom** section. Choose the role you want to assign to the member.
+1. Click **Save**.
 
 **Result:** The member has the assigned role.
 
@@ -167,23 +182,16 @@ There are two methods for changing default cluster/project roles:
 
 You can change the cluster or project role(s) that are automatically assigned to the creating user.
 
-1. From the **Global** view, select **Security > Roles** from the main menu. Select either the **Cluster** or **Project** tab.
-
-1. Find the custom or individual role that you want to use as default. Then edit the role by selecting **&#8942; > Edit**.
-
-1. Enable the role as default.
-{{% accordion id="cluster" label="For Clusters" %}}
-1. From **Cluster Creator Default**, choose **Yes: Default role for new cluster creation**.
+1. In the upper left corner, click **☰ > Users & Authentication**.
+1. In the left navigation bar, click **Roles**.
+1. Click the **Cluster** or **Project/Namespaces** tab.
+1. Find the custom or individual role that you want to use as default. Then edit the role by selecting **⋮ > Edit Config**.
+1. In the **Cluster Creator Default** or **Project Creator Default** section, enable the role as the default.
 1. Click **Save**.
-{{% /accordion %}}
-{{% accordion id="project" label="For Projects" %}}
-1. From **Project Creator Default**, choose **Yes: Default role for new project creation**.
-1. Click **Save**.
-{{% /accordion %}}
-
-1. If you want to remove a default role, edit the permission and select **No** from the default roles option.
 
 **Result:** The default roles are configured based on your changes. Roles assigned to cluster/project creators display a check in the **Cluster/Project Creator Default** column.
+
+If you want to remove a default role, edit the permission and select **No** from the default roles option.
 
 ### Cluster Membership Revocation Behavior
 

--- a/content/rancher/v2.6/en/admin-settings/rbac/default-custom-roles/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/rbac/default-custom-roles/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Custom Roles
 weight: 1128
-aliases:
-  - /rancher/v2.6/en/tasks/global-configuration/roles/
 ---
 
 Within Rancher, _roles_ determine what actions a user can make within a cluster or project.
@@ -14,36 +12,35 @@ Note that _roles_ are different from _permissions_, which determine what cluster
 This section covers the following topics:
 
 - [Prerequisites](#prerequisites)
-- [Creating a custom role for a cluster or project](#creating-a-custom-role-for-a-cluster-or-project)
-- [Creating a custom global role](#creating-a-custom-global-role)
-- [Deleting a custom global role](#deleting-a-custom-global-role)
-- [Assigning a custom global role to a group](#assigning-a-custom-global-role-to-a-group)
+- [Creating a custom role](#creating-a-custom-role)
+- [Creating a custom role that inherits from another role](#creating-a-custom-role-that-inherits-from-another-role)
+- [Deleting a custom role](#deleting-a-custom-role)
+- [Assigning a custom role to a group](#assigning-a-custom-role-to-a-group)
 - [Privilege escalation](#privilege-escalation)
 
-## Prerequisites
+# Prerequisites
 
 To complete the tasks on this page, one of the following permissions are required:
 
  - [Administrator Global Permissions]({{<baseurl>}}/rancher/v2.6/en/admin-settings/rbac/global-permissions/).
  - [Custom Global Permissions]({{<baseurl>}}/rancher/v2.6/en/admin-settings/rbac/global-permissions/#custom-global-permissions) with the [Manage Roles]({{<baseurl>}}/rancher/v2.6/en/admin-settings/rbac/global-permissions/) role assigned.
 
-## Creating A Custom Role for a Cluster or Project
+# Creating A Custom Role
 
 While Rancher comes out-of-the-box with a set of default user roles, you can also create default custom roles to provide users with very specific permissions within Rancher.
 
 The steps to add custom roles differ depending on the version of Rancher.
 
-1.  From the **Global** view, select **Security > Roles** from the main menu.
+1. In the upper left corner, click **☰ > Users & Authentication**.
+1. In the left navigation bar, click **Roles**.
+1.  Select a tab to determine the scope of the role you're adding. The tabs are:
 
-1.  Select a tab to determine the scope of the roles you're adding. The tabs are:
+  - **Global:** The role is valid for allowing members to manage global scoped resources.
+  - **Cluster:** The role is valid for assignment when adding/managing members to clusters.
+  - **Project/Namespaces:** The role is valid for assignment when adding/managing members to projects or namespaces.
 
-  - **Cluster:** The role is valid for assignment when adding/managing members to _only_ clusters.
-  - **Project:** The role is valid for assignment when adding/managing members to _only_ projects.
-
-1.  Click **Add Cluster/Project Role.**
-
-1.  **Name** the role.
-
+1.  Click **Create Global Role,** **Create Cluster Role** or **Create Project/Namespaces Role,** depending on the scope.
+1. Enter a **Name** for the role.
 1.  Optional: Choose the **Cluster/Project Creator Default** option to assign this role to a user when they create a new cluster or project. Using this feature, you can expand or restrict the default roles for cluster/project creators.
 
     > Out of the box, the Cluster Creator Default and the Project Creator Default roles are `Cluster Owner` and `Project Owner` respectively.
@@ -56,65 +53,51 @@ The steps to add custom roles differ depending on the version of Rancher.
 
     You can also choose the individual cURL methods (`Create`, `Delete`, `Get`, etc.) available for use with each endpoint you assign.
 
-1.  Use the **Inherit from a Role** options to assign individual Rancher roles to your custom roles. Note: When a custom role inherits from a parent role, the parent role cannot be deleted until the child role is deleted.
+1.  Use the **Inherit from** options to assign individual Rancher roles to your custom roles. Note: When a custom role inherits from a parent role, the parent role cannot be deleted until the child role is deleted.
 
 1.  Click **Create**.
 
-# Creating a Custom Global Role
+# Creating a Custom Role that Inherits from Another Role
 
-### Creating a Custom Global Role that Copies Rules from an Existing Role
+If you have a group of individuals that need the same level of access in Rancher, it can save time to create a custom role in which all of the rules from another role, such as the administrator role, are copied into a new role. This allows you to only configure the variations between the existing role and the new role.
 
-If you have a group of individuals that need the same level of access in Rancher, it can save time to create a custom global role in which all of the rules from another role, such as the administrator role, are copied into a new role. This allows you to only configure the variations between the existing role and the new role.
+The custom role can then be assigned to a user or group so that the role takes effect the first time the user or users sign into Rancher.
 
-The custom global role can then be assigned to a user or group so that the custom global role takes effect the first time the user or users sign into Rancher.
+To create a custom role based on an existing role,
 
-To create a custom global role based on an existing role,
-
-1. Go to the **Global** view and click **Security > Roles.**
-1. On the **Global** tab, go to the role that the custom global role will be based on. Click **&#8942; (…) > Clone.**
+1. In the upper left corner, click **☰ > Users & Authentication**.
+1. In the left navigation bar, click **Roles**.
+1. Click the **Cluster** or **Project/Namespaces** tab. Click **Create Cluster Role** or **Create Project/Namespaces Role** depending on the scope. Note: Only cluster roles and project/namespace roles can inherit from another role.
 1. Enter a name for the role.
-1. Optional: To assign the custom role default for new users, go to the **New User Default** section and click **Yes: Default role for new users.**
-1. In the **Grant Resources** section, select the Kubernetes resource operations that will be enabled for users with the custom role.
+1. In the **Inherit From** tab, select the role(s) that the custom role will inherit permissions from.
+1. In the **Grant Resources** tab, select the Kubernetes resource operations that will be enabled for users with the custom role.
 
     > The Resource text field provides a method to search for pre-defined Kubernetes API resources, or enter a custom resource name for the grant. The pre-defined or `(Custom)` resource must be selected from the dropdown, after entering a resource name into this field.
+1. Optional: Assign the role as default.
+1. Click **Create**.
 
-1. Click **Save.**
+# Deleting a Custom Role
 
-### Creating a Custom Global Role that Does Not Copy Rules from Another Role
+When deleting a custom role, all global role bindings with this custom role are deleted.
 
-Custom global roles don't have to be based on existing roles. To create a custom global role by choosing the specific Kubernetes resource operations that should be allowed for the role, follow these steps:
+If a user is only assigned one custom role, and the role is deleted, the user would lose access to Rancher. For the user to regain access, an administrator would need to edit the user and apply new global permissions.
 
-1. Go to the **Global** view and click **Security > Roles.**
-1. On the **Global** tab, click **Add Global Role.**
-1. Enter a name for the role.
-1. Optional: To assign the custom role default for new users, go to the **New User Default** section and click **Yes: Default role for new users.**
-1. In the **Grant Resources** section, select the Kubernetes resource operations that will be enabled for users with the custom role.
+Custom roles can be deleted, but built-in roles cannot be deleted.
 
-    > The Resource text field provides a method to search for pre-defined Kubernetes API resources, or enter a custom resource name for the grant. The pre-defined or `(Custom)` resource must be selected from the dropdown, after entering a resource name into this field.
-    
-1. Click **Save.**
+To delete a custom role,
 
-# Deleting a Custom Global Role
+1. In the upper left corner, click **☰ > Users & Authentication**.
+1. In the left navigation bar, click **Roles**.
+2. Go to the custom global role that should be deleted and click **⋮ (…) > Delete**.
+3. Click **Delete**.
 
-When deleting a custom global role, all global role bindings with this custom role are deleted.
+# Assigning a Custom Role to a Group
 
-If a user is only assigned one custom global role, and the role is deleted, the user would lose access to Rancher. For the user to regain access, an administrator would need to edit the user and apply new global permissions.
-
-Custom global roles can be deleted, but built-in roles cannot be deleted.
-
-To delete a custom global role,
-
-1. Go to the **Global** view and click **Security > Roles.**
-2. On the **Global** tab, go to the custom global role that should be deleted and click **&#8942; (…) > Delete.**
-3. Click **Delete.**
-
-# Assigning a Custom Global Role to a Group
-
-If you have a group of individuals that need the same level of access in Rancher, it can save time to create a custom global role. When the role is assigned to a group, the users in the group have the appropriate level of access the first time they sign into Rancher.
+If you have a group of individuals that need the same level of access in Rancher, it can save time to create a custom role. When the role is assigned to a group, the users in the group have the appropriate level of access the first time they sign into Rancher.
 
 When a user in the group logs in, they get the built-in Standard User global role by default. They will also get the permissions assigned to their groups.
 
-If a user is removed from the external authentication provider group, they would lose their permissions from the custom global role that was assigned to the group. They would continue to have their individual Standard User role.
+If a user is removed from the external authentication provider group, they would lose their permissions from the custom role that was assigned to the group. They would continue to have their individual Standard User role.
 
 > **Prerequisites:** You can only assign a global role to a group if:
 >
@@ -122,16 +105,16 @@ If a user is removed from the external authentication provider group, they would
 > * The external authentication provider supports [user groups]({{<baseurl>}}/rancher/v2.6/en/admin-settings/authentication/user-groups/)
 > * You have already set up at least one user group with the authentication provider
 
-To assign a custom global role to a group, follow these steps:
+To assign a custom role to a group, follow these steps:
 
-1. From the **Global** view, go to **Security > Groups.**
-1. Click **Assign Global Role.**
-1. In the **Select Group To Add** field, choose the existing group that will be assigned the custom global role.
-1. In the **Custom** section, choose any custom global role that will be assigned to the group.
+1. In the upper left corner, click **☰ > Users & Authentication**.
+1. In the left navigation bar, click **Groups**.
+1. Go to the existing group that will be assigned the custom role and click **⋮ > Edit Config**.
+1. If you have created roles, they will show in the **Custom** section. Choose any custom role that will be assigned to the group.
 1. Optional: In the **Global Permissions** or **Built-in** sections, select any additional permissions that the group should have.
-1. Click **Create.**
+1. Click **Save.**.
 
-**Result:** The custom global role will take effect when the users in the group log into Rancher.
+**Result:** The custom role will take effect when the users in the group log into Rancher.
 
 # Privilege Escalation
 

--- a/content/rancher/v2.6/en/admin-settings/rbac/global-permissions/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/rbac/global-permissions/_index.md
@@ -112,13 +112,25 @@ Global permissions for local users are assigned differently than users who log i
 
 When you create a new local user, you assign them a global permission as you complete the **Add User** form.
 
-To see the default permissions for new users, go to the **Global** view and click **Security > Roles.** On the **Global** tab, there is a column named **New User Default.** When adding a new local user, the user receives all  default global permissions that are marked as checked in this column. You can [change the default global permissions to meet your needs.](#configuring-default-global-permissions)
+To see the default permissions for new users,
+
+1. In the upper left corner, click **☰ > Users & Authentication**.
+1. In the left navigation bar, click **Roles**.
+1. The **Roles** page has tabs for roles grouped by scope. Each table lists the roles in that scope. In the **Global** tab, in the **New User Default** column, the permissions given to new users by default are indicated with a checkmark.
+
+You can [change the default global permissions to meet your needs.](#configuring-default-global-permissions)
 
 ### Global Permissions for Users with External Authentication
 
 When a user logs into Rancher using an external authentication provider for the first time, they are automatically assigned the  **New User Default** global permissions. By default, Rancher assigns the **Standard User** permission for new users.
 
-To see the default permissions for new users, go to the **Global** view and click **Security > Roles.** On the **Global** tab, there is a column named **New User Default.** When adding a new local user, the user receives all default global permissions that are marked as checked in this column, and you can [change them to meet your needs.](#configuring-default-global-permissions)
+To see the default permissions for new users, 
+
+1. In the upper left corner, click **☰ > Users & Authentication**.
+1. In the left navigation bar, click **Roles**.
+1. The **Roles** page has tabs for roles grouped by scope. Each table lists the roles in that scope. In the **New User Default** column on each page, the permissions given to new users by default are indicated with a checkmark.
+
+You can [change the default permissions to meet your needs.](#configuring-default-global-permissions)
 
 Permissions can be assigned to an individual user with [these steps.](#configuring-global-permissions-for-existing-individual-users)
 
@@ -157,14 +169,13 @@ The following table lists each custom global permission available and whether it
 | Manage Settings                    | ✓             |               |           |
 | Manage Users                       | ✓             |               |           |
 | Use Catalog Templates              | ✓             | ✓             |           |
-| User Base\* (Basic log-in access)  | ✓             | ✓             |           |
+| User-Base (Basic log-in access)  | ✓             | ✓             |           |
 
-> \*This role has two names:
->
-> - When you go to the <b>Users</b> tab and edit a user's global role, this role is called <b>Login Access</b> in the custom global permissions list.
-> - When you go to the <b>Security</b> tab and edit the roles from the roles page, this role is called <b>User Base.</b>
+For details on which Kubernetes resources correspond to each global permission,
 
-For details on which Kubernetes resources correspond to each global permission, you can go to the **Global** view in the Rancher UI. Then click **Security > Roles** and go to the **Global** tab. If you click an individual role, you can refer to the **Grant Resources** table to see all of the operations and resources that are permitted by the role.
+1. In the upper left corner, click **☰ > Users & Authentication**.
+1. In the left navigation bar, click **Roles**.
+1.  If you click the name of an individual role, a table shows all of the operations and resources that are permitted by the role.
 
 > **Notes:**
 >
@@ -179,13 +190,10 @@ If you want to restrict the default permissions for new users, you can remove th
 
 To change the default global permissions that are assigned to external users upon their first log in, follow these steps:
 
-1. From the **Global** view, select **Security > Roles** from the main menu. Make sure the **Global** tab is selected.
-
-1. Find the permissions set that you want to add or remove as a default. Then edit the permission by selecting **&#8942; > Edit**.
-
-1. If you want to add the permission as a default, Select **Yes: Default role for new users** and then click **Save**.
-
-1. If you want to remove a default permission, edit the permission and select **No** from **New User Default**.
+1. In the upper left corner, click **☰ > Users & Authentication**.
+1. In the left navigation bar, click **Roles**. On the **Roles** page, make sure the **Global** tab is selected.
+1. Find the permissions set that you want to add or remove as a default. Then edit the permission by selecting **⋮ > Edit Config**.
+1. If you want to add the permission as a default, Select **Yes: Default role for new users** and then click **Save**. If you want to remove a default permission, edit the permission and select **No**.
 
 **Result:** The default global permissions are configured based on your changes. Permissions assigned to new users display a check in the **New User Default** column.
 
@@ -193,15 +201,11 @@ To change the default global permissions that are assigned to external users upo
 
 To configure permission for a user,
 
-1. Go to the **Users** tab.
-
-1. On this page, go to the user whose access level you want to change and click **&#8942; > Edit.**
-
-1. In the **Global Permissions** section, click **Custom.**
-
-1. Check the boxes for each subset of permissions you want the user to have access to.
-
-1. Click **Save.**
+1. In the upper left corner, click **☰ > Users & Authentication**.
+1. In the left navigation bar, click **Users**.
+1. Go to the user whose access level you want to change and click **⋮ > Edit Config**.
+1. In the **Global Permissions** and **Built-in** sections, check the boxes for each permission you want the user to have. If you have created roles from the **Roles** page, they will appear in the **Custom** section and you can choose from them as well.
+1. Click **Save**.
 
 > **Result:** The user's global permissions have been updated.
 
@@ -215,7 +219,7 @@ For existing users, the new permissions will take effect when the users log out 
 
 For new users, the new permissions take effect when the users log in to Rancher for the first time. New users from this group will receive the permissions from the custom global role in addition to the **New User Default** global permissions. By default, the **New User Default** permissions are equivalent to the **Standard User** global role, but the default permissions can be [configured.](#configuring-default-global-permissions)
 
-If a user is removed from the external authentication provider group, they would lose their permissions from the custom global role that was assigned to the group. They would continue to have any remaining roles that were assigned to them, which would typically include the roles marked as **New User Default.** Rancher will remove the permissions that are associated with the group when the user logs out, or when an administrator [refreshes group memberships,](#refreshing-group-memberships) whichever comes first.
+If a user is removed from the external authentication provider group, they would lose their permissions from the custom global role that was assigned to the group. They would continue to have any remaining roles that were assigned to them, which would typically include the roles marked as **New User Default**. Rancher will remove the permissions that are associated with the group when the user logs out, or when an administrator [refreshes group memberships,](#refreshing-group-memberships) whichever comes first.
 
 > **Prerequisites:** You can only assign a global role to a group if:
 >
@@ -225,11 +229,11 @@ If a user is removed from the external authentication provider group, they would
 
 To assign a custom global role to a group, follow these steps:
 
-1. From the **Global** view, go to **Security > Groups.**
-1. Click **Assign Global Role.**
-1. In the **Select Group To Add** field, choose the existing group that will be assigned the custom global role.
+1. In the upper left corner, click **☰ > Users & Authentication**.
+1. In the left navigation bar, click **Groups**.
+1. Go to the group you want to assign a custom global role to and click **⋮ > Edit Config**.
 1. In the **Global Permissions,** **Custom,** and/or **Built-in** sections, select the permissions that the group should have.
-1. Click **Create.**
+1. Click **Create**.
 
 **Result:** The custom global role will take effect when the users in the group log into Rancher.
 
@@ -243,7 +247,8 @@ An administrator might also want to refresh group memberships if a user is remov
 
 To refresh group memberships,
 
-1. From the **Global** view, click **Security > Users.**
-1. Click **Refresh Group Memberships.**
+1. In the upper left corner, click **☰ > Users & Authentication**.
+1. In the left navigation bar, click **Users**.
+1. Click **Refresh Group Memberships**.
 
 **Result:** Any changes to the group members' permissions will take effect.

--- a/content/rancher/v2.6/en/admin-settings/rbac/locked-roles/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/rbac/locked-roles/_index.md
@@ -3,7 +3,7 @@ title: Locked Roles
 weight: 1129
 ---
 
-You can set roles to a status of `locked`. Locking roles prevent them from being assigned users in the future.
+You can set roles to a status of `locked`. Locking roles prevent them from being assigned to users in the future.
 
 Locked roles:
 
@@ -30,8 +30,10 @@ You can lock roles in two contexts:
 - When you're [adding a custom role]({{<baseurl>}}/rancher/v2.6/en/admin-settings/rbac/default-custom-roles/).
 - When you editing an existing role (see below).
 
-1. From the **Global** view, select **Security** > **Roles**.
+Cluster roles and project/namespace roles can be locked, but global roles cannot.
 
-2. From the role that you want to lock (or unlock), select **&#8942;** > **Edit**.
-
-3. From the **Locked** option, choose the **Yes** or **No** radio button. Then click **Save**.
+1. In the upper left corner, click **☰ > Users & Authentication**.
+1. In the left navigation bar, click **Roles**.
+1. Go to the **Cluster** tab or the **Project/Namespaces** tab.
+1. From the role that you want to lock (or unlock), select **⋮ > Edit Config**.
+1. From the **Locked** option, choose the **Yes** or **No** radio button. Then click **Save**.

--- a/content/rancher/v2.6/en/admin-settings/rke-templates/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/rke-templates/_index.md
@@ -67,7 +67,7 @@ Some of the example scenarios include the following:
 
 # Template Management
 
-When you create an RKE template, it is available in the Rancher UI from the **Global** view under **Tools > RKE Templates.** When you create a template, you become the template owner, which gives you permission to revise and share the template. You can share the RKE templates with specific users or groups, and you can also make it public.
+When you create an RKE template, it is available in the Rancher UI from the **Cluster Management** view under **RKE Templates**. When you create a template, you become the template owner, which gives you permission to revise and share the template. You can share the RKE templates with specific users or groups, and you can also make it public.
 
 Administrators can turn on template enforcement to require users to always use RKE templates when creating a cluster. This allows administrators to guarantee that Rancher always provisions clusters with specific settings.
 
@@ -122,4 +122,4 @@ Some things you could do with add-ons include:
 - Install plugins on nodes that are deployed with a Kubernetes daemonset
 - Automatically set up namespaces, service accounts, or role binding
 
-The RKE template configuration must be nested within the `rancher_kubernetes_engine_config` directive. To set add-ons, when creating the template, you will click **Edit as YAML.** Then use the `addons` directive to add a manifest, or the `addons_include` directive to set which YAML files are used for the add-ons. For more information on custom add-ons, refer to the [user-defined add-ons documentation.]({{<baseurl>}}/rke/latest/en/config-options/add-ons/user-defined-add-ons/)
+The RKE template configuration must be nested within the `rancher_kubernetes_engine_config` directive. To set add-ons, when creating the template, you will click **Edit as YAML**. Then use the `addons` directive to add a manifest, or the `addons_include` directive to set which YAML files are used for the add-ons. For more information on custom add-ons, refer to the [user-defined add-ons documentation.]({{<baseurl>}}/rke/latest/en/config-options/add-ons/user-defined-add-ons/)

--- a/content/rancher/v2.6/en/admin-settings/rke-templates/applying-templates/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/rke-templates/applying-templates/_index.md
@@ -21,13 +21,13 @@ This section covers the following topics:
 
 To add a cluster [hosted by an infrastructure provider]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters) using an RKE template, use these steps:
 
-1. From the **Global** view, go to the **Clusters** tab.
-1. Click **Add Cluster** and choose the infrastructure provider.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, click **Create** and choose the infrastructure provider.
 1. Provide the cluster name and node template details as usual.
-1. To use an RKE template, under the **Cluster Options**, check the box for **Use an existing RKE template and revision.**
-1. Choose an existing template and revision from the dropdown menu.
+1. To use an RKE template, under the **Cluster Options**, check the box for **Use an existing RKE template and revision**.
+1. Choose an RKE template and revision from the dropdown menu.
 1. Optional: You can edit any settings that the RKE template owner marked as **Allow User Override** when the template was created. If there are settings that you want to change, but don't have the option to, you will need to contact the template owner to get a new revision of the template. Then you will need to edit the cluster to upgrade it to the new revision.
-1. Click **Save** to launch the cluster.
+1. Click **Create** to launch the cluster.
 
 ### Updating a Cluster Created with an RKE Template
 
@@ -50,9 +50,9 @@ RKE templates cannot be applied to existing clusters, except if you save an exis
 
 To convert an existing cluster to use an RKE template,
 
-1. From the **Global** view in Rancher, click the **Clusters** tab.
-1. Go to the cluster that will be converted to use an RKE template. Click **&#8942;** > **Save as RKE Template.**
-1. Enter a name for the template in the form that appears, and click **Create.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster that will be converted to use an RKE template. Click **⋮  > Save as RKE Template**.
+1. Enter a name for the template in the form that appears, and click **Create**.
 
 **Results:**
 

--- a/content/rancher/v2.6/en/admin-settings/rke-templates/creating-and-revising/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/rke-templates/creating-and-revising/_index.md
@@ -1,9 +1,9 @@
 ---
-title: Creating and Revising Templates
+title: Creating and Revising RKE Templates
 weight: 32
 ---
 
-This section describes how to manage RKE templates and revisions. You an create, share, update, and delete templates from the **Global** view under **Tools > RKE Templates.**
+This section describes how to manage RKE templates and revisions. You an create, share, update, and delete templates from the **Cluster Management** view under **RKE1 Configuration > RKE Templates**.
 
 Template updates are handled through a revision system. When template owners want to change or update a template, they create a new revision of the template. Individual revisions cannot be edited. However, if you want to prevent a revision from being used to create a new cluster, you can disable it.
 
@@ -34,8 +34,9 @@ You can revise, share, and delete a template if you are an owner of the template
 
 ### Creating a Template
 
-1. From the **Global** view, click **Tools > RKE Templates.**
-1. Click **Add Template.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Click **RKE1 configuration > Node Templates**.
+1. Click **Add Template**.
 1. Provide a name for the template. An auto-generated name is already provided for the template' first version, which is created along with this template.
 1. Optional: Share the template with other users or groups by [adding them as members.]({{<baseurl>}}/rancher/v2.6/en/admin-settings/rke-templates/template-access-and-sharing/#sharing-templates-with-specific-users-or-groups) You can also make the template public to share with everyone in the Rancher setup.
 1. Then follow the form on screen to save the cluster configuration parameters as part of the template's revision. The revision can be marked as default for this template.
@@ -50,9 +51,10 @@ You can't edit individual revisions. Since you can't edit individual revisions o
 
 When new template revisions are created, clusters using an older revision of the template are unaffected.
 
-1. From the **Global** view, click **Tools > RKE Templates.**
-1. Go to the template that you want to edit and click the **&#8942; > Edit.**
-1. Edit the required information and click **Save.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. In the left navigation menu, click **RKE1 Configuration > RKE Templates**.
+1. Go to the template that you want to edit and click the **⋮ > Edit**.
+1. Edit the required information and click **Save**.
 1. Optional: You can change the default revision of this template and also change who it is shared with.
 
 **Result:** The template is updated. To apply it to a cluster using an older version of the template, refer to the section on [upgrading a cluster to use a new revision of a template.](#upgrading-a-cluster-to-use-a-new-template-revision)
@@ -61,9 +63,10 @@ When new template revisions are created, clusters using an older revision of the
 
 When you no longer use an RKE template for any of your clusters, you can delete it.
 
-1. From the **Global** view, click **Tools > RKE Templates.**
-1. Go to the RKE template that you want to delete and click the **&#8942; > Delete.**
-1. Confirm the deletion when prompted.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Click **RKE1 configuration > RKE Templates**.
+1. Go to the RKE template that you want to delete and click the **⋮ > Delete**.
+1. Confirm the deletion.
 
 **Result:** The template is deleted.
 
@@ -71,8 +74,9 @@ When you no longer use an RKE template for any of your clusters, you can delete 
 
 You can clone the default template revision and quickly update its settings rather than creating a new revision from scratch. Cloning templates saves you the hassle of re-entering the access keys and other parameters needed for cluster creation.
 
-1. From the **Global** view, click **Tools > RKE Templates.**
-1. Go to the RKE template that you want to clone and click the **&#8942; > New Revision From Default.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. In the left navigation menu, click **RKE1 Configuration > RKE Templates**.
+1. Go to the RKE template that you want to clone and click the **⋮ > New Revision from Default**.
 1. Complete the rest of the form to create a new revision.
 
 **Result:** The RKE template revision is cloned and configured.
@@ -81,8 +85,9 @@ You can clone the default template revision and quickly update its settings rath
 
 When creating new RKE template revisions from your user settings, you can clone an existing revision and quickly update its settings rather than creating a new one from scratch. Cloning template revisions saves you the hassle of re-entering the cluster parameters.
 
-1. From the **Global** view, click **Tools > RKE Templates.**
-1. Go to the template revision you want to clone. Then select **&#8942; > Clone Revision.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Under **RKE1 configuration**, click **RKE Templates**.
+1. Go to the template revision you want to clone. Then select **⋮ > Clone Revision**.
 1. Complete the rest of the form.
 
 **Result:** The RKE template revision is cloned and configured. You can use the RKE template revision later when you provision a cluster. Any existing cluster using this RKE template can be upgraded to this new revision.
@@ -93,8 +98,9 @@ When you no longer want an RKE template revision to be used for creating new clu
 
 You can disable the revision if it is not being used by any cluster.
 
-1. From the **Global** view, click **Tools > RKE Templates.**
-1. Go to the template revision you want to disable. Then select **&#8942; > Disable.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. In the left navigation menu, click **RKE1 Configuration > RKE Templates**.
+1. Go to the template revision you want to disable. Then select **⋮ > Disable**.
 
 **Result:** The RKE template revision cannot be used to create a new cluster.
 
@@ -102,8 +108,9 @@ You can disable the revision if it is not being used by any cluster.
 
 If you decide that a disabled RKE template revision should be used to create new clusters, you can re-enable it.
 
-1. From the **Global** view, click **Tools > RKE Templates.**
-1. Go to the template revision you want to re-enable. Then select **&#8942; > Enable.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Under **RKE1 configuration**, click **RKE Templates**.
+1. Go to the template revision you want to re-enable. Then select **⋮ > Enable**.
 
 **Result:** The RKE template revision can be used to create a new cluster.
 
@@ -113,8 +120,9 @@ When end users create a cluster using an RKE template, they can choose which rev
 
 To set an RKE template revision as default,
 
-1. From the **Global** view, click **Tools > RKE Templates.**
-1. Go to the RKE template revision that should be default and click the **&#8942; > Set as Default.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. In the left navigation menu, click **RKE1 Configuration > RKE templates**.
+1. Go to the RKE template revision that should be default and click the **⋮ > Set as Default**.
 
 **Result:** The RKE template revision will be used as the default option when clusters are created with the template.
 
@@ -124,8 +132,9 @@ You can delete all revisions of a template except for the default revision.
 
 To permanently delete a revision,
 
-1. From the **Global** view, click **Tools > RKE Templates.**
-1. Go to the RKE template revision that should be deleted and click the **&#8942; > Delete.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. In the left navigation menu, click **RKE1 Configuration > RKE templates**.
+1. Go to the RKE template revision that should be deleted and click the **⋮ > Delete**.
 
 **Result:** The RKE template revision is deleted.
 
@@ -136,10 +145,10 @@ To permanently delete a revision,
 
 To upgrade a cluster to use a new template revision,
 
-1. From the **Global** view in Rancher, click the **Clusters** tab.
-1. Go to the cluster that you want to upgrade and click **&#8942; > Edit.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster that you want to upgrade and click **⋮ > Edit Config**.
 1. In the **Cluster Options** section, click the dropdown menu for the template revision, then select the new template revision.
-1. Click **Save.**
+1. Click **Save**.
 
 **Result:** The cluster is upgraded to use the settings defined in the new template revision.
 
@@ -151,9 +160,9 @@ This exports the cluster's settings as a new RKE template, and also binds the cl
 
 To convert an existing cluster to use an RKE template,
 
-1. From the **Global** view in Rancher, click the **Clusters** tab.
-1. Go to the cluster that will be converted to use an RKE template. Click **&#8942;** > **Save as RKE Template.**
-1. Enter a name for the template in the form that appears, and click **Create.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster that will be converted to use an RKE template and **⋮ > Save as RKE Template**.
+1. Enter a name for the RKE template in the form that appears, and click **Create**.
 
 **Results:**
 

--- a/content/rancher/v2.6/en/admin-settings/rke-templates/creator-permissions/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/rke-templates/creator-permissions/_index.md
@@ -9,7 +9,7 @@ For more information on administrator permissions, refer to the [documentation o
 
 # Giving Users Permission to Create Templates
 
-Templates can only be created by users who have the global permission **Create RKE Templates.**
+Templates can only be created by users who have the global permission **Create RKE Templates**.
 
 Administrators have the global permission to create templates, and only administrators can give that permission to other users.
 
@@ -24,8 +24,11 @@ Administrators can give users permission to create RKE templates in two ways:
 
 An administrator can individually grant the role **Create RKE Templates** to any existing user by following these steps:
 
-1. From the global view, click the **Users** tab. Choose the user you want to edit and click the **&#8942; > Edit.**
-1. In the **Global Permissions** section, choose **Custom** and select the **Create RKE Templates** role along with any other roles the user should have. Click **Save.**
+1. In the upper left corner, click **☰ > Users & Authentication**.
+1. In the left navigation bar, click **Users**.
+1. Choose the user you want to edit and click **⋮ > Edit Config**.
+1. In the **Built-in** section, check the box for **Create new RKE Cluster Templates** role along with any other roles the user should have. You may want to also check the box for **Create RKE Template Revisions**.
+1. Click **Save**.
 
 **Result:** The user has permission to create RKE templates.
 
@@ -33,18 +36,23 @@ An administrator can individually grant the role **Create RKE Templates** to any
 
 Alternatively, the administrator can give all new users the default permission to create RKE templates by following the following steps. This will not affect the permissions of existing users.
 
-1. From the **Global** view, click **Security > Roles.**
-1. Under the **Global** roles tab, go to the role **Create RKE Templates** and click the **&#8942; > Edit**.
-1. Select the option **Yes: Default role for new users** and click **Save.**
+1. In the upper left corner, click **☰ > Users & Authentication**.
+1. In the left navigation bar, click **Roles**.
+1. Go to the role named **Create new RKE Cluster Templates and click **⋮ > Edit Config**.
+1. Select the option **Yes: Default role for new users**.
+1. Click **Save**.
+1. If you would like new users to also be able to create RKE template revisions, enable that role as default as well.
 
 **Result:** Any new user created in this Rancher installation will be able to create RKE templates. Existing users will not get this permission.
 
 ### Revoking Permission to Create Templates
 
-Administrators can remove a user's permission to create templates with the following steps:
+Administrators can remove a user's permission to create templates with the following steps. Note: Administrators have full control over all resources regardless of whether fine-grained permissions are selected.
 
-1. From the global view, click the **Users** tab. Choose the user you want to edit and click the **&#8942; > Edit.**
-1. In the **Global Permissions** section, un-check the box for **Create RKE Templates**. In this section, you can change the user back to a standard user, or give the user a different set of custom permissions.
-1. Click **Save.**
+1. In the upper left corner, click **☰ > Users & Authentication**.
+1. In the left navigation bar, click **Users**.
+1. Choose the user you want to edit permissions for and click **⋮ > Edit Config**.
+1. In the **Built-in** section, un-check the box for **Create RKE Templates** and **Create RKE Template Revisions,** if applicable. In this section, you can change the user back to a standard user, or give the user a different set of permissions.
+1. Click **Save**.
 
 **Result:** The user cannot create RKE templates.

--- a/content/rancher/v2.6/en/admin-settings/rke-templates/enforcement/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/rke-templates/enforcement/_index.md
@@ -21,9 +21,9 @@ You might want to require new clusters to use a template to ensure that any clus
 
 To require new clusters to use an RKE template, administrators can turn on RKE template enforcement with the following steps:
 
-1. From the **Global** view, click the **Settings** tab.
-1. Go to the `cluster-template-enforcement` setting. Click the vertical **&#8942;** and click **Edit.**
-1. Set the value to **True** and click **Save.**
+1. Click **☰ > Global Settings**.
+1. Go to the `cluster-template-enforcement` setting. Click **⋮ > Edit Setting**.
+1. Set the value to **True** and click **Save**.
 
 **Result:** All clusters provisioned by Rancher must use a template, unless the creator is an administrator.
 
@@ -31,8 +31,8 @@ To require new clusters to use an RKE template, administrators can turn on RKE t
 
 To allow new clusters to be created without an RKE template, administrators can turn off RKE template enforcement with the following steps:
 
-1. From the **Global** view, click the **Settings** tab.
-1. Go to the `cluster-template-enforcement` setting. Click the vertical **&#8942;** and click **Edit.**
-1. Set the value to **False** and click **Save.**
+1. Click **☰ > Global Settings**.
+1. Go to the `cluster-template-enforcement` setting. Click **⋮ > Edit Setting**.
+1. Set the value to **False** and click **Save**.
 
 **Result:** When clusters are provisioned by Rancher, they don't need to use a template.

--- a/content/rancher/v2.6/en/admin-settings/rke-templates/example-scenarios/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/rke-templates/example-scenarios/_index.md
@@ -52,7 +52,7 @@ The template owner has several options for allowing the cluster creators to upgr
 
 - **Specify Kubernetes v1.15 on the template:** The template owner can create a new template revision that specifies Kubernetes v1.15. Then the owner of each cluster that uses that template can upgrade their cluster to a new revision of the template. This template upgrade allows the cluster creator to upgrade Kubernetes to v1.15 on their cluster.
 - **Allow any Kubernetes version on the template:** When creating a template revision, the template owner can also mark the the Kubernetes version as **Allow User Override** using the switch near that setting on the Rancher UI. This will allow clusters that upgrade to this template revision to use any version of Kubernetes.
-- **Allow the latest minor Kubernetes version on the template:** The template owner can also create a template revision in which the Kubernetes version is defined as **Latest v1.14 (Allows patch version upgrades).** This means clusters that use that revision will be able to get patch version upgrades, but major version upgrades will not be allowed.
+- **Allow the latest minor Kubernetes version on the template:** The template owner can also create a template revision in which the Kubernetes version is defined as **Latest v1.14 (Allows patch version upgrades)**. This means clusters that use that revision will be able to get patch version upgrades, but major version upgrades will not be allowed.
 
 # Allowing Other Users to Control and Share a Template
 

--- a/content/rancher/v2.6/en/admin-settings/rke-templates/overrides/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/rke-templates/overrides/_index.md
@@ -3,9 +3,9 @@ title: Overriding Template Settings
 weight: 33
 ---
 
-When a user creates an RKE template, each setting in the template has a switch in the Rancher UI that indicates if users can override the setting. This switch marks those settings as **Allow User Override.**
+When a user creates an RKE template, each setting in the template has a switch in the Rancher UI that indicates if users can override the setting. This switch marks those settings as **Allow User Override**.
 
-After a cluster is created with a template, end users can't update any of the settings defined in the template unless the template owner marked them as **Allow User Override.** However, if the template is [updated to a new revision]({{<baseurl>}}/rancher/v2.6/en/admin-settings/rke-templates/creating-and-revising) that changes the settings or allows end users to change them, the cluster can be upgraded to a new revision of the template and the changes in the new revision will be applied to the cluster.
+After a cluster is created with a template, end users can't update any of the settings defined in the template unless the template owner marked them as **Allow User Override**. However, if the template is [updated to a new revision]({{<baseurl>}}/rancher/v2.6/en/admin-settings/rke-templates/creating-and-revising) that changes the settings or allows end users to change them, the cluster can be upgraded to a new revision of the template and the changes in the new revision will be applied to the cluster.
 
 When any parameter is set as **Allow User Override** on the RKE template, it means that end users have to fill out those fields during cluster creation and they can edit those settings afterward at any time.
 

--- a/content/rancher/v2.6/en/admin-settings/rke-templates/template-access-and-sharing/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/rke-templates/template-access-and-sharing/_index.md
@@ -27,20 +27,23 @@ There are several ways to share templates:
 
 To allow users or groups to create clusters using your template, you can give them the basic **User** access level for the template.
 
-1. From the **Global** view, click **Tools > RKE Templates.**
-1. Go to the template that you want to share and click the **&#8942; > Edit.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Under **RKE1 configuration**, click **RKE Templates**.
+1. Go to the template that you want to share and click the **⋮ > Edit**.
 1. In the **Share Template** section, click on **Add Member**.
 1. Search in the **Name** field for the user or group you want to share the template with.
 1. Choose the **User** access type.
-1. Click **Save.**
+1. Click **Save**.
 
 **Result:** The user or group can create clusters using the template.
 
 ### Sharing Templates with All Users
 
-1. From the **Global** view, click **Tools > RKE Templates.**
-1. Go to the template that you want to share and click the **&#8942; > Edit.**
-1. Under **Share Template,** click **Make Public (read-only).** Then click **Save.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. In the left navigation menu, click **RKE1 Configuration > RKE Templates**.
+1. Go to the template that you want to share and click the **⋮ > Edit**.
+1. Under **Share Template,** check the box for **Make Public (read-only)**.
+1. Click **Save**.
 
 **Result:** All users in the Rancher setup can create clusters using the template.
 
@@ -52,10 +55,11 @@ In that case, you can give users the Owner access type, which allows another use
 
 To give Owner access to a user or group,
 
-1. From the **Global** view, click **Tools > RKE Templates.**
-1. Go to the RKE template that you want to share and click the **&#8942; > Edit.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Under **RKE1 configuration**, click **RKE Templates**.
+1. Go to the RKE template that you want to share and click the **⋮ > Edit**.
 1. Under **Share Template**, click on **Add Member** and search in the **Name** field for the user or group you want to share the template with.
-1. In the **Access Type** field, click **Owner.**
-1. Click **Save.**
+1. In the **Access Type** field, click **Owner**.
+1. Click **Save**.
 
 **Result:** The user or group has the Owner access type, and can modify, share, or delete the template.

--- a/content/rancher/v2.6/en/api/api-tokens/_index.md
+++ b/content/rancher/v2.6/en/api/api-tokens/_index.md
@@ -1,8 +1,6 @@
 ---
 title: API Tokens
 weight: 1
-aliases:
-  - /rancher/v2.6/en/cluster-admin/api/api-tokens/
 ---
 
 By default, some cluster-level API tokens are generated with infinite time-to-live (`ttl=0`). In other words, API tokens with `ttl=0` never expire unless you invalidate them. Tokens are not invalidated by changing a password.
@@ -16,7 +14,7 @@ To delete a token,
 
 1. Access the token you want to delete by its ID. For example, `https://<Rancher-Server-IP>/v3/tokens/kubectl-shell-user-vqkqt`
 
-1. Click **Delete.**
+1. Click **Delete**.
 
 Here is the complete list of tokens that are generated with `ttl=0`:
 

--- a/content/rancher/v2.6/en/backups/_index.md
+++ b/content/rancher/v2.6/en/backups/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Backups and Disaster Recovery
 weight: 5
-aliases:
-  - /rancher/v2.6/en/backups/v2.6
 ---
 
 In this section, you'll learn how to create backups of Rancher, how to restore Rancher from backup, and how to migrate Rancher to a new Kubernetes cluster. 
@@ -51,28 +49,19 @@ The `rancher-backup` operator can be installed from the Rancher UI, or with the 
 
 ### Installing rancher-backup with the Rancher UI
 
-1. In the Rancher UI's Cluster Manager, choose the cluster named **local**
-1. On the upper-right click on the **Cluster Explorer.**
-1. Click **Apps.**
-1. Click the `rancher-backup` operator.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the `local` cluster and click **Explore**.
+1. In the left navigation bar, **Apps & Marketplace > Charts**.
+1. Click **Rancher Backups**.
+1. Click **Install**.
 1. Optional: Configure the default storage location. For help, refer to the [configuration section.](./configuration/storage-config)
+1. Click **Install**.
 
 **Result:** The `rancher-backup` operator is installed.
 
-From the **Cluster Explorer,** you can see the `rancher-backup` operator listed under **Deployments.**
+From the **Cluster Dashboard,** you can see the `rancher-backup` operator listed under **Deployments**.
 
-To configure the backup app in Rancher, click **Cluster Explorer** in the upper left corner and click **Rancher Backups.**
-
-### Installing rancher-backup with the Helm CLI
-
-Install the backup app as a Helm chart:
-
-```
-helm repo add rancher-charts https://charts.rancher.io
-helm repo update
-helm install rancher-backup-crd rancher-charts/rancher-backup-crd -n cattle-resources-system --create-namespace
-helm install rancher-backup rancher-charts/rancher-backup -n cattle-resources-system
-```
+To configure the backup app in Rancher, go to the left navigation menu and click **Rancher Backups**.
 
 ### RBAC
 

--- a/content/rancher/v2.6/en/backups/back-up-rancher/_index.md
+++ b/content/rancher/v2.6/en/backups/back-up-rancher/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Backing up Rancher
 weight: 1
-aliases:
-  - /rancher/v2.6/en/backups/v2.5/back-up-rancher
 ---
 
 In this section, you'll learn how to back up Rancher running on any Kubernetes cluster. To backup Rancher installed with Docker, refer the instructions for [single node backups]({{<baseurl>}}/rancher/v2.6/en/backups/v2.5/docker-installs/docker-backups)
@@ -11,28 +9,33 @@ The backup-restore operator needs to be installed in the local cluster, and only
 
 ### Prerequisites
 
-Rancher version must be v2.5.0 and up
+The Rancher version must be v2.5.0 and up.
 
-### 1. Install the `rancher-backup` operator
+### 1. Install the Rancher Backups operator
 
-The backup storage location is an operator-level setting, so it needs to be configured when `rancher-backup` is installed or upgraded.
+The backup storage location is an operator-level setting, so it needs to be configured when the Rancher Backups application is installed or upgraded.
 
 Backups are created as .tar.gz files. These files can be pushed to S3 or Minio, or they can be stored in a persistent volume.
 
-1. In the Rancher UI, go to the **Cluster Explorer** view for the local cluster.
-1. Click **Apps.**
-1. Click **Rancher Backups.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the `local` cluster and click **Explore**. The `local` cluster runs the Rancher server.
+1. Click **Apps & Marketplace > Charts**.
+1. Click **Rancher Backups**.
+1. Click **Install**.
 1. Configure the default storage location. For help, refer to the [storage configuration section.](../configuration/storage-config)
+1. Click **Install**.
 
 ### 2. Perform a Backup
 
 To perform a backup, a custom resource of type Backup must be created.
 
-1. In the **Cluster Explorer,** go to the dropdown menu in the upper left corner and click **Rancher Backups.**
-1. Click **Backup.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the `local` cluster and click **Explore**.
+1. In the left navigation bar, click **Rancher Backups > Backups**.
+1. Click **Create**.
 1. Create the Backup with the form, or with the YAML editor.
 1. For configuring the Backup details using the form, click **Create** and refer to the [configuration reference](../configuration/backup-config) and to the [examples.](../examples/#backup)
-1. For using the YAML editor, we can click **Create > Create from YAML.** Enter the Backup YAML. This example Backup custom resource would create encrypted recurring backups in S3. The app uses the `credentialSecretNamespace` value to determine where to look for the S3 backup secret:
+1. For using the YAML editor, we can click **Create > Create from YAML**. Enter the Backup YAML. This example Backup custom resource would create encrypted recurring backups in S3. The app uses the `credentialSecretNamespace` value to determine where to look for the S3 backup secret:
 
     ```yaml
     apiVersion: resources.cattle.io/v1
@@ -59,7 +62,7 @@ To perform a backup, a custom resource of type Backup must be created.
     For help configuring the Backup, refer to the [configuration reference](../configuration/backup-config) and to the [examples.](../examples/#backup)    
 
     > **Important:** The `rancher-backup` operator doesn't save the EncryptionConfiguration file. The contents of the EncryptionConfiguration file must be saved when an encrypted backup is created, and the same file must be used when restoring from this backup.
-1. Click **Create.**
+1. Click **Create**.
 
 **Result:** The backup file is created in the storage location configured in the Backup custom resource. The name of this file is used when performing a restore.
 

--- a/content/rancher/v2.6/en/backups/configuration/_index.md
+++ b/content/rancher/v2.6/en/backups/configuration/_index.md
@@ -2,8 +2,6 @@
 title: Rancher Backup Configuration Reference
 shortTitle: Configuration
 weight: 4
-aliases:
-  - /rancher/v2.6/en/backups/v2.5/configuration
 ---
 
 - [Backup configuration](./backup-config)

--- a/content/rancher/v2.6/en/backups/configuration/backup-config/_index.md
+++ b/content/rancher/v2.6/en/backups/configuration/backup-config/_index.md
@@ -2,13 +2,9 @@
 title: Backup Configuration
 shortTitle: Backup
 weight: 1
-aliases:
-  - /rancher/v2.6/en/backups/v2.5/configuration/backup-config
 ---
 
 The Backup Create page lets you configure a schedule, enable encryption and specify the storage location for your backups.
-
-{{< img "/img/rancher/backup_restore/backup/backup.png" "">}}
 
 - [Schedule](#schedule)
 - [Encryption](#encryption)
@@ -20,7 +16,6 @@ The Backup Create page lets you configure a schedule, enable encryption and spec
   - [IAM Permissions for EC2 Nodes to Access S3](#iam-permissions-for-ec2-nodes-to-access-s3)
 - [Examples](#examples)
 
-
 # Schedule
 
 Select the first option to perform a one-time backup, or select the second option to schedule recurring backups. Selecting **Recurring Backups** lets you configure following two fields:
@@ -29,8 +24,6 @@ Select the first option to perform a one-time backup, or select the second optio
   - Standard [cron expressions](https://en.wikipedia.org/wiki/Cron), such as `"0 * * * *"`
   - Descriptors, such as `"@midnight"` or `"@every 1h30m"`
 -  **Retention Count**: This value specifies how many backup files must be retained. If files exceed the given retentionCount,  the oldest files will be deleted. The default value is 10.
-
-{{< img "/img/rancher/backup_restore/backup/schedule.png" "">}}
 
 | YAML Directive Name | Description |
 | ---------------- | ---------------- |
@@ -74,8 +67,6 @@ In the example command above, the name `encryptionconfig` can be changed to anyt
 | `encryptionConfigSecretName` |  Provide the name of the Secret from `cattle-resources-system` namespace, that contains the encryption config file.  |
 
 # Storage Location
-
-{{< img "/img/rancher/backup_restore/backup/storageLocation.png" "">}}
 
 If the StorageLocation is specified in the Backup, the operator will retrieve the backup location from that particular S3 bucket. If not specified, the operator will try to find this file in the default operator-level S3 store, and in the operator-level PVC store. The default storage location is configured during the deployment of the `rancher-backup` operator.
 

--- a/content/rancher/v2.6/en/backups/configuration/restore-config/_index.md
+++ b/content/rancher/v2.6/en/backups/configuration/restore-config/_index.md
@@ -2,8 +2,6 @@
 title: Restore Configuration
 shortTitle: Restore
 weight: 2
-aliases:
-  - /rancher/v2.6/en/backups/v2.5/configuration/restore-config
 ---
 
 The Restore Create page lets you provide details of the backup to restore from

--- a/content/rancher/v2.6/en/backups/configuration/storage-config/_index.md
+++ b/content/rancher/v2.6/en/backups/configuration/storage-config/_index.md
@@ -2,8 +2,6 @@
 title: Backup Storage Location Configuration
 shortTitle: Storage
 weight: 3
-aliases:
-  - /rancher/v2.6/en/backups/v2.5/configuration/storage-config
 ---
 
 Configure a storage location where all backups are saved by default. You will have the option to override this with each backup, but will be limited to using an S3-compatible object store.

--- a/content/rancher/v2.6/en/backups/docker-installs/_index.md
+++ b/content/rancher/v2.6/en/backups/docker-installs/_index.md
@@ -2,9 +2,6 @@
 title: Backup and Restore for Rancher Installed with Docker
 shortTitle: Docker Installs
 weight: 10
-aliases:
-  - /rancher/v2.6/en/installation/backups-and-restoration/single-node-backup-and-restoration/
-  - /rancher/v2.6/en/backups/v2.5/docker-installs
 ---
 
 - [Backups](./docker-backups)

--- a/content/rancher/v2.6/en/backups/docker-installs/docker-backups/_index.md
+++ b/content/rancher/v2.6/en/backups/docker-installs/docker-backups/_index.md
@@ -2,12 +2,6 @@
 title: Backing up Rancher Installed with Docker
 shortTitle: Backups
 weight: 3
-aliases:
-  - /rancher/v2.6/en/installation/after-installation/single-node-backup-and-restoration/
-  - /rancher/v2.6/en/installation/after-installation/single-node-backup-and-restoration/
-  - /rancher/v2.6/en/backups/backups/single-node-backups/
-  - /rancher/v2.6/en/backups/legacy/backup/single-node-backups/
-  - /rancher/v2.6/en/backups/v2.5/docker-installs/docker-backups/
 ---
 
 

--- a/content/rancher/v2.6/en/backups/docker-installs/docker-restores/_index.md
+++ b/content/rancher/v2.6/en/backups/docker-installs/docker-restores/_index.md
@@ -2,10 +2,6 @@
 title: Restoring Backups—Docker Installs
 shortTitle: Restores
 weight: 3
-aliases:
-  - /rancher/v2.6/en/installation/after-installation/single-node-backup-and-restoration/
-  - /rancher/v2.6/en/backups/restorations/single-node-restoration
-  - /rancher/v2.6/en/backups/v2.5/docker-installs/docker-restores
 ---
 
 If you encounter a disaster scenario, you can restore your Rancher Server to your most recent backup.

--- a/content/rancher/v2.6/en/backups/examples/_index.md
+++ b/content/rancher/v2.6/en/backups/examples/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Examples
 weight: 5
-aliases:
-  - /rancher/v2.6/en/backups/v2.5/examples
 ---
 
 This section contains examples of Backup and Restore custom resources.

--- a/content/rancher/v2.6/en/backups/restoring-rancher/_index.md
+++ b/content/rancher/v2.6/en/backups/restoring-rancher/_index.md
@@ -1,9 +1,6 @@
 ---
 title: Restoring Rancher
 weight: 2
-aliases:
-  - /rancher/v2.x/en/installation/backups/restores
-  - /rancher/v2.x/en/backups/restoring-rancher
 ---
 
 A restore is performed by creating a Restore custom resource. 
@@ -15,10 +12,12 @@ A restore is performed by creating a Restore custom resource.
 
 ### Create the Restore Custom Resource
 
-1. In the **Cluster Explorer,** go to the dropdown menu in the upper left corner and click **Rancher Backups.**
-1. Click **Restore.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the `local` cluster and click **Explore**. The `local` cluster runs the Rancher server.
+1. In the left navigation bar, click **Rancher Backups > Restores**.
+1. Click **Create**.
 1. Create the Restore with the form, or with YAML.  For creating the Restore resource using form, refer to the [configuration reference]({{<baseurl>}}/rancher/v2.6/en/backups/configuration/restore-config) and to the [examples.]({{<baseurl>}}/rancher/v2.6/en/backups/examples)
-1. For using the YAML editor, we can click **Create > Create from YAML.** Enter the Restore YAML.
+1. For using the YAML editor, we can click **Create > Create from YAML**. Enter the Restore YAML.
 
     ```yaml
     apiVersion: resources.cattle.io/v1
@@ -40,7 +39,7 @@ A restore is performed by creating a Restore custom resource.
 
       For help configuring the Restore, refer to the [configuration reference]({{<baseurl>}}/rancher/v2.6/en/backups/configuration/restore-config) and to the [examples.]({{<baseurl>}}/rancher/v2.6/en/backups/examples)
 
-1. Click **Create.**
+1. Click **Create**.
 
 **Result:** The rancher-operator scales down the rancher deployment during restore, and scales it back up once the restore completes. The resources are restored in this order:
 
@@ -54,7 +53,7 @@ To check how the restore is progressing, you can check the logs of the operator.
 
 ```
 kubectl logs -n cattle-resources-system -l app.kubernetes.io/name=rancher-backup -f
-
+```
 
 ### Cleanup
 

--- a/content/rancher/v2.6/en/best-practices/_index.md
+++ b/content/rancher/v2.6/en/best-practices/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Best Practices Guide
 weight: 4
-aliases:
-  - /rancher/v2.6/en/best-practices/v2.5
 ---
 
 The purpose of this section is to consolidate best practices for Rancher implementations. This also includes recommendations for related technologies, such as Kubernetes, Docker, containers, and more. The objective is to improve the outcome of a Rancher implementation using the operational experience of Rancher and its customers.

--- a/content/rancher/v2.6/en/best-practices/rancher-managed/_index.md
+++ b/content/rancher/v2.6/en/best-practices/rancher-managed/_index.md
@@ -2,8 +2,6 @@
 title: Best Practices for Rancher Managed Clusters
 shortTitle: Rancher Managed Clusters
 weight: 2
-aliases:
-  - /rancher/v2.6/en/best-practices/v2.5/rancher-managed
 ---
 
 ### Logging

--- a/content/rancher/v2.6/en/best-practices/rancher-managed/containers/_index.md
+++ b/content/rancher/v2.6/en/best-practices/rancher-managed/containers/_index.md
@@ -1,9 +1,6 @@
 ---
 title: Tips for Setting Up Containers
 weight: 100
-aliases:
-  - /rancher/v2.6/en/best-practices/containers
-  - /rancher/v2.6/en/best-practices/v2.5/rancher-managed/containers
 ---
 
 Running well-built containers can greatly impact the overall performance and security of your environment.

--- a/content/rancher/v2.6/en/best-practices/rancher-managed/logging/_index.md
+++ b/content/rancher/v2.6/en/best-practices/rancher-managed/logging/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Logging Best Practices
 weight: 1
-aliases:
-  - /rancher/v2.6/en/best-practices/v2.6/rancher-managed/logging
 ---
 In this guide, we recommend best practices for cluster-level logging and application logging.
 

--- a/content/rancher/v2.6/en/best-practices/rancher-managed/managed-vsphere/_index.md
+++ b/content/rancher/v2.6/en/best-practices/rancher-managed/managed-vsphere/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Best Practices for Rancher Managed vSphere Clusters
 shortTitle: Rancher Managed Clusters in vSphere
-aliases:
-  - /rancher/v2.6/en/best-practices/v2.5/rancher-managed/managed-vsphere
 ---
 
 This guide outlines a reference architecture for provisioning downstream Rancher clusters in a vSphere environment, in addition to standard vSphere best practices as documented by VMware.

--- a/content/rancher/v2.6/en/best-practices/rancher-managed/monitoring/_index.md
+++ b/content/rancher/v2.6/en/best-practices/rancher-managed/monitoring/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Monitoring Best Practices
 weight: 2
-aliases:
-  - /rancher/v2.6/en/best-practices/v2.5/rancher-managed/monitoring
 ---
 
 Configuring sensible monitoring and alerting rules is vital for running any production workloads securely and reliably. This is not different when using Kubernetes and Rancher. Fortunately the integrated monitoring and alerting functionality makes this whole process a lot easier.

--- a/content/rancher/v2.6/en/best-practices/rancher-server/_index.md
+++ b/content/rancher/v2.6/en/best-practices/rancher-server/_index.md
@@ -2,8 +2,6 @@
 title: Best Practices for the Rancher Server
 shortTitle: Rancher Server
 weight: 1
-aliases:
-  - /rancher/v2.6/en/best-practices/v2.5/rancher-server
 ---
 
 This guide contains our recommendations for running the Rancher server, and is intended to be used in situations in which Rancher manages downstream Kubernetes clusters.

--- a/content/rancher/v2.6/en/best-practices/rancher-server/deployment-strategies/_index.md
+++ b/content/rancher/v2.6/en/best-practices/rancher-server/deployment-strategies/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Rancher Deployment Strategy
 weight: 100
-aliases:
-  - /rancher/v2.6/en/best-practices/v2.5/rancher-server/deployment-strategies
 ---
 
 There are two recommended deployment strategies for a Rancher server that manages downstream Kubernetes clusters. Each one has its own pros and cons. Read more about which one would fit best for your use case:

--- a/content/rancher/v2.6/en/best-practices/rancher-server/deployment-types/_index.md
+++ b/content/rancher/v2.6/en/best-practices/rancher-server/deployment-types/_index.md
@@ -1,9 +1,6 @@
 ---
 title: Tips for Running Rancher
 weight: 100
-aliases:
-  - /rancher/v2.6/en/best-practices/deployment-types
-  - /rancher/v2.6/en/best-practices/v2.5/rancher-server/deployment-types
 ---
 
 This guide is geared toward use cases where Rancher is used to manage downstream Kubernetes clusters. The high-availability setup is intended to prevent losing access to downstream clusters if the Rancher server is not available.

--- a/content/rancher/v2.6/en/best-practices/rancher-server/rancher-in-vsphere/_index.md
+++ b/content/rancher/v2.6/en/best-practices/rancher-server/rancher-in-vsphere/_index.md
@@ -2,8 +2,6 @@
 title: Installing Rancher in a vSphere Environment
 shortTitle: On-Premises Rancher in vSphere
 weight: 3
-aliases:
-  - /rancher/v2.6/en/best-practices/v2.5/rancher-server/rancher-in-vsphere
 ---
 
 This guide outlines a reference architecture for installing Rancher on an RKE Kubernetes cluster in a vSphere environment, in addition to standard vSphere best practices as documented by VMware.

--- a/content/rancher/v2.6/en/cis-scans/_index.md
+++ b/content/rancher/v2.6/en/cis-scans/_index.md
@@ -1,8 +1,6 @@
 ---
 title: CIS Scans
 weight: 17
-aliases:
-  - /rancher/v2.6/en/cis-scans/v2.6
 ---
 
 Rancher can run a security scan to check whether Kubernetes is deployed according to security best practices as defined in the CIS Kubernetes Benchmark. The CIS scans can run on any Kubernetes cluster, including hosted Kubernetes providers such as EKS, AKS, and GKE.
@@ -16,8 +14,8 @@ The `rancher-cis-benchmark` app leverages <a href="https://github.com/aquasecuri
 - [Roles-based Access Control](./rbac)
 - [Configuration](./configuration)
 - [How-to Guides](#how-to-guides)
-  - [Installing rancher-cis-benchmark](#installing-rancher-cis-benchmark)
-  - [Uninstalling rancher-cis-benchmark](#uninstalling-rancher-cis-benchmark)
+  - [Installing CIS Benchmark](#installing-cis-benchmark)
+  - [Uninstalling CIS Benchmark](#uninstalling-cis-benchmark)
   - [Running a Scan](#running-a-scan)
   - [Running a Scan Periodically on a Schedule](#running-a-scan-periodically-on-a-schedule)
   - [Skipping Tests](#skipping-tests)
@@ -131,21 +129,21 @@ For more information about configuring the custom resources for the scans, profi
 - [Enabling Alerting for rancher-cis-benchmark](#enabling-alerting-for-rancher-cis-benchmark)
 - [Configuring Alerts for a Periodic Scan on a Schedule](#configuring-alerts-for-a-periodic-scan-on-a-schedule)
 - [Creating a Custom Benchmark Version for Running a Cluster Scan](#creating-a-custom-benchmark-version-for-running-a-cluster-scan)
-### Installing rancher-cis-benchmark
+### Installing CIS Benchmark
 
-1. In the Rancher UI, go to the **Cluster Explorer.**
-1. Click **Apps.**
-1. Click `rancher-cis-benchmark`.
-1. Click **Install.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to install CIS Benchmark and click **Explore**.
+1. In the left navigation bar, click **Apps & Marketplace > Charts**.
+1. Click **CIS Benchmark**
+1. Click **Install**.
 
 **Result:** The CIS scan application is deployed on the Kubernetes cluster.
 
-### Uninstalling rancher-cis-benchmark
+### Uninstalling CIS Benchmark
 
-1. From the **Cluster Explorer,** go to the top left dropdown menu and click **Apps & Marketplace.**
-1. Click **Installed Apps.**
+1. From the **Cluster Dashboard,** go to the left navigation bar and click **Apps & Marketplace > Installed Apps**.
 1. Go to the `cis-operator-system` namespace and check the boxes next to `rancher-cis-benchmark-crd` and `rancher-cis-benchmark`.
-1. Click **Delete** and confirm **Delete.**
+1. Click **Delete** and confirm **Delete**.
 
 **Result:** The `rancher-cis-benchmark` application is uninstalled.
 
@@ -157,23 +155,26 @@ Note: There is currently a limitation of running only one CIS scan at a time for
 
 To run a scan,
 
-1. Go to the **Cluster Explorer** in the Rancher UI. In the top left dropdown menu, click **Cluster Explorer > CIS Benchmark.**
-1. In the **Scans** section, click **Create.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to run a CIS scan and click **Explore**.
+1. Click **CIS Benchmark > Scan**.
+1. Click **Create**.
 1. Choose a cluster scan profile. The profile determines which CIS Benchmark version will be used and which tests will be performed. If you choose the Default profile, then the CIS Operator will choose a profile applicable to the type of Kubernetes cluster it is installed on.
-1. Click **Create.**
+1. Click **Create**.
 
 **Result:** A report is generated with the scan results. To see the results, click the name of the scan that appears.
 ### Running a Scan Periodically on a Schedule
 
 To run a ClusterScan on a schedule,
 
-1. Go to the **Cluster Explorer** in the Rancher UI. In the top left dropdown menu, click **Cluster Explorer > CIS Benchmark.**
-1. In the **Scans** section, click **Create.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to run a CIS scan and click **Explore**.
+1. Click **CIS Benchmark > Scan**.
 1. Choose a cluster scan profile. The profile determines which CIS Benchmark version will be used and which tests will be performed. If you choose the Default profile, then the CIS Operator will choose a profile applicable to the type of Kubernetes cluster it is installed on.
-1. Choose the option **Run scan on a schedule.**
-1. Enter a valid <a href="https://en.wikipedia.org/wiki/Cron#CRON_expression" target="_blank">cron schedule expression</a> in the field **Schedule.**
+1. Choose the option **Run scan on a schedule**.
+1. Enter a valid <a href="https://en.wikipedia.org/wiki/Cron#CRON_expression" target="_blank">cron schedule expression</a> in the field **Schedule**.
 1. Choose a **Retention** count, which indicates the number of reports maintained for this recurring scan. By default this count is 3. When this retention limit is reached, older reports will get purged.
-1. Click **Create.**
+1. Click **Create**.
 
 **Result:** The scan runs and reschedules to run according to the cron schedule provided. The **Next Scan** value indicates the next time this scan will run again. 
 
@@ -187,9 +188,10 @@ CIS scans can be run using test profiles with user-defined skips.
 
 To skip tests, you will create a custom CIS scan profile. A profile contains the configuration for the CIS scan, which includes the benchmark versions to use and any specific tests to skip in that benchmark.
 
-1. In the **Cluster Explorer,** go to the top-left dropdown menu and click **CIS Benchmark.**
-1. Click **Profiles.**
-1. From here, you can create a profile in multiple ways. To make a new profile, click **Create** and fill out the form in the UI. To make a new profile based on an existing profile, go to the existing profile, click the three vertical dots, and click **Clone as YAML.**  If you are filling out the form, add the tests to skip using the test IDs, using the relevant CIS Benchmark as a reference. If you are creating the new test profile as YAML, you will add the IDs of the tests to skip in the `skipTests` directive. You will also give the profile a name:
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to run a CIS scan and click **Explore**.
+1. Click **CIS Benchmark > Profile**.
+1. From here, you can create a profile in multiple ways. To make a new profile, click **Create** and fill out the form in the UI. To make a new profile based on an existing profile, go to the existing profile and click **⋮ Clone**.  If you are filling out the form, add the tests to skip using the test IDs, using the relevant CIS Benchmark as a reference. If you are creating the new test profile as YAML, you will add the IDs of the tests to skip in the `skipTests` directive. You will also give the profile a name:
 
     ```yaml
     apiVersion: cis.cattle.io/v1
@@ -207,7 +209,7 @@ To skip tests, you will create a custom CIS scan profile. A profile contains the
         - "1.1.20"
         - "1.1.21"
     ```
-1. Click **Create.**
+1. Click **Create**.
 
 **Result:** A new CIS scan profile is created.
 
@@ -217,7 +219,9 @@ When you [run a scan](#running-a-scan) that uses this profile, the defined tests
 
 To view the generated CIS scan reports,
 
-1. In the **Cluster Explorer,** go to the top left dropdown menu and click **Cluster Explorer > CIS Benchmark.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to run a CIS scan and click **Explore**.
+1. Click **CIS Benchmark > Scan**.
 1. The **Scans** page will show the generated reports. To see a detailed report, go to a scan report and click the name.
 
 One can download the report from the Scans list or from the scan detail page.
@@ -232,7 +236,7 @@ Alerts can be configured to be sent out for a scan that runs on a schedule.
 >
 > While configuring the routes for `rancher-cis-benchmark` alerts, you can specify the matching using the key-value pair `job: rancher-cis-scan`. An example route configuration is [here.]({{<baseurl>}}/rancher/v2.6/en/monitoring-alerting/v2.5/configuration/alertmanager/#example-route-config-for-cis-scan-alerts)
 
-While installing or upgrading the `rancher-cis-benchmark` application, set the following flag to `true` in the `values.yaml`:
+While installing or upgrading the `rancher-cis-benchmark` Helm chart, set the following flag to `true` in the `values.yaml`:
 
 ```yaml
 alerts:
@@ -247,7 +251,7 @@ A scheduled scan can also specify if you should receive alerts when the scan com
 
 Alerts are supported only for a scan that runs on a schedule.
 
-The `rancher-cis-benchmark` application supports two types of alerts:
+The CIS Benchmark application supports two types of alerts:
 
 - Alert on scan completion: This alert is sent out when the scan run finishes. The alert includes details including the ClusterScan's name and the ClusterScanProfile name.
 - Alert on scan failure: This alert is sent out if there are some test failures in the scan run or if the scan is in a `Fail` state.
@@ -261,14 +265,16 @@ The `rancher-cis-benchmark` application supports two types of alerts:
 To configure alerts for a scan that runs on a schedule,
 
 1. Please enable alerts on the `rancher-cis-benchmark` application (#enabling-alerting-for-rancher-cis-benchmark)
-1. Go to the **Cluster Explorer** in the Rancher UI. In the top left dropdown menu, click **Cluster Explorer > CIS Benchmark.**
-1. In the **Scans** section, click **Create.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to run a CIS scan and click **Explore**.
+1. Click **CIS Benchmark > Scan**.
+1. Click **Create**.
 1. Choose a cluster scan profile. The profile determines which CIS Benchmark version will be used and which tests will be performed. If you choose the Default profile, then the CIS Operator will choose a profile applicable to the type of Kubernetes cluster it is installed on.
-1. Choose the option **Run scan on a schedule.**
-1. Enter a valid [cron schedule expression](https://en.wikipedia.org/wiki/Cron#CRON_expression) in the field **Schedule.**
-1. Check the boxes next to the Alert types under **Alerting.**
-1. Optional: Choose a **Retention** count, which indicates the number of reports maintained for this recurring scan. By default this count is 3. When this retention limit is reached, older reports will get purged.
-1. Click **Create.**
+1. Choose the option **Run scan on a schedule**.
+1. Enter a valid [cron schedule expression](https://en.wikipedia.org/wiki/Cron#CRON_expression) in the field **Schedule**.
+1. Check the boxes next to the Alert types under **Alerting**.
+1. Optional: Choose a **Retention Count**, which indicates the number of reports maintained for this recurring scan. By default this count is 3. When this retention limit is reached, older reports will get purged.
+1. Click **Create**.
 
 **Result:** The scan runs and reschedules to run according to the cron schedule provided. Alerts are sent out when the scan finishes if routes and receiver are configured under `rancher-monitoring` application.
 

--- a/content/rancher/v2.6/en/cis-scans/configuration/_index.md
+++ b/content/rancher/v2.6/en/cis-scans/configuration/_index.md
@@ -1,13 +1,15 @@
 ---
 title: Configuration
 weight: 3
-aliases:
-  - /rancher/v2.6/en/cis-scans/v2.5/configuration
 ---
 
 This configuration reference is intended to help you manage the custom resources created by the `rancher-cis-benchmark` application. These resources are used for performing CIS scans on a cluster, skipping tests, setting the test profile that will be used during a scan, and other customization.
 
-To configure the custom resources, go to the **Cluster Explorer** in the Rancher UI. In dropdown menu in the top left corner, click **Cluster Explorer > CIS Benchmark.**
+To configure the custom resources, go to the **Cluster Dashboard** To configure the CIS scans,
+
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to configure CIS scans and click **Explore**.
+1. In the left navigation bar, click **CIS Benchmark**.
 
 ### Scans
 

--- a/content/rancher/v2.6/en/cis-scans/custom-benchmark/_index.md
+++ b/content/rancher/v2.6/en/cis-scans/custom-benchmark/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Creating a Custom Benchmark Version for Running a Cluster Scan
 weight: 4
-aliases:
-  - /rancher/v2.6/en/cis-scans/v2.5/custom-benchmark
 ---
 
 Each Benchmark Version defines a set of test configuration files that define the CIS tests to be run by the <a href="https://github.com/aquasecurity/kube-bench" target="_blank">kube-bench</a> tool.
@@ -48,25 +46,27 @@ To prepare a custom benchmark version ConfigMap, suppose we want to add a custom
 
 ### 2. Add a Custom Benchmark Version to a Cluster
 
-1. Once the ConfigMap has been created in your cluster, navigate to the **Cluster Explorer** in the Rancher UI. 
-1. In the top left dropdown menu, click **Cluster Explorer > CIS Benchmark.**
-1. In the **Benchmark Versions** section, click **Create.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to add a custom benchmark and click **Explore**.
+1. In the left navigation bar, click **CIS Benchmark > Benchmark Version**.
+1. Click **Create**.
 1. Enter the **Name** and a description for your custom benchmark version.
 1. Choose the cluster provider that your benchmark version applies to.
 1. Choose the ConfigMap you have uploaded from the dropdown.
 1. Add the minimum and maximum Kubernetes version limits applicable, if any.
-1. Click **Create.**
+1. Click **Create**.
 
 ### 3. Create a New Profile for the Custom Benchmark Version
 
 To run a scan using your custom benchmark version, you need to add a new Profile pointing to this benchmark version.
 
-1. Once the custom benchmark version has been created in your cluster, navigate to the **Cluster Explorer** in the Rancher UI. 
-1. In the top left dropdown menu, click **Cluster Explorer > CIS Benchmark.**
-1. In the **Profiles** section, click **Create.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to add a custom benchmark and click **Explore**.
+1. In the left navigation bar, click **CIS Benchmark > Profile**.
+1. Click **Create**.
 1. Provide a **Name** and description. In this example, we name it `foo-profile`.
-1. Choose the Benchmark Version `foo` from the dropdown.
-1. Click **Create.**
+1. Choose the Benchmark Version from the dropdown.
+1. Click **Create**.
 
 ### 4. Run a Scan Using the Custom Benchmark Version
 
@@ -74,9 +74,11 @@ Once the Profile pointing to your custom benchmark version `foo` has been create
 
 To run a scan,
 
-1. Go to the **Cluster Explorer** in the Rancher UI. In the top left dropdown menu, click **Cluster Explorer > CIS Benchmark.**
-1. In the **Scans** section, click **Create.**
-1. Choose the new cluster scan profile `foo-profile`.
-1. Click **Create.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to add a custom benchmark and click **Explore**.
+1. In the left navigation bar, click **CIS Benchmark > Scan**.
+1. Click **Create**.
+1. Choose the new cluster scan profile.
+1. Click **Create**.
 
 **Result:** A report is generated with the scan results. To see the results, click the name of the scan that appears.

--- a/content/rancher/v2.6/en/cis-scans/rbac/_index.md
+++ b/content/rancher/v2.6/en/cis-scans/rbac/_index.md
@@ -2,9 +2,6 @@
 title: Roles-based Access Control
 shortTitle: RBAC
 weight: 3
-aliases:
-  - /rancher/v2.6/en/cis-scans/rbac
-  - /rancher/v2.6/en/cis-scans/v2.5/rbac
 ---
 
 This section describes the permissions required to use the rancher-cis-benchmark App.

--- a/content/rancher/v2.6/en/cis-scans/skipped-tests/_index.md
+++ b/content/rancher/v2.6/en/cis-scans/skipped-tests/_index.md
@@ -1,9 +1,6 @@
 ---
 title: Skipped and Not Applicable Tests
 weight: 3
-aliases:
-  - /rancher/v2.6/en/cis-scans/skipped-tests
-  - /rancher/v2.6/en/cis-scans/v2.5/skipped-tests
 ---
 
 This section lists the tests that are skipped in the permissive test profile for RKE.

--- a/content/rancher/v2.6/en/cli/_index.md
+++ b/content/rancher/v2.6/en/cli/_index.md
@@ -4,8 +4,6 @@ description: The Rancher CLI is a unified tool that you can use to interact with
 metaTitle: "Using the Rancher Command Line Interface "
 metaDescription: "The Rancher CLI is a unified tool that you can use to interact with Rancher. With it, you can operate Rancher using a command line interface rather than the GUI"
 weight: 21
-aliases:
-  - /rancher/v2.6/en/cluster-admin/cluster-access/cli
 ---
 
 The Rancher CLI (Command Line Interface) is a unified tool that you can use to interact with Rancher. With this tool, you can operate Rancher using a command line rather than the GUI.

--- a/content/rancher/v2.6/en/cluster-admin/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/_index.md
@@ -13,12 +13,6 @@ This page covers the following topics:
 
 > This section assumes a basic familiarity with Docker and Kubernetes. For a brief explanation of how Kubernetes components work together, refer to the [concepts]({{<baseurl>}}/rancher/v2.6/en/overview/concepts) page.
 
-## Switching between Clusters
-
-To switch between clusters, use the drop-down available in the navigation bar.
-
-Alternatively, you can switch between projects and clusters directly in the navigation bar. Open the **Global** view and select **Clusters** from the main menu. Then select the name of the cluster you want to open.
-
 ## Managing Clusters in Rancher
 
 After clusters have been [provisioned into Rancher]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/), [cluster owners]({{<baseurl>}}/rancher/v2.6/en/admin-settings/rbac/cluster-project-roles/#cluster-roles) will need to manage these clusters. There are many different options of how to manage your cluster. 

--- a/content/rancher/v2.6/en/cluster-admin/backing-up-etcd/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/backing-up-etcd/_index.md
@@ -100,9 +100,9 @@ In the **Advanced Cluster Options** section, there are several options available
 
 In addition to recurring snapshots, you may want to take a "one-time" snapshot. For example, before upgrading the Kubernetes version of a cluster it's best to backup the state of the cluster to protect against upgrade failure.
 
-1. In the **Global** view, navigate to the cluster that you want to take a one-time snapshot.
-
-2. Click the **&#8942; > Snapshot Now**.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, navigate to the cluster where you want to take a one-time snapshot.
+1. Click **⋮ > Take Snapshot**.
 
 **Result:** Based on your [snapshot backup target](#snapshot-backup-targets), a one-time snapshot will be taken and saved in the selected backup target.
 
@@ -149,9 +149,9 @@ The `S3` backup target supports using IAM authentication to AWS API in addition 
 
 The list of all available snapshots for the cluster is available in the Rancher UI.
 
-1. In the **Global** view, navigate to the cluster that you want to view snapshots.
-
-2. Click **Tools > Snapshots** from the navigation bar to view the list of saved snapshots. These snapshots include a timestamp of when they were created.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. In the **Clusters** page, go to the cluster where you want to view the snapshots and click its name.
+1. Click the **Snapshots** tab to view the list of saved snapshots. These snapshots include a timestamp of when they were created.
 
 # Safe Timestamps
 

--- a/content/rancher/v2.6/en/cluster-admin/cleaning-cluster-nodes/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/cleaning-cluster-nodes/_index.md
@@ -2,8 +2,6 @@
 title: Removing Kubernetes Components from Nodes
 description: Learn about cluster cleanup when removing nodes from your Rancher-launched Kubernetes cluster. What is removed, how to do it manually
 weight: 2055
-aliases:
-  - /rancher/v2.6/en/faq/cleaning-cluster-nodes/
 ---
 
 This section describes how to disconnect a node from a Rancher-launched Kubernetes cluster and remove all of the Kubernetes components from the node. This process allows you to use the node for other purposes.

--- a/content/rancher/v2.6/en/cluster-admin/cloning-clusters/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/cloning-clusters/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Cloning Clusters
 weight: 2035
-aliases:
-  - /rancher/v2.6/en/cluster-provisioning/cloning-clusters/
 ---
 
 If you have a cluster in Rancher that you want to use as a template for creating similar clusters, you can use Rancher CLI to clone the cluster's configuration, edit it, and then use it to quickly launch the cloned cluster.
@@ -98,4 +96,4 @@ Move `cluster-template.yml` into the same directory as the Rancher CLI binary. T
 
     ./rancher up --file cluster-template.yml
 
-**Result:** Your cloned cluster begins provisioning. Enter `./rancher cluster ls` to confirm. You can also log into the Rancher UI and open the **Global** view to watch your provisioning cluster's progress.
+**Result:** Your cloned cluster begins provisioning. Enter `./rancher cluster ls` to confirm.

--- a/content/rancher/v2.6/en/cluster-admin/cluster-access/cluster-members/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/cluster-access/cluster-members/_index.md
@@ -1,11 +1,6 @@
 ---
 title: Adding Users to Clusters
 weight: 2020
-aliases:
-  - /rancher/v2.6/en/tasks/clusters/adding-managing-cluster-members/
-  - /rancher/v2.6/en/k8s-in-rancher/cluster-members/
-  - /rancher/v2.6/en/cluster-admin/cluster-members
-  - /rancher/v2.6/en/cluster-provisioning/cluster-members/
 ---
 
 If you want to provide a user with access and permissions to _all_ projects, nodes, and resources within a cluster, assign the user a cluster membership.
@@ -26,11 +21,10 @@ There are two contexts where you can add cluster members:
 
 Cluster administrators can edit the membership for a cluster, controlling which Rancher users can access the cluster and what features they can use.
 
-1. From the **Global** view, open the cluster that you want to add members to.
-
-2. From the main menu, select **Members**. Then click **Add Member**.
-
-3. Search for the user or group that you want to add to the cluster.
+1. Click **☰ > Cluster Management**.
+1. Go to the cluster you want to add members to and click **⋮ > Edit Config**.
+1. In the **Member Roles** tab, click **Add Member**.
+1. Search for the user or group that you want to add to the cluster.
 
  	If external authentication is configured:
 
@@ -43,7 +37,7 @@ Cluster administrators can edit the membership for a cluster, controlling which 
 
 		>**Note:** If you are logged in as a local user, external users do not display in your search results. For more information, see [External Authentication Configuration and Principal Users]({{<baseurl>}}/rancher/v2.6/en/admin-settings/authentication/#external-authentication-configuration-and-principal-users).
 
-4. Assign the user or group **Cluster** roles.  
+1. Assign the user or group **Cluster** roles.  
 
 	[What are Cluster Roles?]({{<baseurl>}}/rancher/v2.6/en/admin-settings/rbac/cluster-project-roles/)
 

--- a/content/rancher/v2.6/en/cluster-admin/cluster-access/kubectl/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/cluster-access/kubectl/_index.md
@@ -2,12 +2,6 @@
 title: "Access a Cluster with Kubectl and kubeconfig"
 description: "Learn how you can access and manage your Kubernetes clusters using kubectl with kubectl Shell or with kubectl CLI and kubeconfig file. A kubeconfig file is used to configure access to Kubernetes. When you create a cluster with Rancher, it automatically creates a kubeconfig for your cluster."
 weight: 2010
-aliases:
-  - /rancher/v2.6/en/k8s-in-rancher/kubectl/
-  - /rancher/v2.6/en/cluster-admin/kubectl
-  - /rancher/v2.6/en/concepts/clusters/kubeconfig-files/
-  - /rancher/v2.6/en/k8s-in-rancher/kubeconfig/
-  - /rancher/2.x/en/cluster-admin/kubeconfig
 ---
 
 This section describes how to manipulate your downstream Kubernetes cluster with kubectl from the Rancher UI or from your workstation.
@@ -26,9 +20,9 @@ For more information on using kubectl, see [Kubernetes Documentation: Overview o
 
 You can access and manage your clusters by logging into Rancher and opening the kubectl shell in the UI. No further configuration necessary.
 
-1. From the **Global** view, open the cluster that you want to access with kubectl.
-
-2. Click **Launch kubectl**. Use the window that opens to interact with your Kubernetes cluster.
+1. Click **☰ > Cluster Management**.
+1. Go to the cluster you want to access with kubectl and click **Explore**.
+1. In the top navigation menu, click the **Kubectl Shell** button. Use the window that opens to interact with your Kubernetes cluster.
 
 ### Accessing Clusters with kubectl from Your Workstation
 
@@ -38,10 +32,10 @@ This alternative method of accessing the cluster allows you to authenticate with
 
 > **Prerequisites:** These instructions assume that you have already created a Kubernetes cluster, and that kubectl is installed on your workstation. For help installing kubectl, refer to the official [Kubernetes documentation.](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 
-1. Log into Rancher. From the **Global** view, open the cluster that you want to access with kubectl.
-1. Click **Kubeconfig File**.
-1. Copy the contents displayed to your clipboard.
-1. Paste the contents into a new file on your local computer. Move the file to `~/.kube/config`. Note: The default location that kubectl uses for the kubeconfig file is `~/.kube/config`, but you can use any directory and specify it using the `--kubeconfig` flag, as in this command:
+1. Log into Rancher. Click **☰ > Cluster Management**.
+1. Go to the cluster that you want to access with kubectl and click **Explore**.
+1. In the top navigation bar, click **Download KubeConfig** button.
+1. Save the YAML file on your local computer. Move the file to `~/.kube/config`. Note: The default location that kubectl uses for the kubeconfig file is `~/.kube/config`, but you can use any directory and specify it using the `--kubeconfig` flag, as in this command:
   ```
   kubectl --kubeconfig /custom/path/kube.config get pods
   ```

--- a/content/rancher/v2.6/en/cluster-admin/editing-clusters/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/editing-clusters/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Cluster Configuration
 weight: 2025
-aliases:
-  - /rancher/v2.6/en/k8s-in-rancher/editing-clusters
 ---
 
 After you provision a Kubernetes cluster using Rancher, you can still edit options and settings for the cluster.

--- a/content/rancher/v2.6/en/cluster-admin/editing-clusters/aks-config-reference/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/editing-clusters/aks-config-reference/_index.md
@@ -27,7 +27,7 @@ To get the tenant ID, go to the Azure Portal, then click **Azure Active Director
 
 ### Subscription ID
 
-To get the subscription ID, click **All Services** in the left navigation bar. Then click **Subscriptions.** Go to the name of the subscription that you want to associate with your Kubernetes cluster and copy the **Subscription ID.**
+To get the subscription ID, click **All Services** in the left navigation bar. Then click **Subscriptions**. Go to the name of the subscription that you want to associate with your Kubernetes cluster and copy the **Subscription ID**.
 
 ### Client ID
 
@@ -39,7 +39,7 @@ You can't retrieve the client secret value after it is created, so if you don't 
 
 To get a new client secret, go to the Azure Portal, then click **Azure Active Directory**, then click **App registrations,** then click the name of the service principal.
 
-Then click **Certificates & secrets** and click **New client secret.** Click **Add.** Then copy the **Value** of the new client secret.
+Then click **Certificates & secrets** and click **New client secret**. Click **Add**. Then copy the **Value** of the new client secret.
 
 ### Environment
 

--- a/content/rancher/v2.6/en/cluster-admin/editing-clusters/gke-config-reference/private-clusters/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/editing-clusters/gke-config-reference/private-clusters/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Private Clusters
 weight: 2
-aliases:
-  - /rancher/v2.6/en/cluster-provisioning/hosted-kubernetes-clusters/gke/private-clusters
 ---
 
 In GKE, [private clusters](https://cloud.google.com/kubernetes-engine/docs/concepts/private-cluster-concept) are clusters whose nodes are isolated from inbound and outbound traffic by assigning them internal IP addresses only. Private clusters in GKE have the option of exposing the control plane endpoint as a publicly accessible address or as a private address. This is different from other Kubernetes providers, which may refer to clusters with private control plane endpoints as "private clusters" but still allow traffic to and from nodes. You may want to create a cluster with private nodes, with or without a public control plane endpoint, depending on your organization's networking and security requirements. A GKE cluster provisioned from Rancher can use isolated nodes by selecting "Private Cluster" in the Cluster Options (under "Show advanced options"). The control plane endpoint can optionally be made private by selecting "Enable Private Endpoint".

--- a/content/rancher/v2.6/en/cluster-admin/editing-clusters/rke-config-reference/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/editing-clusters/rke-config-reference/_index.md
@@ -56,11 +56,9 @@ The forms in the Rancher UI don't include all advanced options for configuring R
 
 # Editing Clusters with a Form in the Rancher UI
 
-To edit your cluster with a form in the Rancher UI, open the **Global** view, make sure the **Clusters** tab is selected, and then select **&#8942; > Edit** for the cluster that you want to edit.
-
 To edit your cluster,
 
-1. In the upper left corner, click **≡ > Cluster Management**.
+1. In the upper left corner, click **☰ > Cluster Management**.
 1. Go to the cluster you want to configure and click **⋮ > Edit Config**.
 
 
@@ -72,17 +70,10 @@ RKE clusters (also called RKE1 clusters) are edited differently than RKE2 and K3
 
 To edit an RKE config file directly from the Rancher UI,
 
-1. Click **≡ > Cluster Management.**
+1. Click **☰ > Cluster Management**.
 1. Go to the RKE cluster you want to configure. Click and click **⋮ > Edit Config**. This take you to the RKE configuration form. Note: Because cluster provisioning changed in Rancher 2.6, the **⋮ > Edit as YAML** can be used for configuring RKE2 clusters, but it can't be used for editing RKE1 configuration.
-1. Scroll down and click **Edit as YAML.**
+1. In the configuration form, scroll down and click **Edit as YAML**.
 1. Edit the RKE options under the `rancher_kubernetes_engine_config` directive.
-
-To read from an existing RKE file,
-
-1. Click **≡ > Cluster Management.**
-1. Go to the RKE cluster you want to configure. Click and click **⋮ > Edit Config**. 
-1. Click **Edit as YAML.**
-1. Click **Read from File**.
 
 # Configuration Options in the Rancher UI
 

--- a/content/rancher/v2.6/en/cluster-admin/editing-clusters/syncing/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/editing-clusters/syncing/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Syncing
 weight: 10
-aliases:
-  - /rancher/v2.6/en/cluster-provisioning/hosted-kubernetes-clusters/syncing
 ---
 
 Syncing is the feature for EKS and GKE clusters that causes Rancher to update the clusters' values so they are up to date with their corresponding cluster object in the hosted Kubernetes provider. This enables Rancher to not be the sole owner of a hosted cluster’s state. Its largest limitation is that processing an update from Rancher and another source at the same time or within 5 minutes of one finishing may cause the state from one source to completely overwrite the other.

--- a/content/rancher/v2.6/en/cluster-admin/nodes/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/nodes/_index.md
@@ -76,7 +76,7 @@ Editing a node lets you:
 * Add [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
 * Add/Remove [taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
 
-To manage individual nodes, browse to the cluster that you want to manage and then select **Nodes** from the main menu. You can open the options menu for a node by clicking its **&#8942;** icon (**...**).
+To manage individual nodes, browse to the cluster that you want to manage and then select **Nodes** from the main menu. You can open the options menu for a node by clicking its **⋮** icon (**..**.).
 
 # Viewing a Node in the Rancher API
 
@@ -96,18 +96,13 @@ For nodes hosted by an infrastructure provider, you can scale the number of node
 
 # SSH into a Node Hosted by an Infrastructure Provider
 
-For [nodes hosted by an infrastructure provider]({{< baseurl >}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/), you have the option of downloading its SSH key so that you can connect to it remotely from your desktop.
+For [nodes hosted by an infrastructure provider]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/), you have the option of downloading its SSH key so that you can connect to it remotely from your desktop.
 
-1. From the cluster hosted by an infrastructure provider, select **Nodes** from the main menu.
-
-1. Find the node that you want to remote into. Select **&#8942; > Download Keys**.
-
-    **Step Result:** A ZIP file containing files used for SSH is downloaded.
-
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to SSH into a node and click the name of the cluster.
+1. On the **Machine Pools** tab, find the node that you want to remote into and click  **⋮ > Download SSH Key**. A ZIP file containing files used for SSH will be downloaded.
 1. Extract the ZIP file to any location.
-
 1. Open Terminal. Change your location to the extracted ZIP file.
-
 1. Enter the following command:
 
     ```
@@ -132,7 +127,7 @@ However, you can override the conditions draining when you initiate the drain. Y
 
 ### Aggressive and Safe Draining Options
 
-There are two drain modes: aggressive and safe.
+When you configure the upgrade strategy for the cluster, you will be able to enable node draining. If node draining is enabled, you will be able to configure how pods are deleted and rescheduled.
 
 - **Aggressive Mode**
 
@@ -175,18 +170,6 @@ You can label nodes to be ignored by using a setting in the Rancher UI, or by us
 
 > **Note:** There is an [open issue](https://github.com/rancher/rancher/issues/24172) in which nodes labeled to be ignored can get stuck in an updating state.
 
-### Labeling Nodes to be Ignored with the Rancher UI
-
-To add a node that is ignored by Rancher,
-
-1. From the **Global** view, click the **Settings** tab.
-1. Go to the `ignore-node-name` setting and click **&#8942; > Edit.**
-1. Enter a name that Rancher will use to ignore nodes. All nodes with this name will be ignored.
-1. Click **Save.**
-
-**Result:** Rancher will not wait to register nodes with this name. In the UI, the node will displayed with a grayed-out status. The node is still part of the cluster and can be listed with `kubectl`.
-
-If the setting is changed afterward, the ignored nodes will continue to be hidden.
 
 ### Labeling Nodes to be Ignored with kubectl
 
@@ -202,4 +185,4 @@ If the label is added before the node is added to the cluster, the node will not
 
 If the label is added after the node is added to a Rancher cluster, the node will not be removed from the UI.
 
-If you delete the node from the Rancher server using the Rancher UI or API, the node will not be removed from the cluster if the `nodeName` is listed in the Rancher settings under `ignore-node-name`.
+If you delete the node from the Rancher server using the Rancher UI or API, the node will not be removed from the cluster if the `nodeName` is listed in the Rancher settings in the Rancher API under `v3/settings/ignore-node-name`.

--- a/content/rancher/v2.6/en/cluster-admin/pod-security-policy/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/pod-security-policy/_index.md
@@ -9,11 +9,9 @@ When your cluster is running pods with security-sensitive configurations, assign
 
 You can assign a pod security policy when you provision a cluster. However, if you need to relax or restrict security for your pods later, you can update the policy while editing your cluster.
 
-1. From the **Global** view, find the cluster to which you want to apply a pod security policy. Select **&#8942; > Edit**.
-
-2. Expand **Cluster Options**.
-
-3. From **Pod Security Policy Support**, select **Enabled**.
+1. Click **☰ > Cluster Management**.
+1. Go to the cluster to which you want to apply a pod security policy and click **⋮ > Edit Config**.
+1. From **Pod Security Policy Support**, select **Enabled**.
 
     >**Note:** This option is only available for clusters [provisioned by RKE]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/).
 

--- a/content/rancher/v2.6/en/cluster-admin/projects-and-namespaces/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/projects-and-namespaces/_index.md
@@ -2,11 +2,6 @@
 title: Projects and Kubernetes Namespaces with Rancher
 description: Rancher Projects ease the administrative burden of your cluster and support multi-tenancy. Learn to create projects and divide projects into Kubernetes namespaces
 weight: 2032
-aliases:
-  - /rancher/v2.6/en/concepts/projects/
-  - /rancher/v2.6/en/tasks/projects/
-  - /rancher/v2.6/en/tasks/projects/create-project/
-  - /rancher/v2.6/en/tasks/projects/create-project/  
 ---
 
 A namespace is a Kubernetes concept that allows a virtual cluster within a cluster, which is useful for dividing the cluster into separate "virtual clusters" that each have their own access control and resource quotas.
@@ -97,7 +92,7 @@ If you require another level of organization beyond the **Default** project, you
 
 When troubleshooting, you can view the `system` project to check if important namespaces in the Kubernetes system are working properly. This easily accessible project saves you from troubleshooting individual system namespace containers.
 
-To open it, open the **Global** menu, and then select the `system` project for your cluster.
+To open it, open the cluster view and click **Cluster > Projects/Namespaces**. This view shows all of the namespaces in the `system` project.
 
 The `system` project:
 
@@ -130,10 +125,10 @@ This section describes how to create a new project with a name and with optional
 
 ### 1. Name a New Project
 
-1. From the **Global** view, choose **Clusters** from the main menu. From the **Clusters** page, open the cluster from which you want to create a project.
-
-1. From the main menu, choose **Projects/Namespaces**. Then click **Add Project**.
-
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster you want to project in and click **Explore**.
+1. Click **Cluster > Projects/Namespaces**.
+1. Click **Create Project**.
 1. Enter a **Project Name**.
 
 ### 2. Optional: Select a Pod Security Policy
@@ -159,9 +154,9 @@ By default, your user is added as the project `Owner`.
 
 To add members:
 
-1. Click **Add Member**.
-1. From the **Name** combo box, search for a user or group that you want to assign project access. Note: You can only search for groups if external authentication is enabled.
-1. From the **Role** drop-down, choose a role. For more information, refer to the [documentation on project roles.]({{<baseurl>}}/rancher/v2.6/en/admin-settings/rbac/cluster-project-roles/)
+1. In the **Members** tab, click **Add**.
+1. From the **Select Member** field, search for a user or group that you want to assign project access. Note: You can only search for groups if external authentication is enabled.
+1. In the **Project Permissions** section, choose a role. For more information, refer to the [documentation on project roles.]({{<baseurl>}}/rancher/v2.6/en/admin-settings/rbac/cluster-project-roles/)
 
 ### 4. Optional: Add Resource Quotas
 
@@ -169,8 +164,8 @@ Resource quotas limit the resources that a project (and its namespaces) can cons
 
 To add a resource quota,
 
-1. Click **Add Quota**.
-1. Select a Resource Type. For more information, see [Resource Quotas.]({{<baseurl>}}/rancher/v2.6/en/k8s-in-rancher/projects-and-namespaces/resource-quotas/).
+1. In the **Resource Quotas** tab, click **Add Resource**.
+1. Select a **Resource Type**. For more information, see [Resource Quotas.]({{<baseurl>}}/rancher/v2.6/en/k8s-in-rancher/projects-and-namespaces/resource-quotas/).
 1. Enter values for the **Project Limit** and the **Namespace Default Limit**.
 1. **Optional:** Specify **Container Default Resource Limit**, which will be applied to every container started in the project. The parameter is recommended if you have CPU or Memory limits set by the Resource Quota. It can be overridden on per an individual namespace or a container level. For more information, see [Container Default Resource Limit]({{<baseurl>}}/rancher/v2.6/en/project-admin/resource-quotas/)
 1. Click **Create**.
@@ -181,14 +176,3 @@ To add a resource quota,
 | ----------------------- | -------------------------------------------------------------------------------------------------------- |
 | Project Limit           | The overall resource limit for the project.                                                              |
 | Namespace Default Limit | The default resource limit available for each namespace. This limit is propagated to each namespace in the project when created. The combined limit of all project namespaces shouldn't exceed the project limit.  |
-
-# Switching between Clusters and Projects
-
-To switch between clusters and projects, use the **Global** drop-down available in the main menu.
-
-![Global Menu]({{<baseurl>}}/img/rancher/global-menu.png)
-
-Alternatively, you can switch between projects and clusters using the main menu.
-
-- To switch between clusters, open the **Global** view and select **Clusters** from the main menu. Then open a cluster.
-- To switch between projects, open a cluster, and then select **Projects/Namespaces** from the main menu. Select the link for the project that you want to open.

--- a/content/rancher/v2.6/en/cluster-admin/restoring-etcd/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/restoring-etcd/_index.md
@@ -20,9 +20,9 @@ This section covers the following topics:
 
 The list of all available snapshots for the cluster is available.
 
-1. In the **Global** view, navigate to the cluster that you want to view snapshots.
-
-2. Click **Tools > Snapshots** from the navigation bar to view the list of saved snapshots. These snapshots include a timestamp of when they were created.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. In the **Clusters** page, go to the cluster where you want to view the snapshots and click the name of the cluster.
+1. Click the **Snapshots** tab. The listed snapshots include a timestamp of when they were created.
 
 ## Restoring a Cluster from a Snapshot
 
@@ -38,15 +38,11 @@ When rolling back to a prior Kubernetes version, the [upgrade strategy options](
 
 > **Prerequisite:** To restore snapshots from S3, the cluster needs to be configured to [take recurring snapshots on S3.]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/backing-up-etcd/#configuring-recurring-snapshots)
 
-1. In the **Global** view, navigate to the cluster that you want to restore from a snapshots.
-
-2. Click the **&#8942; > Restore Snapshot**.
-
-3. Select the snapshot that you want to use for restoring your cluster from the dropdown of available snapshots.
-
-4. In the **Restoration Type** field, choose one of the restore options described above.
-
-5. Click **Save**.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. In the **Clusters** page, go to the cluster where you want to view the snapshots and click the name of the cluster.
+1. Click the **Snapshots** tab to view the list of saved snapshots. 
+1. Go to the snapshot you want to restore and click **⋮ > Restore Snapshot**.
+1. Click **Restore**.
 
 **Result:** The cluster will go into `updating` state and the process of restoring the `etcd` nodes from the snapshot will start. The cluster is restored when it returns to an `active` state.
 

--- a/content/rancher/v2.6/en/cluster-admin/tools/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/tools/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Tools for Logging, Monitoring, and Visibility
 weight: 2033
-aliases:
-  - /rancher/v2.6/en/tools/notifiers-and-alerts/
 ---
 
 Rancher contains a variety of tools that aren't included in Kubernetes to assist in your DevOps operations. Rancher can integrate with external services to help your clusters run more efficiently. Tools are divided into following categories:

--- a/content/rancher/v2.6/en/cluster-admin/upgrading-kubernetes/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/upgrading-kubernetes/_index.md
@@ -50,12 +50,9 @@ The restore operation will work on a cluster that is not in a healthy or active 
 > - The options below are available only for [Rancher-launched RKE Kubernetes clusters]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/) and [Registered K3s Kubernetes clusters.]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/registered-clusters/#additional-features-for-registered-k3s-clusters)
 > - Before upgrading Kubernetes, [back up your cluster.]({{<baseurl>}}/rancher/v2.6/en/backups)
 
-1. From the **Global** view, find the cluster for which you want to upgrade Kubernetes. Select **&#8942; > Edit**.
-
-1. Expand **Cluster Options**.
-
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster you want to upgrade and click **⋮ > Edit Config**.
 1. From the **Kubernetes Version** drop-down, choose the version of Kubernetes that you want to use for the cluster.
-
 1. Click **Save**.
 
 **Result:** Kubernetes begins upgrading for the cluster.
@@ -81,10 +78,10 @@ By default, the maximum number of unavailable worker is defined as 10 percent of
 
 To change the default number or percentage of worker nodes,
 
-1. Go to the cluster view in the Rancher UI.
-1. Click **&#8942; > Edit.**
-1. In the **Advanced Options** section, go to the **Maxiumum Worker Nodes Unavailable** field. Enter the percentage of worker nodes that can be upgraded in a batch. Optionally, select **Count** from the drop-down menu and enter the maximum unavailable worker nodes as an integer.
-1. Click **Save.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster you want to upgrade and click **⋮ > Edit Config**.
+1. In the **Upgrade Strategy** tab, enter the **Worker Concurrency** as a fixed number or percentage. To get this number, you can take the number of nodes in your cluster and subtract the max unavailable nodes.
+1. Click **Save**.
 
 **Result:** The cluster is updated to use the new upgrade strategy.
 
@@ -94,13 +91,14 @@ By default, RKE [cordons](https://kubernetes.io/docs/concepts/architecture/nodes
 
 To enable draining each node during a cluster upgrade,
 
-1. Go to the cluster view in the Rancher UI.
-1. Click **&#8942; > Edit.**
-1. In the **Advanced Options** section, go to the **Drain nodes** field and click **Yes.**
-1. Choose a safe or aggressive drain option. For more information about each option, refer to [this section.]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/nodes/#aggressive-and-safe-draining-options)
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster you want to enable node draining and click **⋮ > Edit Config**.
+1. Click **⋮ > Edit**.
+1. In the **Upgrade Strategy** tab, go to the **Drain nodes** field and click **Yes**. Node draining is configured separately for control plane and worker nodes.
+1. Configure the options for how pods are deleted. For more information about each option, refer to [this section.]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/nodes/#aggressive-and-safe-draining-options)
 1. Optionally, configure a grace period. The grace period is the timeout given to each pod for cleaning things up, so they will have chance to exit gracefully. Pods might need to finish any outstanding requests, roll back transactions or save state to some external storage. If this value is negative, the default value specified in the pod will be used.
 1. Optionally, configure a timeout, which is the amount of time the drain should continue to wait before giving up.
-1. Click **Save.**
+1. Click **Save**.
 
 **Result:** The cluster is updated to use the new upgrade strategy.
 

--- a/content/rancher/v2.6/en/cluster-admin/volumes-and-storage/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/volumes-and-storage/_index.md
@@ -2,9 +2,6 @@
 title: "Kubernetes Persistent Storage: Volumes and Storage Classes"
 description: "Learn about the two ways with which you can create persistent storage in Kubernetes: persistent volumes and storage classes"
 weight: 2031
-aliases:
-  - /rancher/v2.6/en/tasks/clusters/adding-storage/
-  - /rancher/v2.6/en/cluster-admin/volumes-and-storage/persistent-volume-claims/
 ---
 When deploying an application that needs to retain data, you'll need to create persistent storage. Persistent storage allows you to store application data external from the pod running your application. This storage practice allows you to maintain application data, even if the application's pod fails.
 

--- a/content/rancher/v2.6/en/cluster-admin/volumes-and-storage/attaching-existing-storage/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/volumes-and-storage/attaching-existing-storage/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Setting up Existing Storage
 weight: 1
-aliases:
-  - /rancher/v2.6/en/k8s-in-rancher/volumes-and-storage/persistent-volume-claims/
 ---
 
 This section describes how to set up existing persistent storage for workloads in Rancher.
@@ -12,9 +10,8 @@ This section describes how to set up existing persistent storage for workloads i
 To set up storage, follow these steps:
 
 1. [Set up persistent storage.](#1-set-up-persistent-storage)
-2. [Add a persistent volume that refers to the persistent storage.](#2-add-a-persistent-volume-that-refers-to-the-persistent-storage)
-3. [Add a persistent volume claim that refers to the persistent volume.](#3-add-a-persistent-volume-claim-that-refers-to-the-persistent-volume)
-4. [Mount the persistent volume claim as a volume in your workload.](#4-mount-the-persistent-volume-claim-as-a-volume-in-your-workload)
+2. [Add a PersistentVolume that refers to the persistent storage.](#2-add-a-persistentvolume-that-refers-to-the-persistent-storage)
+3. [Use the PersistentVolume for Pods Deployed with a StatefulSet.](#3-use-the-persistentvolume-for-pods-deployed-with-a-statefulset)
 
 ### Prerequisites
 
@@ -29,78 +26,57 @@ The steps to set up a persistent storage device will differ based on your infras
 
 If you have a pool of block storage, and you don't want to use a cloud provider, Longhorn could help you provide persistent storage to your Kubernetes cluster. For more information, see [this page.]({{<baseurl>}}/rancher/v2.6/en/longhorn)
 
-### 2. Add a persistent volume that refers to the persistent storage
+### 2. Add a PersistentVolume that refers to the persistent storage
 
-These steps describe how to set up a persistent volume at the cluster level in Kubernetes.
+These steps describe how to set up a PersistentVolume at the cluster level in Kubernetes.
 
-1. From the cluster view, select **Storage > Persistent Volumes**.
-
-1. Click **Add Volume**.
-
+1. Click **☰ > Cluster Management**.
+1. Go to the cluster where you want to add a persistent volume and click **Explore**.
+1. In the left navigation bar, click **Storage > Persistent Volumes**.
+1. Click **Create**.
 1. Enter a **Name** for the persistent volume.
-
 1. Select the **Volume Plugin** for the disk type or service that you're using. When adding storage to a cluster that's hosted by a cloud provider, use the cloud provider's plug-in for cloud storage. For example, if you have a Amazon EC2 cluster and you want to use cloud storage for it, you must use the `Amazon EBS Disk` volume plugin.
-
 1. Enter the **Capacity** of your volume in gigabytes.
-
 1. Complete the **Plugin Configuration** form. Each plugin type requires information specific to the vendor of disk type. For help regarding each plugin's form and the information that's required, refer to the plug-in's vendor documentation.
-
 1. Optional: In the **Customize** form, configure the [access modes.](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) This options sets how many nodes can access the volume, along with the node read/write permissions. The [Kubernetes Documentation](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) includes a table that lists which access modes are supported by the plugins available.
-
 1. Optional: In the **Customize** form, configure the [mount options.](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#mount-options) Each volume plugin allows you to specify additional command line options during the mounting process. Consult each plugin's vendor documentation for the mount options available.
-
-1. Click **Save**.
+1. Click **Create**.
 
 **Result:** Your new persistent volume is created.
 
-### 3. Add a persistent volume claim that refers to the persistent volume
 
-These steps describe how to set up a PVC in the namespace where your stateful workload will be deployed.
+### 3. Use the Storage Class for Pods Deployed with a StatefulSet
 
-1. Go to the project containing a workload that you want to add a persistent volume claim to.
+StatefulSets manage the deployment and scaling of Pods while maintaining a sticky identity for each Pod. In this StatefulSet, we will configure a VolumeClaimTemplate. Each Pod managed by the StatefulSet will be deployed with a PersistentVolumeClaim based on this VolumeClaimTemplate. The PersistentVolumeClaim will refer to the PersistentVolume that we created. Therefore, when each Pod managed by the StatefulSet is deployed, it will be bound a PersistentVolume as defined in its PersistentVolumeClaim.
 
-1. Then click the **Volumes** tab and click **Add Volume**.
+You can configure storage for the StatefulSet during or after workload creation.
 
-1. Enter a **Name** for the volume claim.
+The following steps describe how to assign existing storage to a new StatefulSet:
 
-1. Select the namespace of the workload that you want to add the persistent storage to.
-
-1. In the section called **Use an existing persistent volume,** go to the **Persistent Volume** drop-down and choose the persistent volume that you created.
-
-1. **Optional:** From **Customize**, select the [Access Modes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) that you want to use.
-
-1. Click **Create.**
-
-**Result:** Your PVC is created. You can now attach it to any workload in the project.
-
-### 4. Mount the persistent volume claim as a volume in your workload
-
-Mount PVCs to stateful workloads so that your applications can store their data.
-
-You can mount PVCs during the deployment of a workload, or following workload creation.
-
-The following steps describe how to assign existing storage to a new workload that is a stateful set:
-
-1. From the **Project** view, go to the **Workloads** tab.
-1. Click **Deploy.**
-1. Enter a name for the workload.
-1. Next to the **Workload Type** field, click **More Options.**
-1. Click **Stateful set of 1 pod.** Optionally, configure the number of pods.
+1. Click **☰ > Cluster Management**.
+1. Go to the cluster where you want to configure storage for the StatefulSet and click **Explore**.
+1. In the left navigation bar, click **Workload > StatefulSets**.
+1. Click **Create**.
 1. Choose the namespace where the workload will be deployed.
-1. Expand the **Volumes** section and click **Add Volume > Use an existing persistent volume (claim).**.
-1. In the **Persistent Volume Claim** field, select the PVC that you created.
+1. Enter a name for the StatefulSet.
+1. On the **Volume Claim Templates** tab, click **Add Claim Template**.
+1. Click **Use an existing Persistent Volume**.
+1. In the Persistent Volumes field, select the Persistent Volume that you created.
 1. In the **Mount Point** field, enter the path that the workload will use to access the volume.
-1. Click **Launch.**
+1. Click **Launch**.
 
 **Result:** When the workload is deployed, it will make a request for the specified amount of disk space to the Kubernetes master. If a PV with the specified resources is available when the workload is deployed, the Kubernetes master will bind the PV to the PVC.
 
 The following steps describe how to assign persistent storage to an existing workload:
 
-1. From the **Project** view, go to the **Workloads** tab.
-1. Go to the workload that you want to add the persistent storage to. The workload type should be a stateful set. Click **&#8942; > Edit.**
-1. Expand the **Volumes** section and click **Add Volume > Use an existing persistent volume (claim).**.
-1. In the **Persistent Volume Claim** field, select the PVC that you created.
+1. Click **☰ > Cluster Management**.
+1. Go to the cluster where you want to configure storage for the StatefulSet and click **Explore**.
+1. In the left navigation bar, click **Workload > StatefulSets**.
+1. Go to the workload that you want to add the persistent storage to. Click **⋮ > Edit**.
+1. On the **Volume Claim Templates** tab, click **Add Claim Template**.
+1. Click **Use an existing Persistent Volume**.
+1. In the Persistent Volumes field, select the Persistent Volume that you created.
 1. In the **Mount Point** field, enter the path that the workload will use to access the volume.
-1. Click **Save.**
+1. Click **Launch**.
 
 **Result:** The workload will make a request for the specified amount of disk space to the Kubernetes master. If a PV with the specified resources is available when the workload is deployed, the Kubernetes master will bind the PV to the PVC.

--- a/content/rancher/v2.6/en/cluster-admin/volumes-and-storage/ceph/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/volumes-and-storage/ceph/_index.md
@@ -380,7 +380,7 @@ curl -sfL https://get.rke2.io | INSTALL_RKE2_TYPE="agent" sh -
 systemctl enable --now rke2-agent.service
 ```
 
-The cluster can be imported into Rancher from the Rancher UI by clicking **Global/Add Cluster > Other Cluster.** Then run the provided kubectl command on the server/master node.
+To import the cluster into Rancher, click **☰ > Cluster Management**. Then on the **Clusters** page, click **Import Existing**. Then run the provided kubectl command on the server/master node.
 
 # Tested Versions
 

--- a/content/rancher/v2.6/en/cluster-admin/volumes-and-storage/examples/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/volumes-and-storage/examples/_index.md
@@ -1,9 +1,6 @@
 ---
 title: Provisioning Storage Examples
 weight: 3053
-aliases:
-  - /rancher/v2.6/en/tasks/clusters/adding-storage/provisioning-storage/
-  - /rancher/v2.6/en/k8s-in-rancher/volumes-and-storage/examples/
 ---
 
 Rancher supports persistent storage with a variety of volume plugins. However, before you use any of these plugins to bind persistent storage to your workloads, you have to configure the storage itself, whether its a cloud-based solution from a service-provider or an on-prem solution that you manage yourself.

--- a/content/rancher/v2.6/en/cluster-admin/volumes-and-storage/examples/ebs/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/volumes-and-storage/examples/ebs/_index.md
@@ -5,11 +5,11 @@ weight: 3053
 
 This section describes how to set up Amazon's Elastic Block Store in EC2.
 
-1. From the EC2 console, go to the **ELASTIC BLOCK STORE** section in the left panel and click **Volumes.**
-1. Click **Create Volume.**
+1. From the EC2 console, go to the **ELASTIC BLOCK STORE** section in the left panel and click **Volumes**.
+1. Click **Create Volume**.
 1. Optional: Configure the size of the volume or other options. The volume should be created in the same availability zone as the instance it will be attached to.
-1. Click **Create Volume.**
-1. Click **Close.**
+1. Click **Create Volume**.
+1. Click **Close**.
 
 **Result:** Persistent storage has been created.
 

--- a/content/rancher/v2.6/en/cluster-admin/volumes-and-storage/examples/nfs/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/volumes-and-storage/examples/nfs/_index.md
@@ -1,8 +1,6 @@
 ---
 title: NFS Storage
 weight: 3054
-aliases:
-  - /rancher/v2.6/en/tasks/clusters/adding-storage/provisioning-storage/nfs/
 ---
 
 Before you can use the NFS storage volume plug-in with Rancher deployments, you need to provision an NFS server.

--- a/content/rancher/v2.6/en/cluster-admin/volumes-and-storage/examples/vsphere/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/volumes-and-storage/examples/vsphere/_index.md
@@ -1,8 +1,6 @@
 ---
 title: vSphere Storage
 weight: 3055
-aliases:
-  - /rancher/v2.6/en/tasks/clusters/adding-storage/provisioning-storage/vsphere/
 ---
 
 To provide stateful workloads with vSphere storage, we recommend creating a vSphereVolume StorageClass. This practice dynamically provisions vSphere storage when workloads request volumes through a [persistent volume claim]({{<baseurl>}}/rancher/v2.6/en/k8s-in-rancher/volumes-and-storage/persistent-volume-claims/).
@@ -25,39 +23,39 @@ In order to provision vSphere volumes in a cluster created with the [Rancher Kub
 >
 > The following steps can also be performed using the `kubectl` command line tool. See [Kubernetes documentation on persistent volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) for details.
 
-1. From the Global view, open the cluster where you want to provide vSphere storage.
-2. From the main menu, select **Storage > Storage Classes**. Then click **Add Class**.
-3. Enter a **Name** for the class.
+1. Click **☰ > Cluster Management**.
+1. Go to the cluster where you want to provide vSphere storage.
+1. In the left navigation bar, click **Storage > StorageClasses**.
+1. Click **Create**.
+3. Enter a **Name** for the StorageClass.
 4. Under **Provisioner**, select **VMWare vSphere Volume**.
 
     {{< img "/img/rancher/vsphere-storage-class.png" "vsphere-storage-class">}}
 
 5. Optionally, specify additional properties for this storage class under **Parameters**. Refer to the [vSphere storage documentation](https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/storageclass.html) for details.
-5. Click **Save**.
+5. Click **Create**.
 
 ### Creating a Workload with a vSphere Volume
 
-1. From the cluster where you configured vSphere storage, begin creating a workload as you would in [Deploying Workloads]({{<baseurl>}}/rancher/v2.6/en/k8s-in-rancher/workloads/deploy-workloads/).
-2. For **Workload Type**, select **Stateful set of 1 pod**.
-3. Expand the **Volumes** section and click **Add Volume**.
-4. Choose **Add a new persistent volume (claim)**. This option will implicitly create the claim once you deploy the workload.
-5. Assign a **Name** for the claim, ie. `test-volume` and select the vSphere storage class created in the previous step.
+1. In the left navigation bar, click **Workload**.
+1. Click **Create**.
+1. Click **StatefulSet**.
+1. In the **Volume Claim Templates** tab, click **Add Claim Template**.
+1. Enter a persistent volume name.
+1. In the Storage Class field, select the vSphere StorageClass that you created.
 6. Enter the required **Capacity** for the volume. Then click **Define**.
-
-    {{< img "/img/rancher/workload-add-volume.png" "workload-add-volume">}}
-
 7. Assign a path in the **Mount Point** field. This is the full path where the volume will be mounted in the container file system, e.g. `/persistent`.
-8. Click **Launch** to create the workload.
+8. Click **Create**.
 
 ### Verifying Persistence of the Volume
 
-1. From the context menu of the workload you just created, click **Execute Shell**.
+1. In the left navigation bar, click **Workload > Pods**.
+1. Go to the workload you just created and click **⋮ > Execute Shell**.
 2. Note the directory at root where the volume has been mounted to (in this case `/persistent`).
 3. Create a file in the volume by executing the command `touch /<volumeMountPoint>/data.txt`.
-4. **Close** the shell window.
+4. Close the shell window.
 5. Click on the name of the workload to reveal detail information.
-6. Open the context menu next to the Pod in the *Running* state.
-7. Delete the Pod by selecting **Delete**.
+7. Click **⋮ > Delete**.
 8. Observe that the pod is deleted. Then a new pod is scheduled to replace it so that the workload maintains its configured scale of a single stateful pod.
 9. Once the replacement pod is running, click **Execute Shell**.
 10. Inspect the contents of the directory where the volume is mounted by entering `ls -l /<volumeMountPoint>`. Note that the file you created earlier is still present.

--- a/content/rancher/v2.6/en/cluster-admin/volumes-and-storage/how-storage-works/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/volumes-and-storage/how-storage-works/_index.md
@@ -1,8 +1,6 @@
 ---
 title: How Persistent Storage Works
 weight: 1
-aliases:
-  - /rancher/v2.6/en/tasks/workloads/add-persistent-volume-claim
 ---
 
 A persistent volume (PV) is a piece of storage in the Kubernetes cluster, while a persistent volume claim (PVC) is a request for storage.
@@ -34,7 +32,7 @@ Persistent volume claims (PVCs) are objects that request storage resources from 
 
 To access persistent storage, a pod must have a PVC mounted as a volume. This PVC lets your deployment application store its data in an external location, so that if a pod fails, it can be replaced with a new pod and continue accessing its data stored externally, as though an outage never occurred.
 
-Each Rancher project contains a list of PVCs that you've created, available from **Resources > Workloads > Volumes.** You can reuse these PVCs when creating deployments in the future.
+Each Rancher project contains a list of PVCs that you've created, available from **Resources > Workloads > Volumes**. You can reuse these PVCs when creating deployments in the future.
 
 ### PVCs are Required for Both New and Existing Persistent Storage
 

--- a/content/rancher/v2.6/en/cluster-admin/volumes-and-storage/provisioning-new-storage/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/volumes-and-storage/provisioning-new-storage/_index.md
@@ -14,8 +14,7 @@ If you have a pool of block storage, and you don't want to use a cloud provider,
 To provision new storage for your workloads, follow these steps:
 
 1. [Add a storage class and configure it to use your storage.](#1-add-a-storage-class-and-configure-it-to-use-your-storage)
-2. [Add a persistent volume claim that refers to the storage class.](#2-add-a-persistent-volume-claim-that-refers-to-the-storage-class)
-3. [Mount the persistent volume claim as a volume for your workload.](#3-mount-the-persistent-volume-claim-as-a-volume-for-your-workload)
+2. [Use the Storage Class for Pods Deployed with a StatefulSet.](#2-use-the-storage-class-for-pods-deployed-with-a-statefulset)
 
 ### Prerequisites
 
@@ -44,70 +43,46 @@ To use a storage provisioner that is not on the above list, you will need to use
 
 These steps describe how to set up a storage class at the cluster level.
 
-1. Go to the **Cluster Explorer** of the cluster for which you want to dynamically provision persistent storage volumes.
-
-1. From the cluster view, select `Storage > Storage Classes`. Click `Add Class`.
-
-1. Enter a `Name` for your storage class.
-
-1. From the `Provisioner` drop-down, select the service that you want to use to dynamically provision storage volumes. For example, if you have a Amazon EC2 cluster and you want to use cloud storage for it, use the `Amazon EBS Disk` provisioner.
-
-1. From the `Parameters` section, fill out the information required for the service to dynamically provision storage volumes. Each provisioner requires different information to dynamically provision storage volumes. Consult the service's documentation for help on how to obtain this information.
-
-1. Click `Save`.
+1. Click **☰ > Cluster Management**.
+1. Go to the cluster where you want to dynamically provision persistent storage volumes and click **Explore**.
+1. Click **Storage > Storage Classes**.
+1. Click **Create**.
+1. Enter a name for your storage class.
+1. From the **Provisioner** drop-down, select the service that you want to use to dynamically provision storage volumes. For example, if you have a Amazon EC2 cluster and you want to use cloud storage for it, use the `Amazon EBS Disk` provisioner.
+1. In the **Parameters** tab, fill out the information required for the service to dynamically provision storage volumes. Each provisioner requires different information to dynamically provision storage volumes. Consult the service's documentation for help on how to obtain this information.
+1. Click **Create**.
 
 **Result:** The storage class is available to be consumed by a PVC.
 
 For full information about the storage class parameters, refer to the official [Kubernetes documentation.](https://kubernetes.io/docs/concepts/storage/storage-classes/#parameters).
 
-### 2. Add a persistent volume claim that refers to the storage class
+### 2. Use the Storage Class for Pods Deployed with a StatefulSet
 
-These steps describe how to set up a PVC in the namespace where your stateful workload will be deployed.
+StatefulSets manage the deployment and scaling of Pods while maintaining a sticky identity for each Pod. In this StatefulSet, we will configure a VolumeClaimTemplate. Each Pod managed by the StatefulSet will be deployed with a PersistentVolumeClaim based on this VolumeClaimTemplate. The PersistentVolumeClaim will refer to the StorageClass that we created. Therefore, when each Pod managed by the StatefulSet is deployed, it will be bound to dynamically provisioned storage using the StorageClass defined in its PersistentVolumeClaim.
 
-1. Go to the **Cluster Manager** to the project containing a workload that you want to add a PVC to.
-
-1. From the main navigation bar, choose **Resources > Workloads.** Then select the **Volumes** tab. Click **Add Volume**.
-
-1. Enter a **Name** for the volume claim.
-
-1. Select the namespace of the volume claim.
-
-1. In the **Source** field, click **Use a Storage Class to provision a new persistent volume.**
-
-1. Go to the **Storage Class** drop-down and select the storage class that you created.
-
-1. Enter a volume **Capacity**.
-
-1. Optional: Expand the **Customize** section and select the [Access Modes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes) that you want to use.
-
-1. Click **Create.**
-
-**Result:** Your PVC is created. You can now attach it to any workload in the project.
-
-### 3. Mount the persistent volume claim as a volume for your workload
-
-Mount PVCs to workloads so that your applications can store their data.
-
-You can mount PVCs during the deployment of a workload, or following workload creation.
-
-To attach the PVC to a new workload,
-
-1. Create a workload as you would in [Deploying Workloads]({{<baseurl>}}/rancher/v2.6/en/k8s-in-rancher/workloads/deploy-workloads/).
-1. For **Workload Type**, select **Stateful set of 1 pod**.
-1. Expand the **Volumes** section and click **Add Volume > Add a New Persistent Volume (Claim).**
-1. In the **Persistent Volume Claim** section, select the newly created persistent volume claim that is attached to the storage class.
+1. Click **☰ > Cluster Management**.
+1. Go to the cluster where you want to add use the StorageClass for a workload and click **Explore**.
+1. In the left navigation bar, click **Workload**.
+1. Click **Create**.
+1. Click **StatefulSet**.
+1. In the **Volume Claim Templates** tab, click **Add Claim Template**.
+1. Enter a name for the persistent volume.
+1. In the **StorageClass* field, select the StorageClass that will dynamically provision storage for pods managed by this StatefulSet.
 1. In the **Mount Point** field, enter the path that the workload will use to access the volume.
-1. Click **Launch.**
+1. Click **Launch**.
 
-**Result:** When the workload is deployed, it will make a request for the specified amount of disk space to the Kubernetes master. If a PV with the specified resources is available when the workload is deployed, the Kubernetes master will bind the PV to the PVC.
+**Result:** When each Pod managed by the StatefulSet is deployed, it will make a request for the specified amount of disk space to the Kubernetes master. If a PV with the specified resources is available when the workload is deployed, the Kubernetes master will bind the PV to Pod with a compatible PVC.
 
 To attach the PVC to an existing workload,
 
-1. Go to the project that has the workload that will have the PVC attached.
-1. Go to the workload that will have persistent storage and click **&#8942; > Edit.**
-1. Expand the **Volumes** section and click **Add Volume > Add a New Persistent Volume (Claim).**
-1. In the **Persistent Volume Claim** section, select the newly created persistent volume claim that is attached to the storage class.
+1. Click **☰ > Cluster Management**.
+1. Go to the cluster where you want to add use the StorageClass for a workload and click **Explore**.
+1. In the left navigation bar, click **Workload**.
+1. Go to the workload that will use storage provisioned with the StorageClass that you cared at click **⋮ > Edit Config**.
+1. In the **Volume Claim Templates** section, click **Add Claim Template**.
+1. Enter a persistent volume name.
+1. In the **StorageClass* field, select the StorageClass that will dynamically provision storage for pods managed by this StatefulSet.
 1. In the **Mount Point** field, enter the path that the workload will use to access the volume.
-1. Click **Save.**
+1. Click **Save**.
 
 **Result:** The workload will make a request for the specified amount of disk space to the Kubernetes master. If a PV with the specified resources is available when the workload is deployed, the Kubernetes master will bind the PV to the PVC. If not, Rancher will provision new persistent storage.

--- a/content/rancher/v2.6/en/cluster-provisioning/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/_index.md
@@ -2,10 +2,6 @@
 title: Setting up Kubernetes Clusters in Rancher
 description: Provisioning Kubernetes Clusters
 weight: 7
-aliases:
-  - /rancher/v2.6/en/concepts/clusters/
-  - /rancher/v2.6/en/concepts/clusters/cluster-providers/
-  - /rancher/v2.6/en/tasks/clusters/
 ---
 
 Rancher simplifies the creation of clusters by allowing you to create them through the Rancher UI rather than more complex alternatives. Rancher provides multiple options for launching a cluster. Use the option that best fits your use case.

--- a/content/rancher/v2.6/en/cluster-provisioning/hosted-kubernetes-clusters/ack/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/hosted-kubernetes-clusters/ack/_index.md
@@ -6,7 +6,7 @@ weight: 2120
 
 You can use Rancher to create a cluster hosted in Alibaba Cloud Kubernetes (ACK). Rancher has already implemented and packaged the [cluster driver]({{<baseurl>}}/rancher/v2.6/en/admin-settings/drivers/cluster-drivers/) for ACK, but by default, this cluster driver is `inactive`. In order to launch ACK clusters, you will need to [enable the ACK cluster driver]({{<baseurl>}}/rancher/v2.6/en/admin-settings/drivers/cluster-drivers/#activating-deactivating-cluster-drivers). After enabling the cluster driver, you can start provisioning ACK clusters.
 
-## Prerequisites
+# Prerequisites Outside of Rancher
 
 >**Note**
 >Deploying to ACK will incur charges.
@@ -23,31 +23,34 @@ You can use Rancher to create a cluster hosted in Alibaba Cloud Kubernetes (ACK)
 
 4. In Alibaba Cloud, create an [SSH key pair](https://www.alibabacloud.com/help/doc-detail/51793.html). This key is used to access nodes in the Kubernetes cluster.
 
-## Create an ACK Cluster
+# Prerequisite in Rancher
 
-1. From the **Clusters** page, click **Add Cluster**.
+You will need to enable the Alibaba ACK cluster driver:
 
+1. Click **☰ > Cluster Management**.
+1. Click **Drivers**.
+1. In the **Cluster Drivers** tab, go to the **Alibaba ACK** cluster driver and click **⋮ > Activate**.
+
+When the cluster driver is finished downloading, you will be able to create Alibaba ACK clusters in Rancher.
+
+# Create an ACK Cluster
+
+1. Click **☰ > Cluster Management**.
+1. From the **Clusters** page, click **Create**.
 1. Choose **Alibaba ACK**.
-
 1. Enter a **Cluster Name**.
-
 1. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
-
 1. Configure **Account Access** for the ACK cluster. Choose the geographical region in which to build your cluster, and input the access key that was created as part of the prerequisite steps.
-
 1. Click **Next: Configure Cluster**, then choose cluster type, the version of Kubernetes and the availability zone.
-
 1. If you choose **Kubernetes** as the cluster type, Click **Next: Configure Master Nodes**, then complete the **Master Nodes** form.
-
 1. Click **Next: Configure Worker Nodes**, then complete the **Worker Nodes** form.
-
 1. Review your options to confirm they're correct. Then click **Create**.
 
 **Result:** 
 
-Your cluster is created and assigned a state of **Provisioning.** Rancher is standing up your cluster.
+Your cluster is created and assigned a state of **Provisioning**. Rancher is standing up your cluster.
 
-You can access your cluster after its state is updated to **Active.**
+You can access your cluster after its state is updated to **Active**.
 
 **Active** clusters are assigned two Projects: 
 

--- a/content/rancher/v2.6/en/cluster-provisioning/hosted-kubernetes-clusters/aks/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/hosted-kubernetes-clusters/aks/_index.md
@@ -2,8 +2,6 @@
 title: Creating an AKS Cluster
 shortTitle: Azure Kubernetes Service
 weight: 2115
-aliases:
-  - /rancher/v2.6/en/tasks/clusters/creating-a-cluster/create-cluster-azure-container-service/
 ---
 
 You can use Rancher to create a cluster hosted in Microsoft Azure Kubernetes Service (AKS).
@@ -79,51 +77,53 @@ You can also follow these instructions to set up a service principal and give it
 
 1. Go to the Microsoft Azure Portal [home page](https://portal.azure.com).
 
-1. Click **Azure Active Directory.**
-1. Click **App registrations.**
-1. Click **New registration.**
+1. Click **Azure Active Directory**.
+1. Click **App registrations**.
+1. Click **New registration**.
 1. Enter a name. This will be the name of your service principal.
 1. Optional: Choose which accounts can use the service principal.
-1. Click **Register.**
-1. You should now see the name of your service principal under **Azure Active Directory > App registrations.** 
-1. Click the name of your service principal. Take note of the tenant ID and application ID (also called app ID or client ID) so that you can use it when provisioning your AKS cluster. Then click **Certificates & secrets.**
-1. Click **New client secret.**
-1. Enter a short description, pick an expiration time, and click **Add.** Take note of the client secret so that you can use it when provisioning the AKS cluster.
+1. Click **Register**.
+1. You should now see the name of your service principal under **Azure Active Directory > App registrations**. 
+1. Click the name of your service principal. Take note of the tenant ID and application ID (also called app ID or client ID) so that you can use it when provisioning your AKS cluster. Then click **Certificates & secrets**.
+1. Click **New client secret**.
+1. Enter a short description, pick an expiration time, and click **Add**. Take note of the client secret so that you can use it when provisioning the AKS cluster.
 
-**Result:** You have created a service principal and you should be able to see it listed in the **Azure Active Directory** section under **App registrations.** You still need to give the service principal access to AKS. 
+**Result:** You have created a service principal and you should be able to see it listed in the **Azure Active Directory** section under **App registrations**. You still need to give the service principal access to AKS. 
 
 To give role-based access to your service principal,
 
-1. Click **All Services** in the left navigation bar. Then click **Subscriptions.**
+1. Click **All Services** in the left navigation bar. Then click **Subscriptions**.
 1. Click the name of the subscription that you want to associate with your Kubernetes cluster. Take note of the subscription ID so that you can use it when provisioning your AKS cluster.
-1. Click **Access Control (IAM).**
-1. In the **Add role assignment** section, click **Add.**
+1. Click **Access Control (IAM)**.
+1. In the **Add role assignment** section, click **Add**.
 1. In the **Role** field, select a role that will have access to AKS. For example, you can use the **Contributor** role, which has permission to manage everything except for giving access to other users.
-1. In the **Assign access to** field, select **Azure AD user, group, or service principal.**
-1. In the **Select** field, select the name of your service principal and click **Save.**
+1. In the **Assign access to** field, select **Azure AD user, group, or service principal**.
+1. In the **Select** field, select the name of your service principal and click **Save**.
 
 **Result:** Your service principal now has access to AKS.
 
 # 1. Create the AKS Cloud Credentials
 
-1. In the Rancher UI, click **☰ > Cluster Management.**
-1. Click **Cloud Credentials.**
-1. Click **Create.**
-1. Click **Azure.**
+1. In the Rancher UI, click **☰ > Cluster Management**.
+1. Click **Cloud Credentials**.
+1. Click **Create**.
+1. Click **Azure**.
 1. Fill out the form. For help with filling out the form, see the [configuration reference.]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/editing-clusters/aks-config-reference/#cloud-credentials)
+1. Click **Create**.
 
 # 2. Create the AKS Cluster
 
 Use Rancher to set up and configure your Kubernetes cluster.
 
-1. In the Rancher UI, click **☰ > Cluster Management.**
-1. In the **Clusters** section, click **Create.**
-1. Click **Azure AKS.**
+1. Click **☰ > Cluster Management**.
+1. In the **Clusters** section, click **Create**.
+1. Click **Azure AKS**.
 1. Fill out the form. For help with filling out the form, see the [configuration reference.]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/editing-clusters/aks-config-reference)
+1. Click **Create**.
 
-**Result:** Your cluster is created and assigned a state of **Provisioning.** Rancher is standing up your cluster.
+**Result:** Your cluster is created and assigned a state of **Provisioning**. Rancher is standing up your cluster.
 
-You can access your cluster after its state is updated to **Active.**
+You can access your cluster after its state is updated to **Active**.
 
 # Role-based Access Control
 When provisioning an AKS cluster in the Rancher UI, RBAC is not configurable because it is required to be enabled.

--- a/content/rancher/v2.6/en/cluster-provisioning/hosted-kubernetes-clusters/cce/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/hosted-kubernetes-clusters/cce/_index.md
@@ -6,7 +6,7 @@ weight: 2130
 
 You can use Rancher to create a cluster hosted in Huawei Cloud Container Engine (CCE). Rancher has already implemented and packaged the [cluster driver]({{<baseurl>}}/rancher/v2.6/en/admin-settings/drivers/cluster-drivers/) for CCE, but by default, this cluster driver is `inactive`. In order to launch CCE clusters, you will need to [enable the CCE cluster driver]({{<baseurl>}}/rancher/v2.6/en/admin-settings/drivers/cluster-drivers/#activating-deactivating-cluster-drivers). After enabling the cluster driver, you can start provisioning CCE clusters.
 
-## Prerequisites in Huawei
+# Prerequisites in Huawei
 
 >**Note**
 >Deploying to CCE will incur charges.
@@ -15,14 +15,24 @@ You can use Rancher to create a cluster hosted in Huawei Cloud Container Engine 
 
 2. Create an [Access Key ID and Secret Access Key](https://support.huaweicloud.com/en-us/usermanual-iam/en-us_topic_0079477318.html).
 
-## Limitations
+# Prerequisite in Rancher
+
+You will need to enable the Huawei CCE cluster driver:
+
+1. Click **☰ > Cluster Management**.
+1. Click **Drivers**.
+1. In the **Cluster Drivers** tab, go to the **Huawei CCE** cluster driver and click **⋮ > Activate**.
+
+When the cluster driver is finished downloading, you will be able to create Huawei CCE clusters in Rancher.
+
+# Limitations
 
 Huawei CCE service doesn't support the ability to create clusters with public access through their API. You are required to run Rancher in the same VPC as the CCE clusters that you want to provision.
 
-## Create the CCE Cluster
+# Create the CCE Cluster
 
-1. From the **Clusters** page, click **Add Cluster**.
-1. Choose **Huawei CCE**.
+1. From the **Clusters** page, click **Create**.
+1. Click **Huawei CCE**.
 1. Enter a **Cluster Name**.
 1. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
 1. Enter **Project Id**, Access Key ID as **Access Key** and Secret Access Key **Secret Key**. Then Click **Next: Configure cluster**. Fill in the cluster configuration. For help filling out the form, refer to [Huawei CCE Configuration.](#huawei-cce-configuration)
@@ -31,9 +41,9 @@ Huawei CCE service doesn't support the ability to create clusters with public ac
 
 **Result:** 
 
-Your cluster is created and assigned a state of **Provisioning.** Rancher is standing up your cluster.
+Your cluster is created and assigned a state of **Provisioning**. Rancher is standing up your cluster.
 
-You can access your cluster after its state is updated to **Active.**
+You can access your cluster after its state is updated to **Active**.
 
 **Active** clusters are assigned two Projects: 
 

--- a/content/rancher/v2.6/en/cluster-provisioning/hosted-kubernetes-clusters/eks/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/hosted-kubernetes-clusters/eks/_index.md
@@ -2,8 +2,6 @@
 title: Creating an EKS Cluster
 shortTitle: Amazon EKS
 weight: 2110
-aliases:
-  - /rancher/v2.6/en/tasks/clusters/creating-a-cluster/create-cluster-eks/
 ---
 Amazon EKS provides a managed control plane for your Kubernetes cluster. Amazon EKS runs the Kubernetes control plane instances across multiple Availability Zones to ensure high availability. Rancher provides an intuitive user interface for managing and deploying the Kubernetes clusters you run in Amazon EKS. With this guide, you will use Rancher to quickly and easily launch an Amazon EKS Kubernetes cluster in your AWS account. For more information on Amazon EKS, see this [documentation](https://docs.aws.amazon.com/eks/latest/userguide/what-is-eks.html).
 
@@ -49,23 +47,19 @@ For more detailed information on IAM policies for EKS, refer to the official [do
 
 Use Rancher to set up and configure your Kubernetes cluster.
 
-1. From the **Clusters** page, click **Add Cluster**.
-
+1. Click **☰ > Cluster Management**.
+1. On the **Clusters** page, click **Create**.
 1. Choose **Amazon EKS**.
-
-1. Enter a **Cluster Name.**
-
+1. Enter a **Cluster Name**.
 1. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
-
 1. Fill out the rest of the form. For help, refer to the [configuration reference.](#eks-cluster-configuration-reference) 
-
 1. Click **Create**.
 
 **Result:** 
 
-Your cluster is created and assigned a state of **Provisioning.** Rancher is standing up your cluster.
+Your cluster is created and assigned a state of **Provisioning**. Rancher is standing up your cluster.
 
-You can access your cluster after its state is updated to **Active.**
+You can access your cluster after its state is updated to **Active**.
 
 **Active** clusters are assigned two Projects: 
 

--- a/content/rancher/v2.6/en/cluster-provisioning/hosted-kubernetes-clusters/gke/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/hosted-kubernetes-clusters/gke/_index.md
@@ -2,9 +2,6 @@
 title: Managing GKE Clusters
 shortTitle: Google Kubernetes Engine
 weight: 2105
-aliases:
-  - /rancher/v2.6/en/tasks/clusters/creating-a-cluster/create-cluster-gke/
-  - /rancher/v2.6/en/cluster-provisioning/hosted-kubernetes-clusters/gke
 ---
 
 - [Prerequisites](#prerequisites)
@@ -48,32 +45,33 @@ To get the project ID of an existing project, refer to the Google cloud document
 
 ### 1. Create a Cloud Credential
 
-1. In the upper right corner, click the user profile dropdown menu and click **Cloud Credentials.**
-1. Click **Add Cloud Credential.**
+1. Click **☰ > Cluster Management**.
+1. In the left navigation bar, click **Cloud Credentials**.
+1. Click **Create**.
 1. Enter a name for your Google cloud credentials.
-1. In the **Cloud Credential Type** field, select **Google.**
 1. In the **Service Account** text box, paste your service account private key JSON, or upload the JSON file.
-1. Click **Create.**
+1. Click **Create**.
 
 **Result:** You have created credentials that Rancher will use to provision the new GKE cluster.
 
 ### 2. Create the GKE Cluster
 Use Rancher to set up and configure your Kubernetes cluster.
 
-1. From the **Clusters** page, click **Add Cluster**.
-1. Under **With a hosted Kubernetes provider,** click **Google GKE**.
+1. Click **☰ > Cluster Management**.
+1. On the **Clusters** page, click **Create**.
+1. Click **Google GKE**.
 1. Enter a **Cluster Name**.
 1. Optional: Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
 1. Optional: Add Kubernetes [labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) or [annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) to the cluster.
 1. Enter your Google project ID and your Google cloud credentials.
 1. Fill out the rest of the form. For help, refer to the [GKE cluster configuration reference.](./config-reference)
-1. Click **Create.**
+1. Click **Create**.
 
 **Result:** You have successfully deployed a GKE cluster.
 
-Your cluster is created and assigned a state of **Provisioning.** Rancher is standing up your cluster.
+Your cluster is created and assigned a state of **Provisioning**. Rancher is standing up your cluster.
 
-You can access your cluster after its state is updated to **Active.**
+You can access your cluster after its state is updated to **Active**.
 
 **Active** clusters are assigned two Projects: 
 

--- a/content/rancher/v2.6/en/cluster-provisioning/hosted-kubernetes-clusters/tke/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/hosted-kubernetes-clusters/tke/_index.md
@@ -6,7 +6,7 @@ weight: 2125
 
 You can use Rancher to create a cluster hosted in Tencent Kubernetes Engine (TKE). Rancher has already implemented and packaged the [cluster driver]({{<baseurl>}}/rancher/v2.6/en/admin-settings/drivers/cluster-drivers/) for TKE, but by default, this cluster driver is `inactive`. In order to launch TKE clusters, you will need to [enable the TKE cluster driver]({{<baseurl>}}/rancher/v2.6/en/admin-settings/drivers/cluster-drivers/#activating-deactivating-cluster-drivers). After enabling the cluster driver, you can start provisioning TKE clusters.
 
-## Prerequisites in Tencent
+# Prerequisites in Tencent
 
 >**Note**
 >Deploying to TKE will incur charges.
@@ -19,9 +19,19 @@ You can use Rancher to create a cluster hosted in Tencent Kubernetes Engine (TKE
 
 4. Create a [SSH key pair](https://intl.cloud.tencent.com/document/product/213/6092). This key is used to access the nodes in the Kubernetes cluster.
 
-## Create a TKE Cluster
+# Prerequisite in Rancher
 
-1. From the **Clusters** page, click **Add Cluster**.
+You will need to enable the Tencent TKE cluster driver:
+
+1. Click **☰ > Cluster Management**.
+1. Click **Drivers**.
+1. In the **Cluster Drivers** tab, go to the **Tencent TKE** cluster driver and click **⋮ > Activate**.
+
+When the cluster driver is finished downloading, you will be able to create Tencent TKE clusters in Rancher.
+
+# Create a TKE Cluster
+
+1. From the **Clusters** page, click **Create**.
 
 2. Choose **Tencent TKE**.
 
@@ -74,9 +84,9 @@ You can use Rancher to create a cluster hosted in Tencent Kubernetes Engine (TKE
 
 **Result:** 
 
-Your cluster is created and assigned a state of **Provisioning.** Rancher is standing up your cluster.
+Your cluster is created and assigned a state of **Provisioning**. Rancher is standing up your cluster.
 
-You can access your cluster after its state is updated to **Active.**
+You can access your cluster after its state is updated to **Active**.
 
 **Active** clusters are assigned two Projects: 
 

--- a/content/rancher/v2.6/en/cluster-provisioning/registered-clusters/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/registered-clusters/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Registering Existing Clusters
 weight: 6
-aliases:
-  - /rancher/v2.6/en/cluster-provisioning/imported-clusters
 ---
 
 The cluster registration feature replaced the feature to import clusters.
@@ -36,11 +34,12 @@ If you are registering a K3s cluster, make sure the `cluster.yml` is readable. I
 
 # Registering a Cluster
 
-1. From the **Clusters** page, click **Add Cluster**.
-2. Choose **Register**.
-3. Enter a **Cluster Name**.
+1. Click **☰ > Cluster Management**.
+1. On the **Clusters** page, **Import Existing**.
+1. Enter a **Cluster Name**.
+1. Choose the type of cluster.
 4. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
-5. Use **Agent Environment Variables** under **Cluster Options** to set environment variables for [rancher cluster agent]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/rancher-agents/). The environment variables can be set using key value pairs. If rancher agent requires use of proxy to communicate with Rancher server, `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment variables can be set using agent environment variables.
+5. If it is a generic custom cluster, use **Agent Environment Variables** under **Cluster Options** to set environment variables for [rancher cluster agent]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/rancher-agents/). The environment variables can be set using key value pairs. If rancher agent requires use of proxy to communicate with Rancher server, `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment variables can be set using agent environment variables.
 6. Click **Create**.
 7. The prerequisite for `cluster-admin` privileges is shown (see **Prerequisites** above), including an example command to fulfil the prerequisite.
 8. Copy the `kubectl` command to your clipboard and run it on a node where kubeconfig is configured to point to the cluster you want to import. If you are unsure it is configured correctly, run `kubectl get nodes` to verify before running the command shown in Rancher.
@@ -50,8 +49,8 @@ If you are registering a K3s cluster, make sure the `cluster.yml` is readable. I
 
 **Result:**
 
-- Your cluster is registered and assigned a state of **Pending.** Rancher is deploying resources to manage your cluster.</li>
-- You can access your cluster after its state is updated to **Active.**
+- Your cluster is registered and assigned a state of **Pending**. Rancher is deploying resources to manage your cluster.</li>
+- You can access your cluster after its state is updated to **Active**.
 - **Active** clusters are assigned two Projects: `Default` (containing the namespace `default`) and `System` (containing the namespaces `cattle-system`, `ingress-nginx`, `kube-public` and `kube-system`, if present).
 
 
@@ -191,11 +190,12 @@ All the capabilities and their type definitions can be viewed in the Rancher API
 
 To annotate a registered cluster,
 
-1. Go to the cluster view in Rancher and select **&#8942; > Edit.**
+1. Click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the custom cluster you want to annotate and click **⋮ > Edit Config**.
 1. Expand the **Labels & Annotations** section.
-1. Click **Add Annotation.**
+1. Click **Add Annotation**.
 1. Add an annotation to the cluster with the format `capabilities/<capability>: <value>` where `value` is the cluster capability that will be overridden by the annotation. In this scenario, Rancher is not aware of any capabilities of the cluster until you add the annotation.
-1. Click **Save.**
+1. Click **Save**.
 
 **Result:** The annotation does not give the capabilities to the cluster, but it does indicate to Rancher that the cluster has those capabilities.
 

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/cloud-providers/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/cloud-providers/_index.md
@@ -1,9 +1,6 @@
 ---
 title: Setting up Cloud Providers
 weight: 2300
-aliases:
-  - /rancher/v2.6/en/concepts/clusters/cloud-providers/
-  - /rancher/v2.6/en/cluster-provisioning/rke-clusters/options/cloud-providers
 ---
 A _cloud provider_ is a module in Kubernetes that provides an interface for managing nodes, load balancers, and networking routes. For more information, refer to the [official Kubernetes documentation on cloud providers.](https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/)
 

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/cloud-providers/gce/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/cloud-providers/gce/_index.md
@@ -7,12 +7,12 @@ In this section, you'll learn how to enable the Google Compute Engine (GCE) clou
 
 The official Kubernetes documentation for the GCE cloud provider is [here.](https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#gce)
 
-> **Prerequisites:** The service account of `Identity and API` access on GCE needs the `Computer Admin` permission. 
+> **Prerequisites:** The service account of `Identity and API` access on GCE needs the `Computer Admin` permission.
 
 If you are using Calico,
 
-1. Go to the cluster view in the Rancher UI, and click **&#8942; > Edit.**
-1. Click **Edit as YAML,** and enter the following configuration:
+1. Click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the custom cluster and click **⋮ > Edit YAML.* Enter the following configuration:
 
     ```
     rancher_kubernetes_engine_config:
@@ -33,8 +33,8 @@ If you are using Calico,
 
 If you are using Canal or Flannel,
 
-1. Go to the cluster view in the Rancher UI, and click **&#8942; > Edit.**
-1. Click **Edit as YAML,** and enter the following configuration:
+1. Click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the custom cluster and click **⋮ > Edit YAML.* Enter the following configuration:
 
     ```
     rancher_kubernetes_engine_config:

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/cloud-providers/vsphere/in-tree/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/cloud-providers/vsphere/in-tree/_index.md
@@ -7,9 +7,6 @@ weight: 10
 To set up the in-tree vSphere cloud provider, follow these steps while creating the vSphere cluster in Rancher:
 
 1. Set **Cloud Provider** option to `Custom` or `Custom (In-Tree)`.
-
-    {{< img "/img/rancher/vsphere-node-driver-cloudprovider.png" "vsphere-node-driver-cloudprovider">}}
-
 1. Click on **Edit as YAML**
 1. Insert the following structure to the pre-populated cluster YAML. This structure must be placed under `rancher_kubernetes_engine_config`. Note that the `name` *must* be set to `vsphere`. 
 

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/cloud-providers/vsphere/out-of-tree/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/cloud-providers/vsphere/out-of-tree/_index.md
@@ -22,14 +22,20 @@ The Cloud Provider Interface (CPI) should be installed first before installing t
 
 ### 1. Create a vSphere cluster
 
-1. On the Clusters page, click on **Add Cluster** and select the **vSphere** option or **Existing Nodes** option.
-1. Under **Cluster Options > Cloud Provider** select **External (Out-of-tree)**. This sets the cloud provider option on the Kubernetes cluster to `external` which sets your Kubernetes cluster up to be configured with an out-of-tree cloud provider. 
+1. Click **☰ > Cluster Management**.
+1. On the **Clusters** page, click **Create**.
+1. Click **VMware vSphere** or **Custom**.
+1. On the **Basics** tab in the **Cluster Configuration** section, set the **Cloud Provider** to **vSphere**.
+1. In the **Add-On Config** tab, the vSphere Cloud Provider (CPI) and Storage Provider (CSI) options.
 1. Finish creating your cluster.
 
 ### 2. Install the CPI plugin
  
-1. From the **Cluster Explorer** view, go to the top left dropdown menu and click **Apps & Marketplace.**
-1. Select the **vSphere CPI** chart. Fill out the required vCenter details.
+1. Click **☰ > Cluster Management**.
+1. Go to the cluster where the vSphere CPI plugin will be installed and click **Explore**.
+1. Click **Apps & Marketplace > Charts**.
+1. Click **vSphere CPI**.
+1. Fill out the required vCenter details.
 1. vSphere CPI initializes all nodes with ProviderID which is needed by the vSphere CSI driver. Check if all nodes are initialized with the ProviderID before installing CSI driver with the following command:
 
 	```
@@ -38,10 +44,14 @@ The Cloud Provider Interface (CPI) should be installed first before installing t
 
 ### 3. Installing the CSI plugin
 
- 1. From the **Cluster Explorer** view, go to the top left dropdown menu and click **Apps & Marketplace.**
-1. Select the **vSphere CSI** chart. Fill out the required vCenter details.
-2. Set **Enable CSI Migration** to **false**.
-3. This chart creates a StorageClass with the `csi.vsphere.vmware.com` as the provisioner. Fill out the details for the StorageClass and launch the chart.
+1. Click **☰ > Cluster Management**.
+1. Go to the cluster where the vSphere CSI plugin will be installed and click **Explore**.
+1. Click **Apps & Marketplace > Charts**.
+1. Click **vSphere CSI**.
+1. Click **Install**.
+1. Fill out the required vCenter details. On the **Features** tab, set **Enable CSI Migration** to **false**.
+3. On the **Storage** tab, fill out the details for the StorageClass. This chart creates a StorageClass with the `csi.vsphere.vmware.com` as the provisioner. 
+1. Click **Install**.
 
 
 # Using the CSI driver for provisioning volumes

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/cloud-providers/vsphere/out-of-tree/vsphere-volume-migration/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/cloud-providers/vsphere/out-of-tree/vsphere-volume-migration/_index.md
@@ -57,9 +57,12 @@ chmod +x taints.sh
 
 Once all nodes are tainted by the running the script, launch the Helm vSphere CPI chart. 
 
-1. From the **Cluster Explorer** view, go to the top left dropdown menu and click **Apps & Marketplace.**
-2. Select the **vSphere CPI** chart.
-3. Fill out the required vCenter details and click **Launch**.
+1. Click **☰ > Cluster Management**.
+1. Go to the cluster where the vSphere CPI chart will be installed and click **Explore**.
+1. Click **Apps & Marketplace > Charts**.
+1. Click **vSphere CPI**..
+1. Click **Install**.
+1. Fill out the required vCenter details and click **Install**.
 
 vSphere CPI initializes all nodes with ProviderID, which is needed by the vSphere CSI driver.
 
@@ -71,11 +74,16 @@ kubectl describe nodes | grep "ProviderID"
 
 ### 2. Install the CSI driver
 
-1. From the **Cluster Explorer** view, go to the top left dropdown menu and click **Apps & Marketplace.**
-1. Select the **vSphere CSI** chart. 
-1. Fill out the required vCenter details and click **Launch**.
-1. Set **Enable CSI Migration** to **true**.
-1. This chart creates a StorageClass with the `csi.vsphere.vmware.com` as the provisioner. You can provide the URL of the datastore to be used for CSI volume provisioning while creating this StorageClass. The datastore URL can be found in the vSphere client by selecting the datastore and going to the Summary tab. Fill out the details for the StorageClass and click **Launch**.
+1. Click **☰ > Cluster Management**.
+1. Go to the cluster where the vSphere CSI chart will be installed and click **Explore**.
+1. Click **Apps & Marketplace > Charts**.
+1. Click **vSphere CSI**..
+1. Click **Install**.
+1. Fill out the required vCenter details and click **Install**.
+1. Check **Customize Helm options before install** and click **Next**.
+1. On the **Features** tab, check **Enable CSI Migration**.
+1. Optionally, go to the **Storage** tab and set up a datastore. This chart creates a StorageClass with the `csi.vsphere.vmware.com` as the provisioner. You can provide the URL of the datastore to be used for CSI volume provisioning while creating this StorageClass. The datastore URL can be found in the vSphere client by selecting the datastore and going to the Summary tab. Fill out the details for the StorageClass.
+1. Click **Install**.
 
 ### 3. Edit the cluster to enable CSI migration feature flags
 
@@ -91,8 +99,10 @@ kubectl describe nodes | grep "ProviderID"
 
 Worker nodes must be drained during the upgrade before changing the kubelet and kube-controller-manager args. 
 
-1. Click **Edit as Form** and then click on "Advanced Options."
-1. Set the field **Maximum Worker Nodes Unavailable** to count of 1.
+
+1. Click **☰ > Cluster Management**.
+1. Go to the cluster where you will drain worker nodes and click **⋮ > Edit Config**.
+1. In the **Advanced Options** section, set the field **Maximum Worker Nodes Unavailable** to 1.
 1. To drain the nodes during upgrade, select **Drain Nodes > Yes**. 
 1. Set **Force** and **Delete Local Data** to **true**.
 1. Click **Save** to upgrade the cluster.

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/custom-nodes/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/custom-nodes/_index.md
@@ -3,9 +3,6 @@ title: Launching Kubernetes on Existing Custom Nodes
 description: To create a cluster with custom nodes, you’ll need to access servers in your cluster and provision them according to Rancher requirements 
 metaDescription: "To create a cluster with custom nodes, you’ll need to access servers in your cluster and provision them according to Rancher requirements"
 weight: 2225
-aliases:
-  - /rancher/v2.6/en/tasks/clusters/creating-a-cluster/create-cluster-custom/
-  - /rancher/v2.6/en/cluster-provisioning/custom-clusters/
 ---
 
 When you create a custom cluster, Rancher uses RKE (the Rancher Kubernetes Engine) to create a Kubernetes cluster in on-prem bare-metal servers, on-prem virtual machines, or in any node hosted by an infrastructure provider.
@@ -42,21 +39,19 @@ Provision the host according to the [installation requirements]({{<baseurl>}}/ra
 
 ### 2. Create the Custom Cluster
 
-1. From the **Clusters** page, click **Add Cluster**.
-
-2. Choose **Custom**.
-
-3. Enter a **Cluster Name**.
-
-4. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
-
-5. Use **Cluster Options** to choose the version of Kubernetes, what network provider will be used and if you want to enable project network isolation. To see more cluster options, click on **Show advanced options.**
+1. Click **☰ > Cluster Management**.
+1. On the **Clusters** page, click **Create**.
+1. Click **Custom**.
+1. Enter a **Cluster Name**.
+1. Use **Cluster Configuration** section to choose the version of Kubernetes, what network provider will be used and if you want to enable project network isolation. To see more cluster options, click on **Show advanced options**.
 
     >**Using Windows nodes as Kubernetes workers?**
     >
     >- See [Enable the Windows Support Option]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/windows-clusters/).
     >- The only Network Provider available for clusters with Windows support is Flannel.
 6.	<a id="step-6"></a>Click **Next**.
+
+4. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
 
 7.	From **Node Role**, choose the roles that you want filled by a cluster node. You must provision at least one node for each role: `etcd`, `worker`, and `control plane`. All three roles are required for a custom cluster to finish provisioning. For more information on roles, see [this section.]({{<baseurl>}}/rancher/v2.6/en/overview/concepts/#roles-for-nodes-in-kubernetes-clusters)
 
@@ -77,9 +72,9 @@ Provision the host according to the [installation requirements]({{<baseurl>}}/ra
 
 **Result:** 
 
-Your cluster is created and assigned a state of **Provisioning.** Rancher is standing up your cluster.
+Your cluster is created and assigned a state of **Provisioning**. Rancher is standing up your cluster.
 
-You can access your cluster after its state is updated to **Active.**
+You can access your cluster after its state is updated to **Active**.
 
 **Active** clusters are assigned two Projects: 
 

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/custom-nodes/agent-options/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/custom-nodes/agent-options/_index.md
@@ -1,9 +1,6 @@
 ---
 title: Rancher Agent Options
 weight: 2500
-aliases:
-  - /rancher/v2.6/en/admin-settings/agent-options/
-  - /rancher/v2.6/en/cluster-provisioning/custom-clusters/agent-options
 ---
 
 Rancher deploys an agent on each node to communicate with the node. This pages describes the options that can be passed to the agent. To use these options, you will need to [create a cluster with custom nodes]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/custom-nodes) and add the options to the generated `docker run` command when adding a node.

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Launching Kubernetes on New Nodes in an Infrastructure Provider
 weight: 2205
-aliases:
-  - /rancher/v2.6/en/concepts/global-configuration/node-templates/
 ---
 
 Using Rancher, you can create pools of nodes based on a [node template]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/#node-templates). This node template defines the parameters you want to use to launch nodes in your infrastructure providers or cloud providers.
@@ -49,10 +47,10 @@ Administrators can control all node templates. Admins can now maintain all the n
 
 To access all node templates, an administrator will need to do the following:
 
-1. In the Rancher UI, click the user profile icon in the upper right corner.
-1. Click **Node Templates.**
+1. Click **☰ > Cluster Management**.
+1. Click **RKE1 Configuration > Node Templates**.
 
-**Result:** All node templates are listed and grouped by owner. The templates can be edited or cloned by clicking the **&#8942;.**
+**Result:** All node templates are listed. The templates can be edited or cloned by clicking the **⋮**.
 
 # Node Pools
 
@@ -92,18 +90,9 @@ Node auto-replace works on top of the Kubernetes node controller. The node contr
 
 When you create the node pool, you can specify the amount of time in minutes that Rancher will wait to replace an unresponsive node.
 
-1. In the form for creating a cluster, go to the **Node Pools** section.
+1. In the form for creating or editing a cluster, go to the **Node Pools** section.
 1. Go to the node pool where you want to enable node auto-replace. In the **Recreate Unreachable After** field, enter the number of minutes that Rancher should wait for a node to respond before replacing the node.
-1. Fill out the rest of the form for creating a cluster.
-
-**Result:** Node auto-replace is enabled for the node pool.
-
-You can also enable node auto-replace after the cluster is created with the following steps:
-
-1. From the Global view, click the Clusters tab.
-1. Go to the cluster where you want to enable node auto-replace, click the vertical &#8942; **(…)**, and click **Edit.**
-1. In the **Node Pools** section, go to the node pool where you want to enable node auto-replace. In the **Recreate Unreachable After** field, enter the number of minutes that Rancher should wait for a node to respond before replacing the node.
-1. Click **Save.**
+1. Fill out the rest of the form for creating or editing the cluster.
 
 **Result:** Node auto-replace is enabled for the node pool.
 
@@ -111,10 +100,10 @@ You can also enable node auto-replace after the cluster is created with the foll
 
 You can disable node auto-replace from the Rancher UI with the following steps:
 
-1. From the Global view, click the Clusters tab.
-1. Go to the cluster where you want to enable node auto-replace, click the vertical &#8942; **(…)**, and click **Edit.**
+1. Click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to disable node auto-replace and click **⋮ > Edit Config**.
 1. In the **Node Pools** section, go to the node pool where you want to enable node auto-replace. In the **Recreate Unreachable After** field, enter 0.
-1. Click **Save.**
+1. Click **Save**.
 
 **Result:** Node auto-replace is disabled for the node pool.
 

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/azure/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/azure/_index.md
@@ -2,8 +2,6 @@
 title: Creating an Azure Cluster
 shortTitle: Azure
 weight: 2220
-aliases:
-  - /rancher/v2.6/en/tasks/clusters/creating-a-cluster/create-cluster-azure/
 ---
 
 In this section, you'll learn how to install an [RKE]({{<baseurl>}}/rke/latest/en/) Kubernetes cluster in Azure through Rancher.
@@ -45,12 +43,12 @@ The creation of this service principal returns three pieces of identification in
  
 ### 1. Create your cloud credentials
 
-1. In the Rancher UI, click the user profile button in the upper right corner, and click **Cloud Credentials.**
-1. Click **Add Cloud Credential.**
-1. Enter a name for the cloud credential.
-1. In the **Cloud Credential Type** field, select **Azure**.
+1. Click **☰ > Cluster Management**.
+1. Click **Cloud Credentials**.
+1. Click **Create**.
+1. Click **Azure**.
 1. Enter your Azure credentials.
-1. Click **Create.**
+1. Click **Create**.
 
 **Result:** You have created the cloud credentials that will be used to provision nodes in your cluster. You can reuse these credentials for other node templates, or in other clusters. 
 
@@ -58,27 +56,30 @@ The creation of this service principal returns three pieces of identification in
 
 Creating a [node template]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/#node-templates) for Azure will allow Rancher to provision new nodes in Azure. Node templates can be reused for other clusters.
 
-1. In the Rancher UI, click the user profile button in the upper right corner, and click **Node Templates.**
-1. Click **Add Template.**
+1. Click **☰ > Cluster Management**.
+1. Click **RKE1 Configuration > Node Templates**.
+1. Click **Add Template**.
+1. Click **Azure**.
 1. Fill out a node template for Azure. For help filling out the form, refer to [Azure Node Template Configuration.](./azure-node-template-config)
 
 ### 3. Create a cluster with node pools using the node template
 
 Use Rancher to create a Kubernetes cluster in Azure.
 
-1. From the **Clusters** page, click **Add Cluster**.
-1. Choose **Azure**.
+1. Click **☰ > Cluster Management**.
+1. On the **Clusters** page, click **Create**.
+1. Click **Azure**.
 1. Enter a **Cluster Name**.
-1. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
-1. Use **Cluster Options** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. To see more cluster options, click on **Show advanced options.** For help configuring the cluster, refer to the [RKE cluster configuration reference.]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/options)
 1. Add one or more node pools to your cluster. Each node pool uses a node template to provision new nodes. For more information about node pools, including best practices, see [this section.]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools)
-1. Review your options to confirm they're correct. Then click **Create**.
+1. In the **Cluster Configuration** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. To see more cluster options, click on **Show advanced options**. For help configuring the cluster, refer to the [RKE cluster configuration reference.]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/options)
+1. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
+1. Click **Create**.
 
 **Result:** 
 
-Your cluster is created and assigned a state of **Provisioning.** Rancher is standing up your cluster.
+Your cluster is created and assigned a state of **Provisioning**. Rancher is standing up your cluster.
 
-You can access your cluster after its state is updated to **Active.**
+You can access your cluster after its state is updated to **Active**.
 
 **Active** clusters are assigned two Projects: 
 

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/digital-ocean/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/digital-ocean/_index.md
@@ -2,8 +2,6 @@
 title: Creating a DigitalOcean Cluster
 shortTitle: DigitalOcean
 weight: 2215
-aliases:
-  - /rancher/v2.6/en/tasks/clusters/creating-a-cluster/create-cluster-digital-ocean/
 ---
 In this section, you'll learn how to use Rancher to install an [RKE](https://rancher.com/docs/rke/latest/en/) Kubernetes cluster in DigitalOcean.
 
@@ -18,12 +16,12 @@ Then you will create a DigitalOcean cluster in Rancher, and when configuring the
 
 ### 1. Create your cloud credentials
 
-1. In the Rancher UI, click the user profile button in the upper right corner, and click **Cloud Credentials.**
-1. Click **Add Cloud Credential.**
-1. Enter a name for the cloud credential.
-1. In the **Cloud Credential Type** field, select **DigitalOcean**.
+1. Click **☰ > Cluster Management**.
+1. Click **Cloud Credentials**.
+1. Click **Create**.
+1. Click **DigitalOcean**.
 1. Enter your Digital Ocean credentials.
-1. Click **Create.**
+1. Click **Create**.
 
 **Result:** You have created the cloud credentials that will be used to provision nodes in your cluster. You can reuse these credentials for other node templates, or in other clusters. 
 
@@ -31,25 +29,28 @@ Then you will create a DigitalOcean cluster in Rancher, and when configuring the
 
 Creating a [node template]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/#node-templates) for DigitalOcean will allow Rancher to provision new nodes in DigitalOcean. Node templates can be reused for other clusters.
 
-1. In the Rancher UI, click the user profile button in the upper right corner, and click **Node Templates.**
-1. Click **Add Template.**
+1. Click **☰ > Cluster Management**.
+1. Click **RKE1 Configuration > Node Templates**.
+1. Click **Add Template**.
+1. Click **DigitalOcean**.
 1. Fill out a node template for DigitalOcean. For help filling out the form, refer to [DigitalOcean Node Template Configuration.](./do-node-template-config)
 
 ### 3. Create a cluster with node pools using the node template
 
-1. From the **Clusters** page, click **Add Cluster**.
-1. Choose **DigitalOcean**.
+1. Click **☰ > Cluster Management**.
+1. On the **Clusters** page, click **Create**.
+1. Click **DigitalOcean**.
 1. Enter a **Cluster Name**.
+1. Add one or more node pools to your cluster. Add one or more node pools to your cluster. Each node pool uses a node template to provision new nodes. For more information about node pools, including best practices for assigning Kubernetes roles to them, see [this section.]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools)
+1. **In the Cluster Configuration** section, choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. To see more cluster options, click on **Show advanced options**. For help configuring the cluster, refer to the [RKE cluster configuration reference.]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/options)
 1. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
-1. Use **Cluster Options** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. To see more cluster options, click on **Show advanced options.** For help configuring the cluster, refer to the [RKE cluster configuration reference.]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/options)
-1. Add one or more node pools to your cluster. Add one or more node pools to your cluster. Each node pool uses a node template to provision new nodes. For more information about node pools, including best practices for assigning Kubernetes roles to them, see [this section.]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools) 
-1. Review your options to confirm they're correct. Then click **Create**.
+1. Click **Create**.
 
 **Result:** 
 
-Your cluster is created and assigned a state of **Provisioning.** Rancher is standing up your cluster.
+Your cluster is created and assigned a state of **Provisioning**. Rancher is standing up your cluster.
 
-You can access your cluster after its state is updated to **Active.**
+You can access your cluster after its state is updated to **Active**.
 
 **Active** clusters are assigned two Projects: 
 

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/ec2/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/ec2/_index.md
@@ -29,13 +29,14 @@ The steps to create a cluster differ based on your Rancher version.
 
 ### 1. Create your cloud credentials
 
-1. In the Rancher UI, click the user profile button in the upper right corner, and click **Cloud Credentials.**
-1. Click **Add Cloud Credential.**
+1. Click **☰ > Cluster Management**.
+1. Click **Cloud Credentials**.
+1. Click **Create**.
+1. Click **Amazon**.
 1. Enter a name for the cloud credential.
-1. In the **Cloud Credential Type** field, select **Amazon.**
-1. In the **Region** field, select the AWS region where your cluster nodes will be located.
-1. Enter your AWS EC2 **Access Key** and **Secret Key.**
-1. Click **Create.**
+1. In the **Default Region** field, select the AWS region where your cluster nodes will be located.
+1. Enter your AWS EC2 **Access Key** and **Secret Key**.
+1. Click **Create**.
 
 **Result:** You have created the cloud credentials that will be used to provision nodes in your cluster. You can reuse these credentials for other node templates, or in other clusters. 
 
@@ -43,17 +44,19 @@ The steps to create a cluster differ based on your Rancher version.
 
 Creating a [node template]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/#node-templates) for EC2 will allow Rancher to provision new nodes in EC2. Node templates can be reused for other clusters.
 
-1. In the Rancher UI, click the user profile button in the upper right corner, and click **Node Templates.**
-1. Click **Add Template.**
+1. Click **☰ > Cluster Management**.
+1. Click **RKE1 Configuration > Node Templates**
+1. Click **Add Template**.
 1. Fill out a node template for EC2. For help filling out the form, refer to [EC2 Node Template Configuration.](./ec2-node-template-config)
+1. Click **Create**.
 
 ### 3. Create a cluster with node pools using the node template
 
 Add one or more node pools to your cluster. For more information about node pools, see [this section.]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools)
 
-1. From the **Clusters** page, click **Add Cluster**.
-1. Choose **Amazon EC2**.
-1. Enter a **Cluster Name**.
+1. Click **☰ > Cluster Management**.
+1. On the **Clusters** page, click **Create**.
+1. Click **Amazon EC2**.
 1. Create a node pool for each Kubernetes role. For each node pool, choose a node template that you created. For more information about node pools, including best practices for assigning Kubernetes roles to them, see [this section.]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools) 
 1. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
 1. Use **Cluster Options** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. Refer to [Selecting Cloud Providers]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/options/cloud-providers/) to configure the Kubernetes Cloud Provider. For help configuring the cluster, refer to the [RKE cluster configuration reference.]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/options)
@@ -61,14 +64,15 @@ Add one or more node pools to your cluster. For more information about node pool
 
 **Result:** 
 
-Your cluster is created and assigned a state of **Provisioning.** Rancher is standing up your cluster.
+Your cluster is created and assigned a state of **Provisioning**. Rancher is standing up your cluster.
 
-You can access your cluster after its state is updated to **Active.**
+You can access your cluster after its state is updated to **Active**.
 
 **Active** clusters are assigned two Projects: 
 
 - `Default`, containing the `default` namespace
 - `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+
 ### Optional Next Steps
 
 After creating your cluster, you can access it through the Rancher UI. As a best practice, we recommend setting up these alternate ways of accessing your cluster:

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/vsphere/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/vsphere/_index.md
@@ -4,8 +4,6 @@ shortTitle: vSphere
 description: Use Rancher to create a vSphere cluster. It may consist of groups of VMs with distinct properties which allow for fine-grained control over the sizing of nodes. 
 metaDescription: Use Rancher to create a vSphere cluster. It may consist of groups of VMs with distinct properties which allow for fine-grained control over the sizing of nodes. 
 weight: 2225
-aliases:
-  - /rancher/v2.6/en/tasks/clusters/creating-a-cluster/create-cluster-vsphere/
 ---
 
 By using Rancher with vSphere, you can bring cloud operations on-premises.

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/vsphere/creating-credentials/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/vsphere/creating-credentials/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Creating Credentials in the vSphere Console
 weight: 3
-aliases:
-  - /rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/vsphere/provisioning-vsphere-clusters/creating-credentials
 ---
 
 This section describes how to create a vSphere username and password. You will need to provide these vSphere credentials to Rancher, which allows Rancher to provision resources in vSphere.

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/vsphere/provisioning-vsphere-clusters/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/vsphere/provisioning-vsphere-clusters/_index.md
@@ -56,12 +56,12 @@ The a vSphere cluster is created in Rancher depends on the Rancher version.
 
 ### 1. Create your cloud credentials
 
-1. In the Rancher UI, click the user profile button in the upper right corner, and click **Cloud Credentials.**
-1. Click **Add Cloud Credential.**
-1. Enter a name for the cloud credential.
-1. In the **Cloud Credential Type** field, select **vSphere**.
+1. Click **☰ > Cluster Management**.
+1. Click **Cloud Credentials**.
+1. Click **Create**.
+1. Click **VMware vSphere**.
 1. Enter your vSphere credentials. For help, refer to **Account Access** in the [node template configuration reference.]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/vsphere/vsphere-node-template-config/)
-1. Click **Create.**
+1. Click **Create**.
 
 **Result:** You have created the cloud credentials that will be used to provision nodes in your cluster. You can reuse these credentials for other node templates, or in other clusters. 
 
@@ -69,28 +69,33 @@ The a vSphere cluster is created in Rancher depends on the Rancher version.
 
 Creating a [node template]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/#node-templates) for vSphere will allow Rancher to provision new nodes in vSphere. Node templates can be reused for other clusters.
 
-1. In the Rancher UI, click the user profile button in the upper right corner, and click **Node Templates.**
-1. Click **Add Template.**
+1. Click **☰ > Cluster Management**.
+1. Click **RKE1 Configuration > Node Templates**.
+1. Click **Create**.
+1. Click **Add Template**.
+1. Click **vSphere**.
 1. Fill out a node template for vSphere. For help filling out the form, refer to the vSphere node template [configuration reference.]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/vsphere/vsphere-node-template-config/).
+1. Click **Create**.
 
 ### 3. Create a cluster with node pools using the node template
 
 Use Rancher to create a Kubernetes cluster in vSphere.
 
-1. Navigate to **Clusters** in the **Global** view.
-1. Click **Add Cluster** and select the **vSphere** infrastructure provider.
-1. Enter a **Cluster Name.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, click **Create**.
+1. Click **VMware vSphere**.
+1. Enter a **Cluster Name** and use your vSphere cloud credentials. Click **Continue**.
 1. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
-1. Use **Cluster Options** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. To see more cluster options, click on **Show advanced options.** For help configuring the cluster, refer to the [RKE cluster configuration reference.]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/options)
+1. Use **Cluster Options** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. To see more cluster options, click on **Show advanced options**. For help configuring the cluster, refer to the [RKE cluster configuration reference.]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/options)
 1. If you want to dynamically provision persistent storage or other infrastructure later, you will need to enable the vSphere cloud provider by modifying the cluster YAML file. For details, refer to [this section.]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/cloud-providers/vsphere)
 1. Add one or more node pools to your cluster. Each node pool uses a node template to provision new nodes. For more information about node pools, including best practices for assigning Kubernetes roles to the nodes, see [this section.]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/#node-pools)
 1. Review your options to confirm they're correct. Then click **Create**.
 
 **Result:** 
 
-Your cluster is created and assigned a state of **Provisioning.** Rancher is standing up your cluster.
+Your cluster is created and assigned a state of **Provisioning**. Rancher is standing up your cluster.
 
-You can access your cluster after its state is updated to **Active.**
+You can access your cluster after its state is updated to **Active**.
 
 **Active** clusters are assigned two Projects: 
 

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/vsphere/vsphere-node-template-config/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/vsphere/vsphere-node-template-config/_index.md
@@ -1,9 +1,6 @@
 ---
 title: VSphere Node Template Configuration
 weight: 2
-aliases:
-  - /rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/vsphere/provisioning-vsphere-clusters/node-template-reference
-  - /rancher/v2.6/en/cluster-provisionin/rke-clusters/node-pools/vsphere/provisioning-vsphere-clusters/enabling-uuids
 ---
 
 - [Account Access](#account-access)
@@ -65,7 +62,7 @@ The existing VM or template may use any modern Linux operating system that is co
 Choose the way that the VM will be created:
 
 - **Deploy from template: Data Center:** Choose a VM template that exists in the data center that you selected.
-- **Deploy from template: Content Library:** First, select the [Content Library](https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vm_admin.doc/GUID-254B2CE8-20A8-43F0-90E8-3F6776C2C896.html) that contains your template, then select the template from the populated list **Library templates.**
+- **Deploy from template: Content Library:** First, select the [Content Library](https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vm_admin.doc/GUID-254B2CE8-20A8-43F0-90E8-3F6776C2C896.html) that contains your template, then select the template from the populated list **Library templates**.
 - **Clone an existing virtual machine:** In the **Virtual machine** field, choose an existing VM that the new VM will be cloned from.
 - **Install from boot2docker ISO:** Ensure that the **OS ISO URL** field contains the URL of a VMware ISO release for RancherOS (`rancheros-vmware.iso`). Note that this URL must be accessible from the nodes running your Rancher server installation.
 

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/windows-clusters/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/windows-clusters/_index.md
@@ -140,12 +140,13 @@ If your nodes are hosted by a **Cloud Provider** and you want automation support
 
 The instructions for creating a Windows cluster on existing nodes are very similar to the general [instructions for creating a custom cluster]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/custom-nodes/) with some Windows-specific requirements.
 
-1. From the **Global** view, click on the **Clusters** tab and click **Add Cluster**.
-1. Click **From existing nodes (Custom)**.
-1. Enter a name for your cluster in the **Cluster Name** text box.
-1. In the **Kubernetes Version** dropdown menu, select v1.15 or above.
-1. In the **Network Provider** field, select **Flannel.**
-1. In the **Windows Support** section, click **Enable.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, click **Create**.
+1. Click **Custom**.
+1. Enter a name for your cluster in the **Cluster Name** field.
+1. In the **Kubernetes Version** dropdown menu, select v1.19 or above.
+1. In the **Network Provider** field, select **Flannel**.
+1. In the **Windows Support** section, click **Enabled**.
 1. Optional: After you enable Windows support, you will be able to choose the Flannel backend. There are two network options: [**Host Gateway (L2bridge)**](https://github.com/coreos/flannel/blob/master/Documentation/backends.md#host-gw) and [**VXLAN (Overlay)**](https://github.com/coreos/flannel/blob/master/Documentation/backends.md#vxlan). The default option is **VXLAN (Overlay)** mode.
 1. Click **Next**.
 
@@ -170,9 +171,9 @@ The first node in your cluster should be a Linux host has both the **Control Pla
 
 **Result:** 
 
-Your cluster is created and assigned a state of **Provisioning.** Rancher is standing up your cluster.
+Your cluster is created and assigned a state of **Provisioning**. Rancher is standing up your cluster.
 
-You can access your cluster after its state is updated to **Active.**
+You can access your cluster after its state is updated to **Active**.
 
 **Active** clusters are assigned two Projects: 
 
@@ -188,8 +189,8 @@ In this section, we run a command to register the Linux worker node to the clust
 
 After the initial provisioning of your cluster, your cluster only has a single Linux host. Next, we add another Linux `worker` host, which will be used to support _Rancher cluster agent_, _Metrics server_, _DNS_ and _Ingress_ for your cluster.
 
-1. From the **Global** view, click **Clusters.**
-1. Go to the cluster that you created and click **&#8942; > Edit.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster that you created and click **⋮ > Edit Config**.
 1. Scroll down to **Node Operating System**. Choose **Linux**.
 1. In the **Customize Node Run Command** section, go to the **Node Options** and select the **Worker** role.
 1. Copy the command displayed on screen to your clipboard.
@@ -212,8 +213,8 @@ In this section, we run a command to register the Windows worker node to the clu
 
 You can add Windows hosts to the cluster by editing the cluster and choosing the **Windows** option.
 
-1. From the **Global** view, click **Clusters.**
-1. Go to the cluster that you created and click **&#8942; > Edit.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster that you created and click **⋮ > Edit Config**.
 1. Scroll down to **Node Operating System**. Choose **Windows**. Note: You will see that the **worker** role is the only available role.
 1. Copy the command displayed on screen to your clipboard.
 1. Log in to your Windows host using your preferred tool, such as [Microsoft Remote Desktop](https://docs.microsoft.com/en-us/windows-server/remote/remote-desktop-services/clients/remote-desktop-clients). Run the command copied to your clipboard in the **Command Prompt (CMD)**.

--- a/content/rancher/v2.6/en/contributing/_index.md
+++ b/content/rancher/v2.6/en/contributing/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Contributing to Rancher
 weight: 27
-aliases:
-  - /rancher/v2.6/en/faq/contributing/
 ---
 
 This section explains the repositories used for Rancher, how to build the repositories, and what information to include when you file an issue.

--- a/content/rancher/v2.6/en/deploy-across-clusters/fleet/_index.md
+++ b/content/rancher/v2.6/en/deploy-across-clusters/fleet/_index.md
@@ -19,7 +19,7 @@ For information about how Fleet works, see [this page.](./architecture)
 
 # Accessing Fleet in the Rancher UI
 
-Fleet comes preinstalled in Rancher. To access it, go to the **Cluster Explorer** in the Rancher UI. In the top left dropdown menu, click **Cluster Explorer > Continuous Delivery.** On this page, you can edit Kubernetes resources and cluster groups managed by Fleet.
+Fleet comes preinstalled in Rancher. To access it, click **☰ > Continuous Delivery**.
 
 # Windows Support
 

--- a/content/rancher/v2.6/en/deploy-across-clusters/fleet/proxy/_index.md
+++ b/content/rancher/v2.6/en/deploy-across-clusters/fleet/proxy/_index.md
@@ -29,12 +29,12 @@ When adding Fleet agent environment variables for the proxy, replace <PROXY_IP> 
 
 To add the environment variable to an existing cluster,
 
-1. In the Rancher UI, go to the cluster view for Kubernetes cluster that needs to use a proxy.
-1. Click **&#8942; > Edit**.
-1. Click **Advanced Options.**
-1. Click **Add Environment Variable.**
+1. Click **☰ > Cluster Management**.
+1. Go to the cluster where you want to add environment variables and click **⋮ > Edit Config**.
+1. Click **Advanced Options**.
+1. Click **Add Environment Variable**.
 1. Enter the [required environment variables](#required-environment-variables)
-1. Click **Save.**
+1. Click **Save**.
 
 **Result:** The Fleet agent works behind a proxy.
 

--- a/content/rancher/v2.6/en/deploy-across-clusters/multi-cluster-apps/_index.md
+++ b/content/rancher/v2.6/en/deploy-across-clusters/multi-cluster-apps/_index.md
@@ -3,7 +3,7 @@ title: Multi-cluster Apps
 weight: 2
 ---
 
-> As of Rancher v2.5, we now recommend using [Fleet]({{<baseurl>}}/rancher/v2.6/en/deploy-across-clusters/fleet) for deploying apps across clusters.
+> As of Rancher v2.5, multi-cluster apps are deprecated. We now recommend using [Fleet]({{<baseurl>}}/rancher/v2.6/en/deploy-across-clusters/fleet) for deploying apps across clusters.
 
 Typically, most applications are deployed on a single Kubernetes cluster, but there will be times you might want to deploy multiple copies of the same application across different clusters and/or projects. In Rancher, a _multi-cluster application_,  is an application deployed using a Helm chart across multiple clusters. With the ability to deploy the same application across multiple clusters, it avoids the repetition of the same action on each cluster, which could introduce user error during application configuration. With multi-cluster applications, you can customize to have the same configuration across all projects/clusters as well as have the ability to change the configuration based on your target project. Since multi-cluster application is considered a single application, it's easy to manage and maintain this application.
 
@@ -28,30 +28,33 @@ After creating a multi-cluster application, you can program a global DNS entry t
 
 # Prerequisites
 
+### Permissions
+
 To create a multi-cluster app in Rancher, you must have at least one of the following permissions:
 
 - A [project-member role]({{<baseurl>}}/rancher/v2.6/en/admin-settings/rbac/cluster-project-roles/#project-roles) in the target cluster(s), which gives you the ability to create, read, update, and delete the workloads
 - A [cluster owner role]({{<baseurl>}}/rancher/v2.6/en/admin-settings/rbac/cluster-project-roles/#cluster-roles) for the clusters(s) that include the target project(s)
 
+### Enable Legacy Features
+
+Because multi-cluster apps were deprecated and replaced with Fleet in Rancher v2.5, you will need to enable multi-cluster apps with a feature flag.
+
+1. In the upper left corner, click **☰ > Global Settings**.
+1. Click **Feature Flags**.
+1. Go to the `legacy` feature flag and click **Activate**.
+
 # Launching a Multi-Cluster App
 
-1. From the **Global** view, choose **Apps** in the navigation bar. Click **Launch**.
-
-2. Find the application that you want to launch, and then click **View Details**.
-
-3.  (Optional) Review the detailed descriptions, which are derived from the Helm chart's `README`.
-
-4. Under **Configuration Options** enter a **Name** for the multi-cluster application. By default, this name is also used to create a Kubernetes namespace in each [target project](#targets) for the multi-cluster application. The namespace is named as `<MULTI-CLUSTER_APPLICATION_NAME>-<PROJECT_ID>`.
-
-5. Select a **Template Version**.
-
-6. Complete the [multi-cluster applications specific configuration options](#multi-cluster-app-configuration-options) as well as the [application configuration options](#application-configuration-options).
-
-7. Select the **Members** who can [interact with the multi-cluster application](#members).
-
-8. Add any [custom application configuration answers](#overriding-application-configuration-options-for-specific-projects) that would change the configuration for specific project(s) from the default application configuration answers.
-
-7. Review the files in the **Preview** section. When you're satisfied, click **Launch**.
+1. In the upper left corner, click **☰ > Multi-cluster Apps**.
+1. Click **Launch**.
+1. Find the application that you want to launch.
+1.  (Optional) Review the detailed descriptions, which are derived from the Helm chart's `README`.
+1. Under **Configuration Options** enter a **Name** for the multi-cluster application. By default, this name is also used to create a Kubernetes namespace in each [target project](#targets) for the multi-cluster application. The namespace is named as `<MULTI-CLUSTER_APPLICATION_NAME>-<PROJECT_ID>`.
+1. Select a **Template Version**.
+1. Complete the [multi-cluster applications specific configuration options](#multi-cluster-app-configuration-options) as well as the [application configuration options](#application-configuration-options).
+1. Select the **Members** who can [interact with the multi-cluster application](#members).
+1. Add any [custom application configuration answers](#overriding-application-configuration-options-for-specific-projects) that would change the configuration for specific project(s) from the default application configuration answers.
+1. Review the files in the **Preview** section. When you're satisfied, click **Launch**.
 
 **Result**: Your application is deployed to your chosen namespace. You can view the application status from the project's:
 
@@ -145,9 +148,11 @@ The creator and any users added with the access-type "owner" to a multi-cluster 
 
 One of the benefits of using a multi-cluster application as opposed to multiple individual applications of the same type, is the ease of management. Multi-cluster applications can be cloned, upgraded or rolled back.
 
-1. From the **Global** view, choose **Apps** in the navigation bar.
+> **Prerequisite:** The `legacy` feature flag needs to be enabled.
 
-2. Choose the multi-cluster application you want to take one of these actions on and click the **&#8942;**. Select one of the following options:
+1. In the upper left corner, click **☰ > Multi-cluster Apps**.
+
+2. Choose the multi-cluster application you want to take one of these actions on and click the **⋮**. Select one of the following options:
 
    * **Clone**: Creates another multi-cluster application with the same configuration. By using this option, you can easily duplicate a multi-cluster application.
    * **Upgrade**: Upgrade your multi-cluster application to change some part of the configuration. When performing an upgrade for multi-cluster application, the [upgrade strategy](#upgrades) can be modified if you have the correct [access type](#members).
@@ -155,8 +160,10 @@ One of the benefits of using a multi-cluster application as opposed to multiple 
 
 # Deleting a Multi-Cluster Application
 
-1. From the **Global** view, choose **Apps** in the navigation bar.
+> **Prerequisite:** The `legacy` feature flag needs to be enabled.
 
-2. Choose the multi-cluster application you want to delete and click the **&#8942; > Delete**. When deleting the multi-cluster application, all applications and namespaces are deleted in all of the target projects.
+1. In the upper left corner, click **☰ > Multi-cluster Apps**.
+
+2. Choose the multi-cluster application you want to delete and click the **⋮ > Delete**. When deleting the multi-cluster application, all applications and namespaces are deleted in all of the target projects.
 
    > **Note:** The applications in the target projects, that are created for a multi-cluster application, cannot be deleted individually. The applications can only be deleted when the multi-cluster application is deleted.

--- a/content/rancher/v2.6/en/faq/_index.md
+++ b/content/rancher/v2.6/en/faq/_index.md
@@ -1,8 +1,6 @@
 ---
 title: FAQ
 weight: 25
-aliases:
-  - /rancher/v2.6/en/about/
 ---
 
 This FAQ is a work in progress designed to answers the questions our users most frequently ask about Rancher v2.x.

--- a/content/rancher/v2.6/en/faq/removing-rancher/_index.md
+++ b/content/rancher/v2.6/en/faq/removing-rancher/_index.md
@@ -1,11 +1,6 @@
 ---
 title: Rancher is No Longer Needed
 weight: 8010
-aliases:
-  - /rancher/v2.6/en/installation/removing-rancher/cleaning-cluster-nodes/
-  - /rancher/v2.6/en/installation/removing-rancher/
-  - /rancher/v2.6/en/admin-settings/removing-rancher/
-  - /rancher/v2.6/en/admin-settings/removing-rancher/rancher-cluster-nodes/
 ---
 
 This page is intended to answer questions about what happens if you don't want Rancher anymore, if you don't want a cluster to be managed by Rancher anymore, or if the Rancher server is deleted.
@@ -51,9 +46,9 @@ If a registered cluster is deleted from the Rancher UI, the cluster is detached 
 
 To detach the cluster,
 
-1. From the **Global** view in Rancher, go to the **Clusters** tab.
-2. Go to the registered cluster that should be detached from Rancher and click **&#8942; > Delete.**
-3. Click **Delete.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+2. Go to the registered cluster that should be detached from Rancher and click **⋮ > Delete**.
+3. Click **Delete**.
 
 **Result:** The registered cluster is detached from Rancher and functions normally outside of Rancher.
 

--- a/content/rancher/v2.6/en/faq/technical/_index.md
+++ b/content/rancher/v2.6/en/faq/technical/_index.md
@@ -65,7 +65,7 @@ We follow the validated Docker versions for upstream Kubernetes releases. The va
 
 ### How can I access nodes created by Rancher?
 
-SSH keys to access the nodes created by Rancher can be downloaded via the **Nodes** view. Choose the node which you want to access and click on the vertical &#8942; button at the end of the row, and choose **Download Keys** as shown in the picture below.
+SSH keys to access the nodes created by Rancher can be downloaded via the **Nodes** view. Choose the node which you want to access and click on the vertical ⋮ button at the end of the row, and choose **Download Keys** as shown in the picture below.
 
 ![Download Keys]({{<baseurl>}}/img/rancher/downloadsshkeys.png)
 

--- a/content/rancher/v2.6/en/helm-charts/_index.md
+++ b/content/rancher/v2.6/en/helm-charts/_index.md
@@ -1,14 +1,9 @@
 ---
 title: Helm Charts in Rancher
 weight: 11
-aliases:
-  - /rancher/v2.x/en/helm-charts/apps-marketplace
-  - /rancher/v2.6/en/catalog/
-  - /rancher/v2.6/en/catalog/apps
-  - /rancher/v2.6/en/catalog/launching-apps
 ---
 
-In this section, you'll learn how to manage Helm chart repositories and applications in Rancher. Helm chart repositories are managed using the "Apps & Marketplace" feature found in the Cluster Explorer. It contains a simple catalog-like system to import bundles of charts from repositories and then uses those charts to either deploy custom Helm applications or Rancher's tools such as Monitoring or Istio. Rancher tools come as pre-loaded repositories which deploy as standalone Helm charts. Any additional repositories are only added to the current cluster.
+In this section, you'll learn how to manage Helm chart repositories and applications in Rancher. Helm chart repositories are managed using **Apps & Marketplace**. It uses a catalog-like system to import bundles of charts from repositories and then uses those charts to either deploy custom Helm applications or Rancher's tools such as Monitoring or Istio. Rancher tools come as pre-loaded repositories which deploy as standalone Helm charts. Any additional repositories are only added to the current cluster.
 
 ### Charts
 
@@ -22,7 +17,7 @@ The charts page contains all Rancher, Partner, and Custom Charts.
 
 All three types are deployed and managed in the same way.
 
-> Apps managed by the Cluster Manager should continue to be managed only by the Cluster Manager, and apps managed with the Cluster Explorer must be managed only by the Cluster Explorer.
+> Apps managed by the Cluster Manager (the global view in the legacy Rancher UI) should continue to be managed only by the Cluster Manager, and apps managed with **Apps & Marketplace** in the new UI must be managed only by **Apps & Marketplace**.
 
 ### Repositories
 
@@ -33,7 +28,7 @@ These items represent helm repositories, and can be either traditional helm endp
 
 ### Helm Compatibility
 
-The Cluster Explorer only supports Helm 3 compatible charts.
+Only Helm 3 compatible charts are supported.
 
 
 ### Deployment and Upgrades

--- a/content/rancher/v2.6/en/installation/_index.md
+++ b/content/rancher/v2.6/en/installation/_index.md
@@ -2,8 +2,6 @@
 title: Installing/Upgrading Rancher
 description: Learn how to install Rancher in development and production environments. Read about single node and high availability installation
 weight: 3
-aliases:
-  - /rancher/v2.6/en/installation/how-ha-works/
 ---
 
 This section provides an overview of the architecture options of installing Rancher, describing advantages of each option.

--- a/content/rancher/v2.6/en/installation/install-rancher-on-k8s/_index.md
+++ b/content/rancher/v2.6/en/installation/install-rancher-on-k8s/_index.md
@@ -2,12 +2,6 @@
 title: Install/Upgrade Rancher on a Kubernetes Cluster
 description: Learn how to install Rancher in development and production environments. Read about single node and high availability installation
 weight: 2
-aliases:
-  - /rancher/v2.6/en/installation/k8s-install/
-  - /rancher/v2.6/en/installation/k8s-install/helm-rancher
-  - /rancher/v2.6/en/installation/k8s-install/kubernetes-rke
-  - /rancher/v2.6/en/installation/ha-server-install 
-  - /rancher/v2.6/en/installation/install-rancher-on-k8s/install
 ---
 
 In this section, you'll learn how to deploy Rancher on a Kubernetes cluster using the Helm CLI.
@@ -50,9 +44,7 @@ For an example of how to deploy an ingress on EKS, refer to [this section.]({{<b
 
 # Install the Rancher Helm Chart
 
-Rancher is installed using the Helm package manager for Kubernetes. Helm charts provide templating syntax for Kubernetes YAML manifest documents.
-
-With Helm, we can create configurable deployments instead of just using static files. For more information about creating your own catalog of deployments, check out the docs at https://helm.sh/.
+Rancher is installed using the [Helm](https://helm.sh/) package manager for Kubernetes. Helm charts provide templating syntax for Kubernetes YAML manifest documents. With Helm, we can create configurable deployments instead of just using static files.
 
 For systems without direct internet access, see [Air Gap: Kubernetes install]({{<baseurl>}}/rancher/v2.6/en/installation/air-gap-installation/install-rancher/).
 
@@ -255,7 +247,7 @@ Now that Rancher is deployed, see [Adding TLS Secrets]({{<baseurl>}}/rancher/v2.
 The Rancher chart configuration has many options for customizing the installation to suit your specific environment. Here are some common advanced scenarios.
 
 - [HTTP Proxy]({{<baseurl>}}/rancher/v2.6/en/installation/install-rancher-on-k8s/chart-options/#http-proxy)
-- [Private Docker Image Registry]({{<baseurl>}}/rancher/v2.6/en/installation/install-rancher-on-k8s/chart-options/#private-registry-and-air-gap-installs)
+- [Private container image Registry]({{<baseurl>}}/rancher/v2.6/en/installation/install-rancher-on-k8s/chart-options/#private-registry-and-air-gap-installs)
 - [TLS Termination on an External Load Balancer]({{<baseurl>}}/rancher/v2.6/en/installation/install-rancher-on-k8s/chart-options/#external-tls-termination)
 
 See the [Chart Options]({{<baseurl>}}/rancher/v2.6/en/installation/resources/chart-options/) for the full list of options.
@@ -292,8 +284,3 @@ That's it. You should have a functional Rancher server.
 In a web browser, go to the DNS name that forwards traffic to your load balancer. Then you should be greeted by the colorful login page.
 
 Doesn't work? Take a look at the [Troubleshooting]({{<baseurl>}}/rancher/v2.6/en/installation/options/troubleshooting/) Page
-
-
-### Optional Next Steps
-
-Enable the Enterprise Cluster Manager.

--- a/content/rancher/v2.6/en/installation/install-rancher-on-k8s/amazon-eks/_index.md
+++ b/content/rancher/v2.6/en/installation/install-rancher-on-k8s/amazon-eks/_index.md
@@ -21,9 +21,9 @@ Rancher and Amazon Web Services collaborated on a quick start guide for deployin
 
 The quick start guide provides three options for deploying Rancher on EKS:
 
-- **Deploy Rancher into a new VPC and new Amazon EKS cluster.** This option builds a new AWS environment consisting of the VPC, subnets, NAT gateways, security groups, bastion hosts, Amazon EKS cluster, and other infrastructure components. It then deploys Rancher into this new EKS cluster.
-- **Deploy Rancher into an existing VPC and a new Amazon EKS cluster.** This option provisions Rancher in your existing AWS infrastructure.
-- **Deploy Rancher into an existing VPC and existing Amazon EKS cluster.** This option provisions Rancher in your existing AWS infrastructure.
+- **Deploy Rancher into a new VPC and new Amazon EKS cluster**. This option builds a new AWS environment consisting of the VPC, subnets, NAT gateways, security groups, bastion hosts, Amazon EKS cluster, and other infrastructure components. It then deploys Rancher into this new EKS cluster.
+- **Deploy Rancher into an existing VPC and a new Amazon EKS cluster**. This option provisions Rancher in your existing AWS infrastructure.
+- **Deploy Rancher into an existing VPC and existing Amazon EKS cluster**. This option provisions Rancher in your existing AWS infrastructure.
 
 Deploying this Quick Start for a new virtual private cloud (VPC) and new Amazon EKS cluster using default parameters builds the following Rancher environment in the AWS Cloud:
 

--- a/content/rancher/v2.6/en/installation/install-rancher-on-k8s/chart-options/_index.md
+++ b/content/rancher/v2.6/en/installation/install-rancher-on-k8s/chart-options/_index.md
@@ -1,11 +1,6 @@
 ---
 title: Rancher Helm Chart Options
 weight: 1
-aliases:
-  - /rancher/v2.6/en/installation/options/
-  - /rancher/v2.6/en/installation/options/chart-options/
-  - /rancher/v2.6/en/installation/options/helm2/helm-rancher/chart-options/
-  - /rancher/v2.6/en/installation/resources/chart-options
 ---
 
 This page is a configuration reference for the Rancher Helm chart.
@@ -67,7 +62,7 @@ For information on enabling experimental features, refer to [this page.]({{<base
 | `replicas`                     | 3                                                     | `int` - Number of replicas of Rancher pods                                                                                                        |
 | `resources`                    | {}                                                    | `map` - rancher pod resource requests & limits                                                                                                    |
 | `restrictedAdmin` | `false` | `bool` - When this option is set to true, the initial Rancher user has restricted access to the local Kubernetes cluster to prevent privilege escalation. For more information, see the section about the [restricted-admin role.]({{<baseurl>}}/rancher/v2.6/en/admin-settings/rbac/global-permissions/#restricted-admin) |
-| `systemDefaultRegistry`        | ""                                                    | `string` - private registry to be used for all system Docker images, e.g., http://registry.example.com/                   |
+| `systemDefaultRegistry`        | ""                                                    | `string` - private registry to be used for all system container images, e.g., http://registry.example.com/                   |
 | `tls`                          | "ingress"                                             | `string` - See [External TLS Termination](#external-tls-termination) for details. - "ingress, external"                                           |
 | `useBundledSystemChart`        | `false`                                               | `bool` - select to use the system-charts packaged with Rancher server. This option is used for air gapped installations.  |
 

--- a/content/rancher/v2.6/en/installation/install-rancher-on-k8s/gke/_index.md
+++ b/content/rancher/v2.6/en/installation/install-rancher-on-k8s/gke/_index.md
@@ -31,7 +31,7 @@ The following sections describe how to launch the cloud shell from the Google Cl
 
 ### Cloud Shell
 
-To launch the shell from the [Google Cloud Console,](https://console.cloud.google.com) go to the upper-right corner of the console and click the terminal button. When hovering over the button, it is labeled **Activate Cloud Shell.**
+To launch the shell from the [Google Cloud Console,](https://console.cloud.google.com) go to the upper-right corner of the console and click the terminal button. When hovering over the button, it is labeled **Activate Cloud Shell**.
 
 ### Local Shell
 

--- a/content/rancher/v2.6/en/installation/install-rancher-on-k8s/rollbacks/_index.md
+++ b/content/rancher/v2.6/en/installation/install-rancher-on-k8s/rollbacks/_index.md
@@ -1,13 +1,6 @@
 ---
 title: Rollbacks
 weight: 3
-aliases:
-  - /rancher/v2.x/en/upgrades/rollbacks
-  - /rancher/v2.x/en/installation/upgrades-rollbacks/rollbacks
-  - /rancher/v2.x/en/upgrades/ha-server-rollbacks
-  - /rancher/v2.x/en/upgrades/rollbacks/ha-server-rollbacks
-  - /rancher/v2.x/en/installation/upgrades-rollbacks/rollbacks/ha-server-rollbacks
-  - /rancher/v2.x/en/installation/install-rancher-on-k8s/upgrades-rollbacks/rollbacks
 ---
 
 - [Rolling Back to Rancher v2.5.0+](#rolling-back-to-rancher-v2-5-0)
@@ -16,7 +9,7 @@ aliases:
 
 # Rolling Back to Rancher v2.5.0+
 
-To roll back to Rancher v2.5.0+, use the `rancher-backup` application and restore Rancher from backup.
+To roll back to Rancher v2.5.0+, use the **Rancher Backups** application and restore Rancher from backup.
 
 Rancher has to be started with the lower/previous version after a rollback.
 
@@ -29,10 +22,11 @@ A restore is performed by creating a Restore custom resource.
 
 ### Create the Restore Custom Resource
 
-1. In the **Cluster Explorer,** go to the dropdown menu in the upper left corner and click **Rancher Backups.**
-1. Click **Restore.**
-1. Create the Restore with the form, or with YAML.  For creating the Restore resource using form, refer to the  [configuration reference]({{<baseurl>}}/rancher/v2.6/en/backups/configuration/restore-config) and to the [examples.]({{<baseurl>}}/rancher/v2.6/en/backups/examples)
-1. For using the YAML editor, we can click **Create > Create from YAML.** Enter the Restore YAML.
+1.  Click **☰ > Cluster Management**.
+1. Go to the cluster that you created and click **Explore**.
+1. In the left navigation bar, click **Rancher Backups > Restore**.
+1. Click **Create**.
+1. Create the Restore with the form, or with YAML.  For creating the Restore resource using form, refer to the  [configuration reference]({{<baseurl>}}/rancher/v2.6/en/backups/configuration/restore-config) and to the [examples.]({{<baseurl>}}/rancher/v2.6/en/backups/examples) The following is an example Restore custom resource:
 
     ```yaml
     apiVersion: resources.cattle.io/v1
@@ -54,7 +48,7 @@ A restore is performed by creating a Restore custom resource.
 
       For help configuring the Restore, refer to the [configuration reference]({{<baseurl>}}/rancher/v2.6/en/backups/v2.5/configuration/restore-config/) and to the [examples.]({{<baseurl>}}/rancher/v2.6/en/backups/v2.5/examples/)
 
-1. Click **Create.**
+1. Click **Create**.
 
 **Result:** The rancher-operator scales down the rancher deployment during restore, and scales it back up once the restore completes. The resources are restored in this order:
 
@@ -73,8 +67,9 @@ kubectl logs -n cattle-resources-system -f
 
 Rancher can be rolled back using the Rancher UI.
 
-1. In the Rancher UI, go to the local cluster. 
-1. Go to the System project.
+1.  Click **☰ > Cluster Management**.
+1. Go to the `local` cluster and click **Explore**.
+1. Click **Workload**.
 1. Edit Rancher deployment and modify image to version that you are rolling back to.
 1. Save changes made.
 

--- a/content/rancher/v2.6/en/installation/install-rancher-on-k8s/upgrades/_index.md
+++ b/content/rancher/v2.6/en/installation/install-rancher-on-k8s/upgrades/_index.md
@@ -1,20 +1,6 @@
 ---
 title: Upgrades
 weight: 2
-aliases:
-  - /rancher/v2.6/en/upgrades/upgrades
-  - /rancher/v2.6/en/installation/upgrades-rollbacks/upgrades
-  - /rancher/v2.6/en/upgrades/upgrades/ha-server-upgrade-helm-airgap
-  - /rancher/v2.6/en/upgrades/air-gap-upgrade/
-  - /rancher/v2.6/en/upgrades/upgrades/ha
-  - /rancher/v2.6/en/installation/install-rancher-on-k8s/upgrades/upgrades/ha
-  - /rancher/v2.6/en/installation/upgrades-rollbacks/upgrades/
-  - /rancher/v2.6/en/upgrades/upgrades/ha-server-upgrade-helm/
-  - /rancher/v2.6/en/installation/upgrades-rollbacks/upgrades/ha
-  - /rancher/v2.6/en/installation/install-rancher-on-k8s/upgrades-rollbacks/upgrades
-  - /rancher/v2.6/en/installation/install-rancher-on-k8s/upgrades-rollbacks/upgrades/ha
-  - /rancher/v2.6/en/installation/upgrades-rollbacks/
-  - /rancher/v2.6/en/upgrades/
 ---
 The following instructions will guide you through upgrading a Rancher server that was installed on a Kubernetes cluster with Helm. These steps also apply to air gap installs with Helm.
 
@@ -74,7 +60,7 @@ Follow the steps to upgrade Rancher server:
 
 Use the [backup application]({{<baseurl>}}/rancher/v2.6/en/backups/back-up-rancher) to back up Rancher.
 
-You'll use the backup as a restoration point if something goes wrong during upgrade.
+You'll use the backup as a restore point if something goes wrong during upgrade.
 
 # 2. Update the Helm chart repository
 

--- a/content/rancher/v2.6/en/installation/other-installation-methods/air-gap/_index.md
+++ b/content/rancher/v2.6/en/installation/other-installation-methods/air-gap/_index.md
@@ -1,10 +1,6 @@
 ---
 title: Air Gapped Helm CLI Install
 weight: 1
-aliases:
-  - /rancher/v2.6/en/installation/air-gap-installation/
-  - /rancher/v2.6/en/installation/air-gap-high-availability/
-  - /rancher/v2.6/en/installation/air-gap-single-node/
 ---
 
 This section is about using the Helm CLI to install the Rancher server in an air gapped environment. An air gapped environment could be where Rancher server will be installed offline, behind a firewall, or behind a proxy.

--- a/content/rancher/v2.6/en/installation/other-installation-methods/air-gap/install-rancher/_index.md
+++ b/content/rancher/v2.6/en/installation/other-installation-methods/air-gap/install-rancher/_index.md
@@ -1,13 +1,6 @@
 ---
 title: 4. Install Rancher
 weight: 400
-aliases:
-  - /rancher/v2.6/en/installation/air-gap-high-availability/config-rancher-system-charts/
-  - /rancher/v2.6/en/installation/air-gap-high-availability/config-rancher-for-private-reg/
-  - /rancher/v2.6/en/installation/air-gap-single-node/install-rancher
-  - /rancher/v2.6/en/installation/air-gap/install-rancher
-  - /rancher/v2.6/en/installation/air-gap-installation/install-rancher/
-  - /rancher/v2.6/en/installation/air-gap-high-availability/install-rancher/
 ---
 
 This section is about how to deploy Rancher for your air gapped environment in a high-availability Kubernetes installation. An air gapped environment could be where Rancher server will be installed offline, behind a firewall, or behind a proxy.

--- a/content/rancher/v2.6/en/installation/other-installation-methods/air-gap/install-rancher/docker-install-commands/_index.md
+++ b/content/rancher/v2.6/en/installation/other-installation-methods/air-gap/install-rancher/docker-install-commands/_index.md
@@ -16,7 +16,7 @@ For security purposes, SSL (Secure Sockets Layer) is required when using Rancher
 | `CATTLE_SYSTEM_DEFAULT_REGISTRY` | `<REGISTRY.YOURDOMAIN.COM:PORT>` | Configure Rancher server to always pull from your private registry when provisioning clusters.  |
 | `CATTLE_SYSTEM_CATALOG`          | `bundled`                        | Configure Rancher server to use the packaged copy of Helm system charts. The [system charts](https://github.com/rancher/system-charts) repository contains all the catalog items required for features such as monitoring, logging, alerting and global DNS. These [Helm charts](https://github.com/rancher/system-charts) are located in GitHub, but since you are in an air gapped environment, using the charts that are bundled within Rancher is much easier than setting up a Git mirror. |
 
-> **Do you want to...**
+> **Do you want to..**.
 >
 > - Configure custom CA root certificate to access your services? See [Custom CA root certificate]({{<baseurl>}}/rancher/v2.6/en/installation/options/custom-ca-root-certificate/).
 > - Record all transactions with the Rancher API? See [API Auditing]({{<baseurl>}}/rancher/v2.6/en/installation/other-installation-methods/single-node-docker/advanced/#api-audit-log).

--- a/content/rancher/v2.6/en/installation/other-installation-methods/air-gap/launch-kubernetes/_index.md
+++ b/content/rancher/v2.6/en/installation/other-installation-methods/air-gap/launch-kubernetes/_index.md
@@ -1,8 +1,6 @@
 ---
 title: '3. Install Kubernetes (Skip for Docker Installs)'
 weight: 300
-aliases:
-  - /rancher/v2.6/en/installation/air-gap-high-availability/install-kube
 ---
 
 > Skip this section if you are installing Rancher on a single node with Docker.

--- a/content/rancher/v2.6/en/installation/other-installation-methods/air-gap/populate-private-registry/_index.md
+++ b/content/rancher/v2.6/en/installation/other-installation-methods/air-gap/populate-private-registry/_index.md
@@ -1,12 +1,6 @@
 ---
 title: '2. Collect and Publish Images to your Private Registry'
 weight: 200
-aliases:
-  - /rancher/v2.6/en/installation/air-gap-high-availability/prepare-private-registry/
-  - /rancher/v2.6/en/installation/air-gap-single-node/prepare-private-registry/
-  - /rancher/v2.6/en/installation/air-gap-single-node/config-rancher-for-private-reg/
-  - /rancher/v2.6/en/installation/air-gap-high-availability/config-rancher-for-private-reg/
-  - /rancher/v2.6/en/installation/air-gap-installation/prepare-private-reg/
 ---
 
 This section describes how to set up your private registry so that when you install Rancher, Rancher will pull all the required images from this registry.
@@ -41,7 +35,7 @@ If you will use ARM64 hosts, the registry must support manifests. As of April 20
 
 ### 1. Find the required assets for your Rancher version
 
-1. Go to our [releases page,](https://github.com/rancher/rancher/releases) find the Rancher v2.x.x release that you want to install, and click **Assets.** Note: Don't use releases marked `rc` or `Pre-release`, as they are not stable for production environments.
+1. Go to our [releases page,](https://github.com/rancher/rancher/releases) find the Rancher v2.x.x release that you want to install, and click **Assets**. Note: Don't use releases marked `rc` or `Pre-release`, as they are not stable for production environments.
 
 2. From the release's **Assets** section, download the following files, which are required to install Rancher in an air gap environment:
 
@@ -213,7 +207,7 @@ The workstation must have Docker 18.02+ in order to support manifests, which are
 
 ### 1. Find the required assets for your Rancher version
 
-1. Browse to our [releases page](https://github.com/rancher/rancher/releases) and find the Rancher v2.x.x release that you want to install. Don't download releases marked `rc` or `Pre-release`, as they are not stable for production environments. Click **Assets.**
+1. Browse to our [releases page](https://github.com/rancher/rancher/releases) and find the Rancher v2.x.x release that you want to install. Don't download releases marked `rc` or `Pre-release`, as they are not stable for production environments. Click **Assets**.
 
 2. From the release's **Assets** section, download the following files:
 

--- a/content/rancher/v2.6/en/installation/other-installation-methods/air-gap/prepare-nodes/_index.md
+++ b/content/rancher/v2.6/en/installation/other-installation-methods/air-gap/prepare-nodes/_index.md
@@ -1,8 +1,6 @@
 ---
 title: '1. Set up Infrastructure and Private Registry'
 weight: 100
-aliases:
-  - /rancher/v2.6/en/installation/air-gap-single-node/provision-host
 ---
 
 In this section, you will provision the underlying infrastructure for your Rancher management server in an air gapped environment. You will also set up the private Docker registry that must be available to your Rancher node(s).

--- a/content/rancher/v2.6/en/installation/other-installation-methods/single-node-docker/_index.md
+++ b/content/rancher/v2.6/en/installation/other-installation-methods/single-node-docker/_index.md
@@ -2,10 +2,6 @@
 title: Installing Rancher on a Single Node Using Docker
 description: For development and testing environments only, use a Docker install. Install Docker on a single Linux host, and deploy Rancher with a single Docker container.
 weight: 2
-aliases:
-  - /rancher/v2.6/en/installation/single-node-install/
-  - /rancher/v2.6/en/installation/single-node
-  - /rancher/v2.6/en/installation/other-installation-methods/single-node
 ---
 
 Rancher can be installed by running a single Docker container.
@@ -35,7 +31,7 @@ Provision a single Linux host according to our [Requirements]({{<baseurl>}}/ranc
 
 For security purposes, SSL (Secure Sockets Layer) is required when using Rancher. SSL secures all Rancher network communication, like when you login or interact with a cluster.
 
-> **Do you want to...**
+> **Do you want to..**.
 >
 > - Use a proxy? See [HTTP Proxy Configuration]({{<baseurl>}}/rancher/v2.6/en/installation/other-installation-methods/single-node-docker/proxy/)
 > - Configure custom CA root certificate to access your services? See [Custom CA root certificate]({{<baseurl>}}/rancher/v2.6/en/installation/other-installation-methods/single-node-docker/advanced/#custom-ca-certificate/)

--- a/content/rancher/v2.6/en/installation/other-installation-methods/single-node-docker/proxy/_index.md
+++ b/content/rancher/v2.6/en/installation/other-installation-methods/single-node-docker/proxy/_index.md
@@ -1,9 +1,6 @@
 ---
 title: HTTP Proxy Configuration
 weight: 251
-aliases:
-  - /rancher/v2.6/en/installation/proxy-configuration/
-  - /rancher/v2.6/en/installation/single-node/proxy
 ---
 
 If you operate Rancher behind a proxy and you want to access services through the proxy (such as retrieving catalogs), you must provide Rancher information about your proxy. As Rancher is written in Go, it uses the common proxy environment variables as shown below.

--- a/content/rancher/v2.6/en/installation/other-installation-methods/single-node-docker/single-node-rollbacks/_index.md
+++ b/content/rancher/v2.6/en/installation/other-installation-methods/single-node-docker/single-node-rollbacks/_index.md
@@ -1,9 +1,6 @@
 ---
 title: Rolling Back Rancher Installed with Docker
 weight: 1015
-aliases:
-  - /rancher/v2.6/en/upgrades/single-node-rollbacks
-  - /rancher/v2.6/en/upgrades/rollbacks/single-node-rollbacks
 ---
 
 If a Rancher upgrade does not complete successfully, you'll have to roll back to your Rancher setup that you were using before [Docker Upgrade]({{<baseurl>}}/rancher/v2.6/en/upgrades/upgrades/single-node-upgrade). Rolling back restores:

--- a/content/rancher/v2.6/en/installation/other-installation-methods/single-node-docker/single-node-upgrades/_index.md
+++ b/content/rancher/v2.6/en/installation/other-installation-methods/single-node-docker/single-node-upgrades/_index.md
@@ -1,12 +1,6 @@
 ---
 title: Upgrading Rancher Installed with Docker
 weight: 1010
-aliases:
-  - /rancher/v2.6/en/upgrades/single-node-upgrade/
-  - /rancher/v2.6/en/upgrades/upgrades/single-node-air-gap-upgrade
-  - /rancher/v2.6/en/upgrades/upgrades/single-node
-  - /rancher/v2.6/en/upgrades/upgrades/single-node-upgrade/
-  - /rancher/v2.6/en/installation/install-rancher-on-k8s/upgrades/upgrades/single-node/
 ---
 
 The following instructions will guide you through upgrading a Rancher server that was installed with Docker.
@@ -14,7 +8,7 @@ The following instructions will guide you through upgrading a Rancher server tha
 # Prerequisites
 
 - **Review the [known upgrade issues]({{<baseurl>}}/rancher/v2.6/en/installation/install-rancher-on-k8s/upgrades/#known-upgrade-issues) in the Rancher documentation for the most noteworthy issues to consider when upgrading Rancher. A more complete list of known issues for each Rancher version can be found in the release notes on [GitHub](https://github.com/rancher/rancher/releases) and on the [Rancher forums.](https://forums.rancher.com/c/announcements/12) Note that upgrades to or from any chart in the [rancher-alpha repository]({{<baseurl>}}/rancher/v2.6/en/installation/install-rancher-on-k8s/chart-options/#helm-chart-repositories/) aren’t supported.
-- **For [air gap installs only,]({{<baseurl>}}/rancher/v2.6/en/installation/other-installation-methods/air-gap) collect and populate images for the new Rancher server version.** Follow the guide to [populate your private registry]({{<baseurl>}}/rancher/v2.6/en/installation/other-installation-methods/air-gap/populate-private-registry/) with the images for the Rancher version that you want to upgrade to.
+- **For [air gap installs only,]({{<baseurl>}}/rancher/v2.6/en/installation/other-installation-methods/air-gap) collect and populate images for the new Rancher server version**. Follow the guide to [populate your private registry]({{<baseurl>}}/rancher/v2.6/en/installation/other-installation-methods/air-gap/populate-private-registry/) with the images for the Rancher version that you want to upgrade to.
 
 # Placeholder Review
 

--- a/content/rancher/v2.6/en/installation/resources/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Resources
 weight: 5
-aliases:
-- /rancher/v2.6/en/installation/options
 ---
 
 ### Docker Installations

--- a/content/rancher/v2.6/en/installation/resources/advanced/api-audit-log/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/advanced/api-audit-log/_index.md
@@ -1,9 +1,6 @@
 ---
 title: Enabling the API Audit Log to Record System Events
 weight: 4
-aliases:
-  - /rancher/v2.6/en/installation/options/api-audit-log/
-  - /rancher/v2.6/en/installation/api-auditing
 ---
 
 You can enable the API audit log to record the sequence of system events initiated by individual users. You can know what happened, when it happened, who initiated it, and what cluster it affected. When you enable this feature, all requests to the Rancher API and all responses from it are written to a log.
@@ -60,13 +57,6 @@ The `rancher-audit-log` container is part of the `rancher` pod in the `cattle-sy
 ```bash
 kubectl -n cattle-system logs -f rancher-84d886bdbb-s4s69 rancher-audit-log
 ```
-
-#### Rancher Web GUI
-
-1. From the context menu, select **Cluster: local > System**.
-1. From the main navigation bar, choose **Resources > Workloads.** Find the `cattle-system` namespace. Open the `rancher` workload by clicking its link.
-1. Pick one of the `rancher` pods and select **&#8942; > View Logs**.
-1. From the **Logs** drop-down, select `rancher-audit-log`.
 
 #### Shipping the Audit Log
 

--- a/content/rancher/v2.6/en/installation/resources/advanced/arm64-platform/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/advanced/arm64-platform/_index.md
@@ -1,8 +1,6 @@
 ---
 title: "Running on ARM64 (Experimental)"
 weight: 3
-aliases:
-  - /rancher/v2.6/en/installation/options/arm64-platform
 ---
 
 > **Important:**

--- a/content/rancher/v2.6/en/installation/resources/advanced/etcd/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/advanced/etcd/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Tuning etcd for Large Installations
 weight: 2
-aliases:
-  - /rancher/v2.6/en/installation/options/etcd
 ---
 
 When running larger Rancher installations with 15 or more clusters it is recommended to increase the default keyspace for etcd from the default 2GB. The maximum setting is 8GB and the host should have enough RAM to keep the entire dataset in memory. When increasing this value you should also increase the size of the host. The keyspace size can also be adjusted in smaller installations if you anticipate a high rate of change of pods during the garbage collection interval.

--- a/content/rancher/v2.6/en/installation/resources/advanced/single-node-install-external-lb/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/advanced/single-node-install-external-lb/_index.md
@@ -1,11 +1,6 @@
 ---
 title: Docker Install with TLS Termination at Layer-7 NGINX Load Balancer
 weight: 252
-aliases:
-  - /rancher/v2.6/en/installation/single-node/single-node-install-external-lb/
-  - /rancher/v2.6/en/installation/other-installation-methods/single-node-docker/single-node-install-external-lb
-  - /rancher/v2.6/en/installation/options/single-node-install-external-lb
-  - /rancher/v2.6/en/installation/single-node-install-external-lb
 ---
 
 For development and testing environments that have a special requirement to terminate TLS/SSL at a load balancer instead of your Rancher Server container, deploy Rancher and configure a load balancer to work with it conjunction.
@@ -39,7 +34,7 @@ Provision a single Linux host according to our [Requirements]({{<baseurl>}}/ranc
 
 For security purposes, SSL (Secure Sockets Layer) is required when using Rancher. SSL secures all Rancher network communication, like when you login or interact with a cluster.
 
-> **Do you want to...**
+> **Do you want to..**.
 >
 > - Complete an Air Gap Installation?
 > - Record all transactions with the Rancher API?

--- a/content/rancher/v2.6/en/installation/resources/choosing-version/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/choosing-version/_index.md
@@ -1,15 +1,13 @@
 ---
 title: Choosing a Rancher Version
 weight: 1
-aliases:
-  - /rancher/v2.6/en/installation/options/server-tags
 ---
 
 This section describes how to choose a Rancher version.
 
 For a high-availability installation of Rancher, which is recommended for production, the Rancher server is installed using a **Helm chart** on a Kubernetes cluster. Refer to the [Helm version requirements]({{<baseurl>}}/rancher/v2.6/en/installation/options/helm-version) to choose a version of Helm to install Rancher.
 
-For Docker installations of Rancher, which is used for development and testing, you will install Rancher as a **Docker image.**
+For Docker installations of Rancher, which is used for development and testing, you will install Rancher as a **Docker image**.
 
 {{% tabs %}}
 {{% tab "Helm Charts" %}}

--- a/content/rancher/v2.6/en/installation/resources/custom-ca-root-certificate/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/custom-ca-root-certificate/_index.md
@@ -1,9 +1,6 @@
 ---
 title: About Custom CA Root Certificates
 weight: 1
-aliases:
-  - /rancher/v2.6/en/installation/options/custom-ca-root-certificate/
-  - /rancher/v2.6/en/installation/resources/choosing-version/encryption/custom-ca-root-certificate
 ---
 
 If you're using Rancher in an internal production environment where you aren't exposing apps publicly, use a certificate from a private certificate authority (CA).

--- a/content/rancher/v2.6/en/installation/resources/feature-flags/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/feature-flags/_index.md
@@ -1,9 +1,6 @@
 ---
 title: Enabling Experimental Features
 weight: 17
-aliases:
-  - /rancher/v2.6/en/installation/options/feature-flags/
-  - /rancher/v2.6/en/admin-settings/feature-flags/
 ---
 Rancher includes some features that are experimental and disabled by default. You might want to enable these features, for example, if you decide that the benefits of using an [unsupported storage type]({{<baseurl>}}/rancher/v2.6/en/installation/options/feature-flags/enable-not-default-storage-drivers) outweighs the risk of using an untested feature. Feature flags were introduced to allow you to try these features that are not enabled by default.
 
@@ -122,17 +119,17 @@ docker run -d -p 80:80 -p 443:443 \
 
 # Enabling Features with the Rancher UI
 
-1. Go to the **Global** view and click **Settings.**
-1. Click the **Feature Flags** tab. You will see a list of experimental features.
-1. To enable a feature, go to the disabled feature you want to enable and click **&#8942; > Activate.**
+1. In the upper left corner, click **☰ > Global Settings**.
+1. Click **Feature Flags**.
+1. To enable a feature, go to the disabled feature you want to enable and click **⋮ > Activate**.
 
 **Result:** The feature is enabled.
 
 ### Disabling Features with the Rancher UI
 
-1. Go to the **Global** view and click **Settings.**
-1. Click the **Feature Flags** tab. You will see a list of experimental features.
-1. To disable a feature, go to the enabled feature you want to disable and click **&#8942; > Deactivate.**
+1. In the upper left corner, click **☰ > Global Settings**.
+1. Click **Feature Flags**. You will see a list of experimental features.
+1. To disable a feature, go to the enabled feature you want to disable and click **⋮ > Deactivate**.
 
 **Result:** The feature is disabled.
 
@@ -140,11 +137,11 @@ docker run -d -p 80:80 -p 443:443 \
 
 1. Go to `<RANCHER-SERVER-URL>/v3/features`.
 1. In the `data` section, you will see an array containing all of the features that can be turned on with feature flags. The name of the feature is in the `id` field. Click the name of the feature you want to enable.
-1. In the upper left corner of the screen, under **Operations,** click **Edit.**
-1. In the **Value** drop-down menu, click **True.**
-1. Click **Show Request.**
-1. Click **Send Request.**
-1. Click **Close.**
+1. In the upper left corner of the screen, under **Operations,** click **Edit**.
+1. In the **Value** drop-down menu, click **True**.
+1. Click **Show Request**.
+1. Click **Send Request**.
+1. Click **Close**.
 
 **Result:** The feature is enabled.
 
@@ -152,10 +149,10 @@ docker run -d -p 80:80 -p 443:443 \
 
 1. Go to `<RANCHER-SERVER-URL>/v3/features`.
 1. In the `data` section, you will see an array containing all of the features that can be turned on with feature flags. The name of the feature is in the `id` field. Click the name of the feature you want to enable.
-1. In the upper left corner of the screen, under **Operations,** click **Edit.**
-1. In the **Value** drop-down menu, click **False.**
-1. Click **Show Request.**
-1. Click **Send Request.**
-1. Click **Close.**
+1. In the upper left corner of the screen, under **Operations,** click **Edit**.
+1. In the **Value** drop-down menu, click **False**.
+1. Click **Show Request**.
+1. Click **Send Request**.
+1. Click **Close**.
 
 **Result:** The feature is disabled.

--- a/content/rancher/v2.6/en/installation/resources/feature-flags/enable-not-default-storage-drivers/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/feature-flags/enable-not-default-storage-drivers/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Allow Unsupported Storage Drivers
 weight: 1
-aliases:
-  - /rancher/v2.6/en/installation/options/feature-flags/enable-not-default-storage-drivers/
 ---
 
 This feature allows you to use types for storage providers and provisioners that are not enabled by default.

--- a/content/rancher/v2.6/en/installation/resources/feature-flags/istio-virtual-service-ui/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/feature-flags/istio-virtual-service-ui/_index.md
@@ -1,8 +1,6 @@
 ---
 title: UI for Istio Virtual Services and Destination Rules
 weight: 2
-aliases:
-  - /rancher/v2.6/en/installation/options/feature-flags/istio-virtual-service-ui
 ---
 
 This feature enables a UI that lets you create, read, update and delete virtual services and destination rules, which are traffic management features of Istio.
@@ -22,12 +20,14 @@ A central advantage of Istio's traffic management features is that they allow dy
 
 When enabled, this feature turns on a page that lets you configure some traffic management features of Istio using the Rancher UI. Without this feature, you need to use `kubectl` to manage traffic with Istio.
 
-The feature enables two UI tabs: one tab for **Virtual Services** and another for **Destination Rules.** 
+The feature enables two UI tabs: one tab for **Virtual Services** and another for **Destination Rules**. 
 
 - **Virtual services** intercept and direct traffic to your Kubernetes services, allowing you to direct percentages of traffic from a request to different services. You can use them to define a set of routing rules to apply when a host is addressed. For details, refer to the [Istio documentation.](https://istio.io/docs/reference/config/networking/v1alpha3/virtual-service/)
 - **Destination rules** serve as the single source of truth about which service versions are available to receive traffic from virtual services. You can use these resources to define policies that apply to traffic that is intended for a service after routing has occurred. For details, refer to the [Istio documentation.](https://istio.io/docs/reference/config/networking/v1alpha3/destination-rule)
 
 To see these tabs,
 
-1. Go to the project view in Rancher and click **Resources > Istio.**
-1. You will see tabs for **Traffic Graph,** which has the Kiali network visualization integrated into the UI, and **Traffic Metrics,** which shows metrics for the success rate and request volume of traffic to your services, among other metrics. Next to these tabs, you should see the tabs for **Virtual Services** and **Destination Rules.**
+1.  Click **☰ > Cluster Management**.
+1. Go to the cluster where Istio is installed and click **Explore**.
+1. In the left navigation bar, click **Istio**.
+1. You will see tabs for **Kiali** and **Jaeger**. From the left navigation bar, you can view and configure **Virtual Services** and **Destination Rules**.

--- a/content/rancher/v2.6/en/installation/resources/helm-version/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/helm-version/_index.md
@@ -1,11 +1,6 @@
 ---
 title: Helm Version Requirements
 weight: 3
-aliases:
-  - /rancher/v2.6/en/installation/options/helm-version
-  - /rancher/v2.6/en/installation/options/helm2
-  - /rancher/v2.6/en/installation/options/helm2/helm-init
-  - /rancher/v2.6/en/installation/options/helm2/helm-rancher
 ---
 
 This section contains the requirements for Helm, which is the tool used to install Rancher on a high-availability Kubernetes cluster.

--- a/content/rancher/v2.6/en/installation/resources/installing-docker/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/installing-docker/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Installing Docker
 weight: 1
-aliases:
-  - /rancher/v2.6/en/installation/requirements/installing-docker
 ---
 
 Docker is required to be installed on nodes where the Rancher server will be installed with Helm or Docker.

--- a/content/rancher/v2.6/en/installation/resources/k8s-tutorials/ha-RKE/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/k8s-tutorials/ha-RKE/_index.md
@@ -2,8 +2,6 @@
 title: Setting up a High-availability RKE Kubernetes Cluster
 shortTitle: Set up RKE Kubernetes
 weight: 3
-aliases:
-  - /rancher/v2.6/en/installation/k8s-install/kubernetes-rke
 ---
 
 

--- a/content/rancher/v2.6/en/installation/resources/k8s-tutorials/ha-rke2/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/k8s-tutorials/ha-rke2/_index.md
@@ -2,8 +2,6 @@
 title: Setting up a High-availability RKE2 Kubernetes Cluster for Rancher
 shortTitle: Set up RKE2 for Rancher
 weight: 2
-aliases:
-  - /rancher/v2.x/en/installation/resources/k8s-tutorials/ha-RKE2
 ---
 _Tested on v2.5.6_
 

--- a/content/rancher/v2.6/en/installation/resources/k8s-tutorials/infrastructure-tutorials/ec2-node/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/k8s-tutorials/infrastructure-tutorials/ec2-node/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Setting up Nodes in Amazon EC2
 weight: 3
-aliases:
-  - /rancher/v2.6/en/installation/options/ec2-node
 ---
 
 In this tutorial, you will learn one way to set up Linux nodes for the Rancher management server. These nodes will fulfill the node requirements for [OS, Docker, hardware, and networking.]({{<baseurl>}}/rancher/v2.6/en/installation/requirements/)
@@ -21,19 +19,19 @@ If the Rancher server is installed in a single Docker container, you only need o
 ### 2. Provision Instances
 
 1. Log into the [Amazon AWS EC2 Console](https://console.aws.amazon.com/ec2/) to get started. Make sure to take note of the **Region** where your EC2 instances (Linux nodes) are created, because all of the infrastructure for the Rancher management server should be in the same region.
-1. In the left panel, click **Instances.**
-1. Click **Launch Instance.**
-1. In the section called **Step 1: Choose an Amazon Machine Image (AMI),** we will use Ubuntu 18.04 as the Linux OS, using `ami-0d1cd67c26f5fca19 (64-bit x86)`. Go to the Ubuntu AMI and click **Select.**
+1. In the left panel, click **Instances**.
+1. Click **Launch Instance**.
+1. In the section called **Step 1: Choose an Amazon Machine Image (AMI),** we will use Ubuntu 18.04 as the Linux OS, using `ami-0d1cd67c26f5fca19 (64-bit x86)`. Go to the Ubuntu AMI and click **Select**.
 1. In the **Step 2: Choose an Instance Type** section, select the `t2.medium` type.
-1. Click **Next: Configure Instance Details.**
+1. Click **Next: Configure Instance Details**.
 1. In the **Number of instances** field, enter the number of instances. A high-availability K3s cluster requires only two instances, while a high-availability RKE cluster requires three instances.
 1. Optional: If you created an IAM role for Rancher to manipulate AWS resources, select the new IAM role in the **IAM role** field.
-1. Click **Next: Add Storage,** **Next: Add Tags,** and **Next: Configure Security Group.**
+1. Click **Next: Add Storage,** **Next: Add Tags,** and **Next: Configure Security Group**.
 1. In **Step 6: Configure Security Group,** select a security group that complies with the [port requirements]({{<baseurl>}}/rancher/v2.6/en/installation/requirements/#port-requirements) for Rancher nodes.
-1. Click **Review and Launch.**
-1. Click **Launch.**
+1. Click **Review and Launch**.
+1. Click **Launch**.
 1. Choose a new or existing key pair that you will use to connect to your instance later. If you are using an existing key pair, make sure you already have access to the private key.
-1. Click **Launch Instances.**
+1. Click **Launch Instances**.
 
 
 **Result:** You have created Rancher nodes that satisfy the requirements for OS, hardware, and networking.
@@ -43,7 +41,7 @@ If the Rancher server is installed in a single Docker container, you only need o
 ### 3. Install Docker and Create User for RKE Kubernetes Cluster Nodes
 
 1. From the [AWS EC2 console,](https://console.aws.amazon.com/ec2/) click **Instances** in the left panel.
-1. Go to the instance that you want to install Docker on. Select the instance and click **Actions > Connect.**
+1. Go to the instance that you want to install Docker on. Select the instance and click **Actions > Connect**.
 1. Connect to the instance by following the instructions on the screen that appears. Copy the Public DNS of the instance. An example command to SSH into the instance is as follows:
 ```
 sudo ssh -i [path-to-private-key] ubuntu@[public-DNS-of-instance]

--- a/content/rancher/v2.6/en/installation/resources/k8s-tutorials/infrastructure-tutorials/nginx/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/k8s-tutorials/infrastructure-tutorials/nginx/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Setting up an NGINX Load Balancer
 weight: 4
-aliases:
-  - /rancher/v2.6/en/installation/options/nginx
 ---
 
 NGINX will be configured as Layer 4 load balancer (TCP) that forwards connections to one of your Rancher nodes.

--- a/content/rancher/v2.6/en/installation/resources/k8s-tutorials/infrastructure-tutorials/nlb/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/k8s-tutorials/infrastructure-tutorials/nlb/_index.md
@@ -1,10 +1,6 @@
 ---
 title: Setting up Amazon ELB Network Load Balancer
 weight: 5
-aliases:
-  - /rancher/v2.6/en/installation/ha/create-nodes-lb/nlb
-  - /rancher/v2.6/en/installation/k8s-install/create-nodes-lb/nlb
-  - /rancher/v2.6/en/installation/options/nlb
 ---
 
 This how-to guide describes how to set up a Network Load Balancer (NLB) in Amazon's EC2 service that will direct traffic to multiple instances on EC2.
@@ -165,7 +161,7 @@ After AWS creates the NLB, click **Close**.
 
 3. Use `TCP`:`80` as **Protocol** : **Port**
 
-4. Click **Add action** and choose **Forward to...**
+4. Click **Add action** and choose **Forward to..**.
 
 5. From the **Forward to** drop-down, choose `rancher-tcp-80`.
 

--- a/content/rancher/v2.6/en/installation/resources/k8s-tutorials/infrastructure-tutorials/rds/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/k8s-tutorials/infrastructure-tutorials/rds/_index.md
@@ -1,21 +1,19 @@
 ---
 title: Setting up a MySQL Database in Amazon RDS
 weight: 4
-aliases:
-  - /rancher/v2.6/en/installation/options/rds
 ---
 This tutorial describes how to set up a MySQL database in Amazon's RDS.
 
 This database can later be used as an external datastore for a high-availability K3s Kubernetes cluster.
 
 1. Log into the [Amazon AWS RDS Console](https://console.aws.amazon.com/rds/) to get started. Make sure to select the **Region** where your EC2 instances (Linux nodes) are created.
-1. In the left panel, click **Databases.**
-1. Click **Create database.**
-1. In the **Engine type** section, click **MySQL.**
-1. In the **Version** section, choose **MySQL 5.7.22.**
+1. In the left panel, click **Databases**.
+1. Click **Create database**.
+1. In the **Engine type** section, click **MySQL**.
+1. In the **Version** section, choose **MySQL 5.7.22**.
 1. In **Settings** section, under **Credentials Settings,** enter a master password for the **admin** master username. Confirm the password.
 1. Expand the **Additional configuration** section. In the **Initial database name** field, enter a name. The name can have only letters, numbers, and underscores. This name will be used to connect to the database.
-1. Click **Create database.**
+1. Click **Create database**.
 
 You'll need to capture the following information about the new database so that the K3s Kubernetes cluster can connect to it.
 
@@ -25,7 +23,7 @@ To see this information in the Amazon RDS console, click **Databases,** and clic
 - **Password:** Use the admin password.
 - **Hostname:** Use the **Endpoint** as the hostname. The endpoint is available in the **Connectivity & security** section.
 - **Port:** The port should be 3306 by default. You can confirm it in the **Connectivity & security** section.
-- **Database name:** Confirm the name by going to the **Configuration** tab. The name is listed under **DB name.**
+- **Database name:** Confirm the name by going to the **Configuration** tab. The name is listed under **DB name**.
 
 This information will be used to connect to the database in the following format:
 

--- a/content/rancher/v2.6/en/installation/resources/local-system-charts/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/local-system-charts/_index.md
@@ -1,10 +1,6 @@
 ---
 title: Setting up Local System Charts for Air Gapped Installations
 weight: 120
-aliases:
-  - /rancher/v2.6/en/installation/air-gap-single-node/config-rancher-system-charts/_index.md
-  - /rancher/v2.6/en/installation/air-gap-high-availability/config-rancher-system-charts/_index.md
-  - /rancher/v2.6/en/installation/options/local-system-charts
 ---
 
 The [System Charts](https://github.com/rancher/system-charts) repository contains all the catalog items required for features such as monitoring, logging, alerting and global DNS.

--- a/content/rancher/v2.6/en/installation/resources/tls-secrets/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/tls-secrets/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Adding TLS Secrets
 weight: 2
-aliases:
-  - /rancher/v2.6/en/installation/resources/encryption/tls-secrets/
 ---
 
 Kubernetes will create all the objects and services for Rancher, but it will not become available until we populate the `tls-rancher-ingress` secret in the `cattle-system` namespace with the certificate and key.

--- a/content/rancher/v2.6/en/installation/resources/tls-settings/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/tls-settings/_index.md
@@ -1,10 +1,6 @@
 ---
 title: TLS Settings
 weight: 3
-aliases:
-  - /rancher/v2.6/en/installation/options/tls-settings/ 
-  - /rancher/v2.6/en/admin-settings/tls-settings
-  - /rancher/v2.6/en/installation/resources/encryption/tls-settings
 ---
 
 The default TLS configuration only accepts TLS 1.2 and secure TLS cipher suites. TLS 1.3 and TLS 1.3 exclusive cipher suites are not supported.

--- a/content/rancher/v2.6/en/installation/resources/troubleshooting/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/troubleshooting/_index.md
@@ -1,11 +1,6 @@
 ---
 title: Troubleshooting the Rancher Server Kubernetes Cluster
 weight: 276
-aliases:
-  - /rancher/v2.6/en/installation/k8s-install/helm-rancher/troubleshooting
-  - /rancher/v2.6/en/installation/ha/kubernetes-rke/troubleshooting
-  - /rancher/v2.6/en/installation/k8s-install/kubernetes-rke/troubleshooting
-  - /rancher/v2.6/en/installation/options/troubleshooting
 ---
 
 This section describes how to troubleshoot an installation of Rancher on a Kubernetes cluster.

--- a/content/rancher/v2.6/en/installation/resources/upgrading-cert-manager/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/upgrading-cert-manager/_index.md
@@ -1,10 +1,6 @@
 ---
 title: Upgrading Cert-Manager
 weight: 4
-aliases:
-  - /rancher/v2.6/en/installation/options/upgrading-cert-manager
-  - /rancher/v2.6/en/installation/options/upgrading-cert-manager/helm-2-instructions
-  - /rancher/v2.6/en/installation/resources/encryption/upgrading-cert-manager
 ---
 
 Rancher uses cert-manager to automatically generate and renew TLS certificates for HA deployments of Rancher. As of Fall 2019, three important changes to cert-manager are set to occur that you need to take action on if you have an HA deployment of Rancher:

--- a/content/rancher/v2.6/en/installation/resources/upgrading-cert-manager/helm-2-instructions/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/upgrading-cert-manager/helm-2-instructions/_index.md
@@ -1,9 +1,6 @@
 ---
 title: Upgrading Cert-Manager with Helm 2
 weight: 2040
-aliases:
-  - /rancher/v2.6/en/installation/options/upgrading-cert-manager/helm-2-instructions
-  - /rancher/v2.6/en/installation/resources/choosing-version/encryption/upgrading-cert-manager/helm-2-instructions
 ---
 
 Rancher uses cert-manager to automatically generate and renew TLS certificates for HA deployments of Rancher. As of Fall 2019, three important changes to cert-manager are set to occur that you need to take action on if you have an HA deployment of Rancher:

--- a/content/rancher/v2.6/en/istio/_index.md
+++ b/content/rancher/v2.6/en/istio/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Istio
 weight: 14
-aliases:
-  - /rancher/v2.6/en/dashboard/istio
 ---
 
 [Istio](https://istio.io/) is an open-source tool that makes it easier for DevOps teams to observe, secure, control, and troubleshoot the traffic within a complex network of microservices.
@@ -17,7 +15,7 @@ This core service mesh provides features that include but are not limited to the
 - **Security** with resources to authenticate and authorize traffic and users, mTLS included.
 - **Observability** of logs, metrics, and distributed traffic flows.
 
-After [setting up istio]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/tools/istio/setup) you can leverage Istio's control plane functionality through the Cluster Explorer, `kubectl`, or `istioctl`.
+After [setting up istio]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/tools/istio/setup) you can leverage Istio's control plane functionality through the Rancher UI, `kubectl`, or `istioctl`.
 
 Istio needs to be set up by a `cluster-admin` before it can be used in a project.
 
@@ -79,7 +77,7 @@ To remove Istio components from a cluster, namespace, or workload, refer to the 
 
 # Migrate From Previous Istio Version
 
-There is no upgrade path for Istio versions less than 1.7.x. To successfully install Istio in the **Cluster Explorer**, you will need to disable your existing Istio in the **Cluster Manager**.
+There is no upgrade path for Istio versions less than 1.7.x. To successfully install Istio through **Apps & Marketplace,** you will need to disable your existing Istio from the global view in the legacy Rancher UI.
 
 If you have a significant amount of additional Istio CRDs you might consider manually migrating CRDs that are supported in both versions of Istio. You can do this by running `kubectl get <resource> -n istio-system -o yaml`, save the output yaml and re-apply in the new version. 
 
@@ -89,11 +87,21 @@ Another option is to manually uninstall istio resources one at a time, but leave
 
 > By default, only cluster-admins have access to Kiali. For instructions on how to allow admin, edit or views roles to access them, see [this section.]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/tools/istio/rbac/)
 
-After Istio is set up in a cluster, Grafana, Prometheus,and Kiali are available in the Rancher UI. 
+After Istio is set up in a cluster, Grafana, Prometheus, and Kiali are available in the Rancher UI. 
 
-To access the Grafana and Prometheus visualizations, from the **Cluster Explorer** navigate to the **Monitoring** app overview page, and click on **Grafana** or **Prometheus**
+To access the Grafana and Prometheus visualizations,
 
-To access the Kiali visualization, from the **Cluster Explorer** navigate to the **Istio** app overview page, and click on **Kiali**. From here you can access the **Traffic Graph** tab or the **Traffic Metrics** tab to see network visualizations and metrics. 
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to see the visualizations and click **Explore**.
+1. In the left navigation bar, click **Monitoring**.
+1. Click **Grafana** or any of the other dashboards.
+
+To access the Kiali visualization,
+
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to see Kiali and click **Explore**.
+1. In the left navigation bar, click **Istio**.
+1. Click **Kiali**. From here you can access the **Traffic Graph** tab or the **Traffic Metrics** tab to see network visualizations and metrics. 
 
 By default, all namespace will picked up by prometheus and make data available for Kiali graphs. Refer to [selector/scrape config setup](./configuration-reference/selectors-and-scrape) if you would like to use a different configuration for prometheus data scraping. 
 

--- a/content/rancher/v2.6/en/istio/configuration-reference/_index.md
+++ b/content/rancher/v2.6/en/istio/configuration-reference/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Configuration Options
 weight: 3
-aliases:
-  - /rancher/v2.6/en/istio/v2.5/configuration-reference
 ---
 
 - [Egress Support](#egress-support)

--- a/content/rancher/v2.6/en/istio/configuration-reference/canal-and-project-network/_index.md
+++ b/content/rancher/v2.6/en/istio/configuration-reference/canal-and-project-network/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Additional Steps for Project Network Isolation
 weight: 4
-aliases:
-  - /rancher/v2.6/en/istio/v2.5/configuration-reference/canal-and-project-network
 ---
 
 In clusters where:

--- a/content/rancher/v2.6/en/istio/configuration-reference/enable-istio-with-psp/_index.md
+++ b/content/rancher/v2.6/en/istio/configuration-reference/enable-istio-with-psp/_index.md
@@ -1,11 +1,6 @@
 ---
 title: Enable Istio with Pod Security Policies
 weight: 1
-aliases:
-  - /rancher/v2.6/en/cluster-admin/tools/istio/setup/enable-istio-in-cluster/enable-istio-with-psp
-  - /rancher/v2.6/en/istio/legacy/setup/enable-istio-in-cluster/enable-istio-with-psp
-  - /rancher/v2.6/en/istio/v2.5/setup/enable-istio-in-cluster/enable-istio-with-psp
-  - /rancher/v2.6/en/istio/v2.5/configuration-reference/enable-istio-with-psp
 ---
 
 If you have restrictive Pod Security Policies enabled, then Istio may not be able to function correctly, because it needs certain permissions in order to install itself and manage pod infrastructure. In this section, we will configure a cluster with PSPs enabled for an Istio install, and also set up the Istio CNI plugin. 
@@ -29,16 +24,18 @@ An unrestricted PSP allows Istio to be installed.
 
 Set the PSP to `unrestricted` in the project where is Istio is installed, or the project where you plan to install Istio.
 
-1. From the cluster view of the **Cluster Manager,** select **Projects/Namespaces.**
-1. Find the **Project: System** and select the **&#8942; > Edit**.
-1. Change the Pod Security Policy option to be unrestricted, then click **Save.**
+1.  Click **☰ > Cluster Management**.
+1. Go to the cluster that you created and click **Explore**.
+1. Click **Cluster > Projects/Namespaces**.
+1. Find the **Project: System** and select the **⋮ > Edit Config**.
+1. Change the Pod Security Policy option to be unrestricted, then click **Save**.
 
 ### 2. Enable the CNI
 
 When installing or upgrading Istio through **Apps & Marketplace,**
 
-1. Click **Components.**
-2. Check the box next to **Enabled CNI.**
+1. Click **Components**.
+2. Check the box next to **Enabled CNI**.
 3. Finish installing or upgrading Istio.
 
 The CNI can also be enabled by editing the `values.yaml`:

--- a/content/rancher/v2.6/en/istio/configuration-reference/rke2/_index.md
+++ b/content/rancher/v2.6/en/istio/configuration-reference/rke2/_index.md
@@ -1,14 +1,12 @@
 ---
 title: Additional Steps for Installing Istio on an RKE2 Cluster
 weight: 3
-aliases:
-  - /rancher/v2.6/en/istio/v2.5/configuration-reference/rke2
 ---
 
-Through the **Cluster Explorer,** when installing or upgrading Istio through **Apps & Marketplace,**
+When installing or upgrading the Istio Helm chart through **Apps & Marketplace,**
 
-1. Click **Components.**
-1. Check the box next to **Enabled CNI.**
+1. If you are installing the chart, click **Customize Helm options before install** and click **Next**.
+1. You will see options for configuring the Istio Helm chart. On the **Components** tab, check the box next to **Enabled CNI**.
 1. Add a custom overlay file specifying `cniBinDir` and `cniConfDir`. For more information on these options, refer to the [Istio documentation.](https://istio.io/latest/docs/setup/additional-setup/cni/#helm-chart-parameters) An example is below:
 
     ```yaml
@@ -28,7 +26,7 @@ Through the **Cluster Explorer,** when installing or upgrading Istio through **A
           cniBinDir: /opt/cni/bin
           cniConfDir: /etc/cni/net.d
     ```
-1. After installing Istio, you'll notice the cni-node pods in the istio-system namespace in a CrashLoopBackoff error. Manually edit the `istio-cni-node` daemonset to include the following on the `install-cni` container:
+1. After installing or upgrading Istio, you'll notice the cni-node pods in the istio-system namespace in a CrashLoopBackoff error. Manually edit the `istio-cni-node` daemonset to include the following on the `install-cni` container:
     ```yaml
     securityContext:
         privileged: true

--- a/content/rancher/v2.6/en/istio/configuration-reference/selectors-and-scrape/_index.md
+++ b/content/rancher/v2.6/en/istio/configuration-reference/selectors-and-scrape/_index.md
@@ -1,9 +1,6 @@
 ---
 title: Selectors and Scrape Configs
 weight: 2
-aliases:
-  - /rancher/v2.6/en/istio/v2.5/configuration-reference/selectors-and-scrape
-  - /rancher/v2.6/en/cluster-admin/tools/istio/setup/node-selectors
 ---
 
 The Monitoring app sets `prometheus.prometheusSpec.ignoreNamespaceSelectors=false`, which enables monitoring across all namespaces by default.
@@ -19,13 +16,10 @@ If you would like to limit Prometheus to specific namespaces, set `prometheus.pr
 
 ### Limiting Monitoring to Specific Namespaces by Setting ignoreNamespaceSelectors to True
 
-This limits monitoring to specific namespaces. 
+To limit monitoring to specific namespaces, you will edit the `ignoreNamespaceSelectors` Helm chart option. You will configure this option when installing or upgrading the Monitoring Helm chart:
 
-1. From the **Cluster Explorer**, navigate to **Installed Apps** if Monitoring is already installed, or **Charts** in **Apps & Marketplace** 
-1. If starting a new install, **Click** the **rancher-monitoring** chart, then in **Chart Options** click **Edit as Yaml**. 
-1. If updating an existing installation, click on **Upgrade**, then in **Chart Options** click **Edit as Yaml**. 
-1. Set`prometheus.prometheusSpec.ignoreNamespaceSelectors=true`
-1. Complete install or upgrade
+1. When installing or upgrading the Monitoring Helm chart, edit the values.yml and set`prometheus.prometheusSpec.ignoreNamespaceSelectors=true`.
+1. Complete the install or upgrade.
 
 **Result:** Prometheus will be limited to specific namespaces  which means one of the following configurations will need to be set up to continue to view data in various dashboards
 
@@ -44,11 +38,12 @@ The usability tradeoff is that you have to create the service monitor or pod mon
 
 > **Prerequisite:** Define a ServiceMonitor or PodMonitor for `<your namespace>`. An example ServiceMonitor is provided below. 
 
-1. From the **Cluster Explorer**, open the kubectl shell
-1. Run `kubectl create -f <name of service/pod monitor file>.yaml` if the file is stored locally in your cluster. 
-1. Or run `cat<< EOF | kubectl apply -f -`, paste the file contents into the terminal, then run `EOF` to complete the command. 
-1. If starting a new install, **Click** the **rancher-monitoring** chart and scroll down to **Preview Yaml**. 
-1. Run `kubectl label namespace <your namespace> istio-injection=enabled` to enable the envoy sidecar injection
+1.  Click **☰ > Cluster Management**.
+1. Go to the cluster that you created and click **Explore**.
+1. In the top navigation bar, open the kubectl shell.
+1. If the ServiceMonitor or PodMonitor file is stored locally in your cluster, in `kubectl create -f <name of service/pod monitor file>.yaml`.
+1. If the ServiceMonitor or PodMonitor is not stored locally, run `cat<< EOF | kubectl apply -f -`, paste the file contents into the terminal, then run `EOF` to complete the command. 
+1. Run `kubectl label namespace <your namespace> istio-injection=enabled` to enable the envoy sidecar injection.
 
 **Result:**  `<your namespace>` can be scraped by prometheus. 
 
@@ -93,11 +88,8 @@ This enables monitoring across namespaces by giving Prometheus additional scrape
 
 The usability tradeoff is that  all of Prometheus' `additionalScrapeConfigs` are maintained in a single Secret. This could make upgrading difficult if monitoring is already deployed with additionalScrapeConfigs before installing Istio. 
 
-1. If starting a new install, **Click** the **rancher-monitoring** chart, then in **Chart Options** click **Edit as Yaml**. 
-1. If updating an existing installation, click on **Upgrade**, then in **Chart Options** click **Edit as Yaml**. 
-1. If updating an existing installation, click on **Upgrade** and then **Preview Yaml**.
-1. Set`prometheus.prometheusSpec.additionalScrapeConfigs` array to the **Additional Scrape Config** provided below. 
-1. Complete install or upgrade
+1. When installing or upgrading the Monitoring Helm chart, edit the values.yml and set the `prometheus.prometheusSpec.additionalScrapeConfigs` array to the **Additional Scrape Config** provided below. 
+1. Complete the install or upgrade.
 
 **Result:** All namespaces with the `istio-injection=enabled` label will be scraped by prometheus.
 

--- a/content/rancher/v2.6/en/istio/disabling-istio/_index.md
+++ b/content/rancher/v2.6/en/istio/disabling-istio/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Disabling Istio
 weight: 4
-aliases:
-  - /rancher/v2.6/en/istio/v2.5/disabling-istio
 ---
 
 This section describes how to uninstall Istio in a cluster or disable a namespace, or workload.
@@ -11,9 +9,11 @@ This section describes how to uninstall Istio in a cluster or disable a namespac
 
 To uninstall Istio,
 
-1. From the **Cluster Explorer,** navigate to **Installed Apps** in **Apps & Marketplace** and locate the `rancher-istio` installation.
-1. Select `rancher-istio` in the `istio-system namespace and click **Delete**
-1. After `rancher-istio` is deleted, you can then select all the remaining apps in the `istio-system` namespace and click **Delete**
+1.  Click **☰ > Cluster Management**.
+1. Go to the cluster that you created and click **Explore**.
+1. In the left navigation bar, click **Apps & Marketplace > Installed Apps**.
+1. In the `istio-system` namespace, go to `rancher-istio` and click **⋮ > Delete**.
+1. After `rancher-istio` is deleted, you can then select all the remaining apps in the `istio-system` namespace and click **Delete**.
 
 **Result:** The `rancher-istio` app in the cluster gets removed. The Istio sidecar cannot be deployed on any workloads in the cluster. 
 
@@ -27,10 +27,10 @@ This could mean a few things. You either selected all the apps in the `istio-sys
 
 # Disable Istio in a Namespace
 
-1. From the **Cluster Explorer** view, use the side-nav to select **Namespaces** page 
-1. On the **Namespace** page, you will see a list of namespaces. Go to the namespace where you want to disable and click the select **Edit as Form** or **Edit as Yaml**
-1. Remove the `istio-injection=enabled` label from the namespace
-1. Click **Save**
+1. Click **☰ > Cluster Management**.
+1. Go to the cluster that you created and click **Explore**.
+1. Click **Cluster > Projects/Namespaces**.
+1. Go to the namespace where you want to enable Istio and click **⋮  > Enable Istio Auto Injection**. Alternately, click the namespace, and then on the namespace detail page, click **⋮  > Enable Istio Auto Injection**.
 
 **Result:** When workloads are deployed in this namespace, they will not have the Istio sidecar.
 

--- a/content/rancher/v2.6/en/istio/rbac/_index.md
+++ b/content/rancher/v2.6/en/istio/rbac/_index.md
@@ -1,9 +1,6 @@
 ---
 title: Role-based Access Control
 weight: 3
-aliases:
-  - /rancher/v2.6/en/cluster-admin/tools/istio/rbac
-  - /rancher/v2.6/en/istio/v2.5/rbac
 ---
 
 This section describes the permissions required to access Istio features.

--- a/content/rancher/v2.6/en/istio/release-notes/_index.md
+++ b/content/rancher/v2.6/en/istio/release-notes/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Release Notes
-aliases:
-  - /rancher/v2.6/en/cluster-admin/tools/istio/release-notes
-  - /rancher/v2.6/en/istio/v2.5/release-notes
+weight: 100
 ---
 
 # Istio 1.5.9 release notes

--- a/content/rancher/v2.6/en/istio/resources/_index.md
+++ b/content/rancher/v2.6/en/istio/resources/_index.md
@@ -1,11 +1,6 @@
 ---
 title: CPU and Memory Allocations
 weight: 1
-aliases:
-  - /rancher/v2.6/en/project-admin/istio/configuring-resource-allocations/
-  - /rancher/v2.6/en/project-admin/istio/config/
-  - /rancher/v2.6/en/cluster-admin/tools/istio/resources
-  - /rancher/v2.6/en/istio/v2.5/resources
 ---
 
 This section describes the minimum recommended computing resources for the Istio components in a cluster.
@@ -38,10 +33,14 @@ You can find more information about Istio configuration in the [official Istio d
 
 To configure the resources allocated to an Istio component,
 
-1. In the Rancher **Cluster Explorer**, navigate to your Istio installation in **Apps & Marketplace**
+1.  Click **☰ > Cluster Management**.
+1. Go to the cluster that you created and click **Explore**.
+1. In the left navigation bar, click **Apps & Marketplace**.
+1. Click **Installed Apps**.
+1. Go to the `istio-system` namespace. In one of the Istio workloads, such as `rancher-istio`, click **⋮ > Edit/Upgrade**.
 1. Click **Upgrade** to edit the base components via changes to the values.yaml or add an [overlay file]({{<baseurl>}}/rancher/v2.6/en/istio/v2.5/configuration-reference/#overlay-file). For more information about editing the overlay file, see [this section.](./#editing-the-overlay-file)
 1. Change the CPU or memory allocations, the nodes where each component will be scheduled to, or the node tolerations.
-1. Click **Upgrade.** to rollout changes
+1. Click **Upgrade**. to rollout changes
 
 **Result:** The resource allocations for the Istio components are updated.
 

--- a/content/rancher/v2.6/en/istio/setup/_index.md
+++ b/content/rancher/v2.6/en/istio/setup/_index.md
@@ -1,9 +1,6 @@
 ---
 title: Setup Guide
 weight: 2
-aliases:
-  - /rancher/v2.6/en/cluster-admin/tools/istio/setup
-  - /rancher/v2.6/en/istio/v2.5/setup/
 ---
 
 This section describes how to enable Istio and start using it in your projects.

--- a/content/rancher/v2.6/en/istio/setup/deploy-workloads/_index.md
+++ b/content/rancher/v2.6/en/istio/setup/deploy-workloads/_index.md
@@ -1,37 +1,41 @@
 ---
 title: 3. Add Deployments and Services with the Istio Sidecar
 weight: 4
-aliases:
-  - /rancher/v2.6/en/cluster-admin/tools/istio/setup/deploy-workloads
-  - /rancher/v2.6/en/istio/v2.5/setup/deploy-workloads
 ---
 
 > **Prerequisite:** To enable Istio for a workload, the cluster and namespace must have the Istio app installed.  
 
 Enabling Istio in a namespace only enables automatic sidecar injection for new workloads. To enable the Envoy sidecar for existing workloads, you need to enable it manually for each workload.
 
-To inject the Istio sidecar on an existing workload in the namespace, from the **Cluster Explorer** go to the workload, click the **&#8942;,** and click **Redeploy.** When the workload is redeployed, it will have the Envoy sidecar automatically injected.
+To inject the Istio sidecar on an existing workload in the namespace,
+
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to see the visualizations and click **Explore**.
+1. Click **Workload**.
+1. Go to the workload where you want to inject the Istio sidecar and click **⋮ > Redeploy**. When the workload is redeployed, it will have the Envoy sidecar automatically injected.
 
 Wait a few minutes for the workload to upgrade to have the istio sidecar. Click it and go to the Containers section. You should be able to see `istio-proxy` alongside your original workload. This means the Istio sidecar is enabled for the workload. Istio is doing all the wiring for the sidecar envoy. Now Istio can do all the features automatically if you enable them in the yaml.
 
 ### Add Deployments and Services
 
-There are a few ways to add new **Deployments** in your namespace
+There are a few ways to add new **Deployments** in your namespace:
 
-1. From the **Cluster Explorer** click on **Workload > Overview.**
-1. Click **Create.**
-1. Select **Deployment** from the various workload options.
-1. Fill out the form, or **Edit as Yaml.**
-1. Click **Create.** 
+1.  Click **☰ > Cluster Management**.
+1. Go to the cluster that you created and click **Explore**.
+1. Click **Workload**.
+1. Click **Create**.
+1. Click **Deployment**.
+1. Fill out the form, or **Edit as Yaml**.
+1. Click **Create**. 
 
-Alternatively, you can select the specific workload you want to deploy from the **Workload** section of the left navigation bar and create it from there.
+To add a **Service** to your namespace:
 
-To add a **Service** to your namespace
-
-1. From the **Cluster Explorer** click on **Service Discovery > Services**
-1. Click **Create**
-1. Select the type of service you want to create from the various options
-1. Fill out the form, or **Edit as Yaml**
+1.  Click **☰ > Cluster Management**.
+1. Go to the cluster that you created and click **Explore**.
+1. Click **Service Discovery > Services**.
+1. Click **Create**.
+1. Select the type of service that you want.
+1. Fill out the form, or **Edit as Yaml**.
 1. Click **Create** 
 
 You can also create deployments and services using the kubectl **shell**
@@ -43,9 +47,11 @@ You can also create deployments and services using the kubectl **shell**
 
 Next we add the Kubernetes resources for the sample deployments and services for the BookInfo app in Istio's documentation.
 
-1. From the **Cluster Explorer**, open the kubectl **shell**
+1.  Click **☰ > Cluster Management**.
+1. Go to the cluster that you created and click **Explore**.
+1. In the top navigation bar, open the kubectl shell.
 1. Run `cat<< EOF | kubectl apply -f -`
-1. Copy the below resources into the the shell
+1. Copy the below resources into the the shell.
 1. Run `EOF`
 
 This will set up the following sample resources from Istio's example BookInfo app:

--- a/content/rancher/v2.6/en/istio/setup/enable-istio-in-cluster/_index.md
+++ b/content/rancher/v2.6/en/istio/setup/enable-istio-in-cluster/_index.md
@@ -1,9 +1,6 @@
 ---
 title: 1. Enable Istio in the Cluster
 weight: 1
-aliases:
-  - /rancher/v2.6/en/cluster-admin/tools/istio/setup/enable-istio-in-cluster
-  - /rancher/v2.6/en/istio/v2.5/setup/enable-istio-in-cluster
 ---
 
 >**Prerequisites:**
@@ -13,8 +10,11 @@ aliases:
 >- To install Istio on an RKE2 cluster, additional steps are required. For details, see [this section.]({{<baseurl>}}/rancher/v2.6/en/istio/v2.5/configuration-reference/rke2/)
 >- To install Istio in a cluster where project network isolation is enabled, additional steps are required. For details, see [this section.]({{<baseurl>}}/rancher/v2.6/en/istio/v2.5/configuration-reference/canal-and-project-network)
 
-1. From the **Cluster Explorer**, navigate to available **Charts** in **Apps & Marketplace** 
-1. Select the Istio chart from the rancher provided charts
+1.  Click **☰ > Cluster Management**.
+1. Go to the where you want to enable Istio and click **Explore**.
+1. Click **Apps & Marketplace**.
+1. Click **Charts**.
+1. Click **Istio**.
 1. If you have not already installed your own monitoring app, you will be prompted to install the rancher-monitoring app. Optional: Set your Selector or Scrape config options on rancher-monitoring app install. 
 1. Optional: Configure member access and [resource limits]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/tools/istio/resources/) for the Istio components. Ensure you have enough resources on your worker nodes to enable Istio.
 1. Optional: Make additional configuration changes to values.yaml if needed.

--- a/content/rancher/v2.6/en/istio/setup/enable-istio-in-namespace/_index.md
+++ b/content/rancher/v2.6/en/istio/setup/enable-istio-in-namespace/_index.md
@@ -1,9 +1,6 @@
 ---
 title: 2. Enable Istio in a Namespace
 weight: 2
-aliases:
-  - /rancher/v2.6/en/cluster-admin/tools/istio/setup/enable-istio-in-namespace
-  - /rancher/v2.6/en/istio/v2.5/setup/enable-istio-in-namespace
 ---
 
 You will need to manually enable Istio in each namespace that you want to be tracked or controlled by Istio. When Istio is enabled in a namespace, the Envoy sidecar proxy will be automatically injected into all new workloads that are deployed in the namespace.
@@ -12,8 +9,10 @@ This namespace setting will only affect new workloads in the namespace. Any pree
 
 > **Prerequisite:** To enable Istio in a namespace, the cluster must have Istio installed.  
 
-1. In the Rancher **Cluster Explorer,** open the kubectl shell.
-1. Then run `kubectl label namespace <namespace> istio-injection=enabled`
+1. Click **☰ > Cluster Management**.
+1. Go to the cluster that you created and click **Explore**.
+1. Click **Cluster > Projects/Namespaces**.
+1. Go to the namespace where you want to enable Istio and click **⋮  > Enable Istio Auto Injection**. Alternately, click the namespace, and then on the namespace detail page, click **⋮  > Enable Istio Auto Injection**.
 
 **Result:** The namespace now has the label `istio-injection=enabled`. All new workloads deployed in this namespace will have the Istio sidecar injected by default.
 
@@ -31,10 +30,12 @@ sidecar.istio.io/inject: “false”
 
 To add the annotation to a workload,
 
-1. From the **Cluster Explorer** view, use the side-nav to select the **Overview** page for workloads.
+1.  Click **☰ > Cluster Management**.
+1. Go to the cluster that you created and click **Explore**.
+1. Click **Workload**.
 1. Go to the workload that should not have the sidecar and edit as yaml
 1. Add the following key, value `sidecar.istio.io/inject: false` as an annotation on the workload
-1. Click **Save.**
+1. Click **Save**.
 
 **Result:** The Istio sidecar will not be injected into the workload.
 

--- a/content/rancher/v2.6/en/istio/setup/gateway/_index.md
+++ b/content/rancher/v2.6/en/istio/setup/gateway/_index.md
@@ -1,9 +1,6 @@
 ---
 title: 4. Set up the Istio Gateway
 weight: 5
-aliases:
-  - /rancher/v2.6/en/cluster-admin/tools/istio/setup/gateway
-  - /rancher/v2.6/en/istio/v2.5/setup/gateway
 ---
 
 The gateway to each cluster can have its own port or load balancer, which is unrelated to a service mesh. By default, each Rancher-provisioned cluster has one NGINX ingress controller allowing traffic into the cluster. 
@@ -24,20 +21,22 @@ For more information on the Istio gateway, refer to the [Istio documentation.](h
 
 The ingress gateway is a Kubernetes service that will be deployed in your cluster. The Istio Gateway allows for more extensive customization and flexibility.  
 
-1. From the **Cluster Explorer**, select **Istio** from the nav dropdown. 
-1. Click **Gateways** in the side nav bar.
+1.  Click **☰ > Cluster Management**.
+1. Go to the cluster that you created and click **Explore**.
+1. In the left navigation bar, click **Istio > Gateways**.
 1. Click **Create from Yaml**.
 1. Paste your Istio Gateway yaml, or **Read from File**.
 1. Click **Create**.
 
-**Result:** The gateway is deployed, and will now route traffic with applied rules
+**Result:** The gateway is deployed, and will now route traffic with applied rules.
 
 # Example Istio Gateway
 
 We add the BookInfo app deployments in services when going through the Workloads example. Next we add an Istio Gateway so that the app is accessible from outside your cluster.
 
-1. From the **Cluster Explorer**, select **Istio** from the nav dropdown. 
-1. Click **Gateways** in the side nav bar.
+1.  Click **☰ > Cluster Management**.
+1. Go to the cluster that you created and click **Explore**.
+1. In the left navigation bar, click **Istio > Gateways**.
 1. Click **Create from Yaml**.
 1. Copy and paste the Gateway yaml provided below.
 1. Click **Create**.
@@ -60,10 +59,11 @@ spec:
 ---
 ```
 
-Then to deploy the VirtualService that provides the traffic routing for the Gateway
+Then to deploy the VirtualService that provides the traffic routing for the Gateway:
 
-1. Click **VirtualService** in the side nav bar.
-1. Click **Create from Yaml**.
+1.  Click **☰ > Cluster Management**.
+1. Go to the cluster that you created and click **Explore**.
+1. In the left navigation bar, click **Istio > VirtualServices**.
 1. Copy and paste the VirtualService yaml provided below.
 1. Click **Create**.
 
@@ -117,7 +117,9 @@ To test and see if the BookInfo app deployed correctly, the app can be viewed a 
 
 To get the ingress gateway URL and port,
 
-1. From the **Cluster Explorer**, Click on **Workloads > Overview**. 
+1.  Click **☰ > Cluster Management**.
+1. Go to the cluster that you created and click **Explore**.
+1. In the left navigation bar, click **Workload**.
 1. Scroll down to the `istio-system` namespace. 
 1. Within `istio-system`, there is a workload named `istio-ingressgateway`. Under the name of this workload, you should see links, such as `80/tcp`.
 1. Click one of those links. This should show you the URL of the ingress gateway in your web browser. Append `/productpage` to the URL.
@@ -136,7 +138,9 @@ You can try the steps in this section to make sure the Kubernetes gateway is con
 
 In the gateway resource, the selector refers to Istio's default ingress controller by its label, in which the key of the label is `istio` and the value is `ingressgateway`.  To make sure the label is appropriate for the gateway, do the following:
 
-1. From the **Cluster Explorer**, Click on **Workloads > Overview**. 
+1.  Click **☰ > Cluster Management**.
+1. Go to the cluster that you created and click **Explore**.
+1. In the left navigation bar, click **Workload**.
 1. Scroll down to the `istio-system` namespace. 
 1. Within `istio-system`, there is a workload named `istio-ingressgateway`. Click the name of this workload and go to the **Labels and Annotations** section. You should see that it has the key `istio` and the value `ingressgateway`. This confirms that the selector in the Gateway resource matches Istio's default ingress controller.
 

--- a/content/rancher/v2.6/en/istio/setup/set-up-traffic-management/_index.md
+++ b/content/rancher/v2.6/en/istio/setup/set-up-traffic-management/_index.md
@@ -1,9 +1,6 @@
 ---
 title: 5. Set up Istio's Components for Traffic Management
 weight: 6
-aliases:
-  - /rancher/v2.6/en/cluster-admin/tools/istio/setup/set-up-traffic-management
-  - /rancher/v2.6/en/istio/v2.5/setup/set-up-traffic-management
 ---
 
 A central advantage of traffic management in Istio is that it allows dynamic request routing. Some common applications for dynamic request routing include canary deployments and blue/green deployments. The two key resources in Istio traffic management are *virtual services* and *destination rules*.
@@ -18,33 +15,35 @@ In this example, we take the traffic to the `reviews` service and intercept it s
 After this virtual service is deployed, we will generate traffic and see from the Kiali visualization that traffic is being routed evenly between the two versions of the service.
 
 To deploy the virtual service and destination rules for the `reviews` service,
-
-1. From the **Cluster Explorer**, select **Istio** from the nav dropdown. 
-1. Click **DestinationRule** in the side nav bar.
-1. Click **Create from Yaml**.
+1.  Click **☰ > Cluster Management**.
+1. Go to the cluster where Istio is installed and click **Explore**.
+1. In the cluster where Istio is installed, click **Istio > DestinationRules** in the left navigation bar.
+1. Click **Create**.
 1. Copy and paste the DestinationRule yaml provided below.
 1. Click **Create**.
+1. Click **Edit as YAML** and use this configuration:
 
-```yaml
-apiVersion: networking.istio.io/v1alpha3
-kind: DestinationRule
-metadata:
-  name: reviews
-spec:
-  host: reviews
-  subsets:
-  - name: v1
-    labels:
-      version: v1
-  - name: v2
-    labels:
-      version: v2
-  - name: v3
-    labels:
-      version: v3
-```
+    ```yaml
+    apiVersion: networking.istio.io/v1alpha3
+    kind: DestinationRule
+    metadata:
+      name: reviews
+    spec:
+      host: reviews
+      subsets:
+      - name: v1
+        labels:
+          version: v1
+      - name: v2
+        labels:
+          version: v2
+      - name: v3
+        labels:
+          version: v3
+    ```
+1. Click **Create**.
 
-Then to deploy the VirtualService that provides the traffic routing that utilizes the DestinationRule
+Then to deploy the VirtualService that provides the traffic routing that utilizes the DestinationRule:
 
 1. Click **VirtualService** in the side nav bar.
 1. Click **Create from Yaml**.

--- a/content/rancher/v2.6/en/istio/setup/view-traffic/_index.md
+++ b/content/rancher/v2.6/en/istio/setup/view-traffic/_index.md
@@ -1,10 +1,6 @@
 ---
 title: 6. Generate and View Traffic
 weight: 7
-aliases:
-  - /rancher/v2.6/en/cluster-admin/tools/istio/setup/view-traffic
-  - /rancher/v2.6/en/istio/setup/view-traffic
-  - /rancher/v2.6/en/istio/v2.5/setup/view-traffic
 ---
 
 This section describes how to view the traffic that is being managed by Istio.
@@ -17,8 +13,8 @@ The Istio overview page provides a link to the Kiali dashboard. From the Kiali d
 
 To see the traffic graph,
 
-1. From the **Cluster Explorer**, select **Istio** from the nav dropdown.
-1. Click the **Kiali** link on the Istio **Overview** page.
+1. In the cluster where Istio is installed, click **Istio** in the left navigation bar.
+1. Click the **Kiali** link.
 1. Click on **Graph** in the side nav.
 1. Change the namespace in the **Namespace** dropdown to view the traffic for each namespace. 
 

--- a/content/rancher/v2.6/en/k8s-in-rancher/_index.md
+++ b/content/rancher/v2.6/en/k8s-in-rancher/_index.md
@@ -1,13 +1,9 @@
 ---
 title: Kubernetes Resources
 weight: 18
-aliases:
-  - /rancher/v2.6/en/concepts/
-  - /rancher/v2.6/en/tasks/
-  - /rancher/v2.6/en/concepts/resources/  
 ---
 
-> The <b>Cluster Explorer</b> is a new feature in Rancher v2.5 that allows you to view and manipulate all of the custom resources and CRDs in a Kubernetes cluster from the Rancher UI. This section will be updated to reflect the way that Kubernetes resources are handled in Rancher v2.5.
+You can view and manipulate all of the custom resources and CRDs in a Kubernetes cluster from the Rancher UI.
 
 ## Workloads
 

--- a/content/rancher/v2.6/en/k8s-in-rancher/certificates/_index.md
+++ b/content/rancher/v2.6/en/k8s-in-rancher/certificates/_index.md
@@ -1,45 +1,34 @@
 ---
 title: Encrypting HTTP Communication
-description: Learn how to add an SSL (Secure Sockets Layer) certificate or TLS (Transport Layer Security) certificate to either a project, a namespace, or both, so that you can add it to deployments
+description: Learn how to add an SSL (Secure Sockets Layer) certificate or TLS (Transport Layer Security) certificate
 weight: 3060
-aliases:
-  - /rancher/v2.6/en/tasks/projects/add-ssl-certificates/
-  - /rancher/v2.6/en/k8s-in-rancher/certificates  
 ---
 
-When you create an ingress within Rancher/Kubernetes, you must provide it with a secret that includes a TLS private key and certificate, which are used to encrypt and decrypt communications that come through the ingress. You can make certificates available for ingress use by navigating to its project or namespace, and then uploading the certificate. You can then add the certificate to the ingress deployment.
-
-Add SSL certificates to either projects, namespaces, or both. A project scoped certificate will be available in all its namespaces.
+When you create an ingress within Rancher/Kubernetes, you must provide it with a secret that includes a TLS private key and certificate, which are used to encrypt and decrypt communications that come through the ingress. You can make certificates available for ingress use by adding the certificate to the ingress deployment.
 
 >**Prerequisites:** You must have a TLS private key and certificate available to upload.
 
-1. From the **Global** view, select the project where you want to deploy your ingress.
+### 1. Create a Secret
 
-1. From the main menu, select **Resources > Secrets > Certificates**. Click **Add Certificate**.
 
-1. Enter a **Name** for the certificate.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster where you want to deploy your ingress and click **More Resources > Core > Secrets**.
+1. Click **Create**.
+1. Click **TLS Certificate**.
+1. Enter a name for the secret. Note: Your secret must have a unique name among the other certificates, registries, and secrets within your project/workspace.
+1. In the **Private Key** field, either copy and paste your certificate's private key into the text box (include the header and footer), or click **Read from a file** to browse to the private key on your file system. If possible, we recommend using **Read from a file** to reduce likelihood of error. Note: Private key files end with an extension of `.key`.
+1. In the **Certificate** field, either copy and paste your certificate into the text box (include the header and footer), or click **Read from a file** to browse to the certificate on your file system. If possible, we recommend using **Read from a file** to reduce likelihood of error. Note: Certificate files end with an extension of `.crt`.
+1. Click **Create**.
 
-    >**Note:** Kubernetes classifies SSL certificates as [secrets](https://kubernetes.io/docs/concepts/configuration/secret/), and no two secrets in a project or namespace can have duplicate names. Therefore, to prevent conflicts, your SSL certificate must have a unique name among the other certificates, registries, and secrets within your project/workspace.
+### 2. Add the Secret to an Ingress
 
-1. Select the **Scope** of the certificate.
-
-    - **Available to all namespaces in this project:** The certificate is available for any deployment in any namespaces in the project.
-
-    - **Available to a single namespace:** The certificate is only available for the deployments in one namespace. If you choose this option, select a **Namespace** from the drop-down list or click **Add to a new namespace** to add the certificate to a namespace you create on the fly.
-
-1. From **Private Key**, either copy and paste your certificate's private key into the text box (include the header and footer), or click **Read from a file** to browse to the private key on your file system. If possible, we recommend using **Read from a file** to reduce likelihood of error.
-
-    Private key files end with an extension of `.key`.
-
-1. From **Certificate**, either copy and paste your certificate into the text box (include the header and footer), or click **Read from a file** to browse to the certificate on your file system. If possible, we recommend using **Read from a file** to reduce likelihood of error.
-
-    Certificate files end with an extension of `.crt`.
-
-**Result:** Your certificate is added to the project or namespace. You can now add it to deployments.
-
-- If you added an SSL certificate to the project, the certificate is available for deployments created in any project namespace.
-- If you added an SSL certificate to a namespace, the certificate is available only for deployments in that namespace.
-- Your certificate is added to the **Resources > Secrets > Certificates** view.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster where you want to deploy your ingress and click **Service Discovery > Ingresses**.
+1. Click **Create**.
+1. Select the **Namespace** of the ingress.
+1. Enter a **Name** for the ingress.
+1. In the **Certificates** tab, select the secret containing your certificate and private key.
+1. Click **Create**.
 
 ## What's Next?
 

--- a/content/rancher/v2.6/en/k8s-in-rancher/configmaps/_index.md
+++ b/content/rancher/v2.6/en/k8s-in-rancher/configmaps/_index.md
@@ -1,36 +1,24 @@
 ---
 title: ConfigMaps
 weight: 3061
-aliases:
-  - /rancher/v2.6/en/tasks/projects/add-configmaps
-  - /rancher/v2.6/en/k8s-in-rancher/configmaps  
 ---
 
 While most types of Kubernetes secrets store sensitive information, [ConfigMaps](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/) store general configuration information, such as a group of config files. Because ConfigMaps don't store sensitive information, they can be updated automatically, and therefore don't require their containers to be restarted following update (unlike most secret types, which require manual updates and a container restart to take effect).
 
 ConfigMaps accept key value pairs in common string formats, like config files or JSON blobs. After you upload a config map, any workload can reference it as either an environment variable or a volume mount.
 
->**Note:** ConfigMaps can only be applied to namespaces and not projects.
-
-1. From the **Global** view, select the project containing the namespace that you want to add a ConfigMap to.
-
-1. From the main menu, select **Resources > Config Maps**. Click **Add Config Map**.
-
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster that has the workload that should reference a ConfigMap and click **Explore**.
+1. In the left navigation bar, click **More Resources > Core > ConfigMaps**.
+1. Click **Create**.
 1. Enter a **Name** for the Config Map.
 
     >**Note:** Kubernetes classifies ConfigMaps as [secrets](https://kubernetes.io/docs/concepts/configuration/secret/), and no two secrets in a project or namespace can have duplicate names. Therefore, to prevent conflicts, your ConfigMaps must have a unique name among the other certificates, registries, and secrets within your workspace.
 
-1. Select the **Namespace** you want to add Config Map to. You can also add a new namespace on the fly by clicking **Add to a new namespace**.
+1. Select the **Namespace** you want to add Config Map to.
 
-1. From **Config Map Values**, click **Add Config Map Value** to add a key value pair to your ConfigMap. Add as many values as you need.
-
-1. Click **Save**.
-
-	>**Note:** Don't use ConfigMaps to store sensitive data [use a secret]({{<baseurl>}}/rancher/v2.6/en/k8s-in-rancher/secrets/).
-	>
-	>**Tip:** You can add multiple key value pairs to the ConfigMap by copying and pasting.
-	>
-    > {{< img "/img/rancher/bulk-key-values.gif" "Bulk Key Value Pair Copy/Paste">}}
+1. On the **Data** tab, add a key-value pair to your ConfigMap. Add as many values as you need.  You can add multiple key value pairs to the ConfigMap by copying and pasting. Alternatively, use **Read from File** to add the data. Note: If you need to store sensitive data, [use a secret]({{<baseurl>}}/rancher/v2.6/en/k8s-in-rancher/secrets/), not a ConfigMap.
+1. Click **Create**.
 
 **Result:** Your ConfigMap is added to the namespace. You can view it in the Rancher UI from the **Resources > Config Maps** view.
 

--- a/content/rancher/v2.6/en/k8s-in-rancher/horitzontal-pod-autoscaler/_index.md
+++ b/content/rancher/v2.6/en/k8s-in-rancher/horitzontal-pod-autoscaler/_index.md
@@ -2,8 +2,6 @@
 title: The Horizontal Pod Autoscaler
 description: Learn about the horizontal pod autoscaler (HPA). How to manage HPAs and how to test them with a service deployment
 weight: 3026
-aliases:
-  - /rancher/v2.6/en/k8s-in-rancher/horizontal-pod-autoscaler
 ---
 
 The [Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) (HPA) is a Kubernetes feature that allows you to configure your cluster to automatically scale the services it's running up or down.
@@ -24,7 +22,7 @@ You can create, manage, and delete HPAs using the Rancher UI. From the Rancher U
 Clusters created in Rancher v2.0.7 and higher automatically have all the requirements needed (metrics-server and Kubernetes cluster configuration) to use HPA.
 ## Testing HPAs with a Service Deployment
 
-You can see your HPA's current number of replicas by going to your project and clicking **Resources > HPA.** For more information, refer to [Get HPA Metrics and Status]({{<baseurl>}}/rancher/v2.6/en/k8s-in-rancher/horitzontal-pod-autoscaler/manage-hpa-with-rancher-ui/).
+You can see your HPA's current number of replicas by going to your project and clicking **Resources > HPA**. For more information, refer to [Get HPA Metrics and Status]({{<baseurl>}}/rancher/v2.6/en/k8s-in-rancher/horitzontal-pod-autoscaler/manage-hpa-with-rancher-ui/).
 
 You can also use `kubectl` to get the status of HPAs that you test with your load testing tool. For more information, refer to [Testing HPAs with kubectl]
 ({{<baseurl>}}/rancher/v2.6/en/k8s-in-rancher/horitzontal-pod-autoscaler/testing-hpa/).

--- a/content/rancher/v2.6/en/k8s-in-rancher/horitzontal-pod-autoscaler/hpa-background/_index.md
+++ b/content/rancher/v2.6/en/k8s-in-rancher/horitzontal-pod-autoscaler/hpa-background/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Background Information on HPAs
 weight: 3027
-aliases:
-  - /rancher/v2.6/en/k8s-in-rancher/horizontal-pod-autoscaler/hpa-background
 ---
 
 The [Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) (HPA) is a Kubernetes feature that allows you to configure your cluster to automatically scale the services it's running up or down. This section provides explanation on how HPA works with Kubernetes.

--- a/content/rancher/v2.6/en/k8s-in-rancher/horitzontal-pod-autoscaler/manage-hpa-with-kubectl/_index.md
+++ b/content/rancher/v2.6/en/k8s-in-rancher/horitzontal-pod-autoscaler/manage-hpa-with-kubectl/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Managing HPAs with kubectl
 weight: 3029
-aliases:
-  - /rancher/v2.6/en/k8s-in-rancher/horizontal-pod-autoscaler/manage-hpa-with-kubectl
 ---
 
 This section describes HPA management with `kubectl`. This document has instructions for how to:

--- a/content/rancher/v2.6/en/k8s-in-rancher/horitzontal-pod-autoscaler/manage-hpa-with-rancher-ui/_index.md
+++ b/content/rancher/v2.6/en/k8s-in-rancher/horitzontal-pod-autoscaler/manage-hpa-with-rancher-ui/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Managing HPAs with the Rancher UI
 weight: 3028
-aliases:
-  - /rancher/v2.6/en/k8s-in-rancher/horizontal-pod-autoscaler/manage-hpa-with-rancher-ui
 ---
 
 The Rancher UI supports creating, managing, and deleting HPAs. You can configure CPU or memory usage as the metric that the HPA uses to scale.
@@ -11,20 +9,14 @@ If you want to create HPAs that scale based on other metrics than CPU and memory
 
 ## Creating an HPA
 
-1. From the **Global** view, open the project that you want to deploy a HPA to.
-
-1. Click **Resources > HPA.**
-
-1. Click **Add HPA.**
-
-1. Enter a **Name** for the HPA.
-
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster you want to create an HPA in and click **Explore**.
+1. In the left navigation bar, click **Service Discovery > HorizontalPodAutoscalers**.
+1. Click **Create**.
 1. Select a **Namespace** for the HPA.
-
-1. Select a **Deployment** as scale target for the HPA.
-
-1. Specify the **Minimum Scale** and **Maximum Scale** for the HPA.
-
+1. Enter a **Name** for the HPA.
+1. Select a **Target Reference** as scale target for the HPA.
+1. Specify the **Minimum Replicas** and **Maximum Replicas** for the HPA.
 1. Configure the metrics for the HPA. You can choose memory or CPU usage as the metric that will cause the HPA to scale the service up or down. In the **Quantity** field, enter the percentage of the workload's memory or CPU usage that will cause the HPA to scale the service. To configure other HPA metrics, including metrics available from Prometheus, you need to [manage HPAs using kubectl]({{<baseurl>}}/rancher/v2.6/en/k8s-in-rancher/horitzontal-pod-autoscaler/manage-hpa-with-kubectl/#configuring-hpa-to-scale-using-custom-metrics-with-prometheus).
 
 1. Click **Create** to create the HPA.
@@ -33,23 +25,20 @@ If you want to create HPAs that scale based on other metrics than CPU and memory
 
 ## Get HPA Metrics and Status
 
-1. From the **Global** view, open the project with the HPAs you want to look at.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster that has the HPA and click **Explore**.
+1. In the left navigation bar, click **Service Discovery > HorizontalPodAutoscalers**. The **HorizontalPodAutoscalers** page shows the number of current replicas.
 
-1. Click **Resources > HPA.** The **HPA** tab shows the number of current replicas.
-
-1. For more detailed metrics and status of a specific HPA, click the name of the HPA. This leads to the HPA detail page.
+For more detailed metrics and status of a specific HPA, click the name of the HPA. This leads to the HPA detail page.
 
 
 ## Deleting an HPA
 
-1. From the **Global** view, open the project that you want to delete an HPA from.
-
-1. Click **Resources > HPA.**
-
-1. Find the HPA which you would like to delete.
-
-1. Click **&#8942; > Delete**.
-
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster that has the HPA you want to delete and click **Explore**.
+1. In the left navigation bar, click **Service Discovery > HorizontalPodAutoscalers**.
+1. Click **Resources > HPA**.
+1. Find the HPA which you would like to delete and click **⋮ > Delete**.
 1. Click **Delete** to confirm.
 
 > **Result:** The HPA is deleted from the current cluster.

--- a/content/rancher/v2.6/en/k8s-in-rancher/horitzontal-pod-autoscaler/testing-hpa/_index.md
+++ b/content/rancher/v2.6/en/k8s-in-rancher/horitzontal-pod-autoscaler/testing-hpa/_index.md
@@ -1,9 +1,6 @@
 ---
 title: Testing HPAs with kubectl
 weight: 3031
-
-aliases:
-  - /rancher/v2.6/en/k8s-in-rancher/horizontal-pod-autoscaler/testing-hpa
 ---
 
 This document describes how to check the status of your HPAs after scaling them up or down with your load testing tool. For information on how to check the status from the Rancher UI (at least version 2.3.x), refer to [Managing HPAs with the Rancher UI]({{<baseurl>}}/rancher/v2.6/en/k8s-in-rancher/horitzontal-pod-autoscaler/manage-hpa-with-kubectl/).

--- a/content/rancher/v2.6/en/k8s-in-rancher/load-balancers-and-ingress/_index.md
+++ b/content/rancher/v2.6/en/k8s-in-rancher/load-balancers-and-ingress/_index.md
@@ -2,8 +2,6 @@
 title: Set Up Load Balancer and Ingress Controller within Rancher
 description: Learn how you can set up load balancers and ingress controllers to redirect service requests within Rancher, and learn about the limitations of load balancers
 weight: 3040
-aliases:
-  - /rancher/v2.6/en/k8s-in-rancher/load-balancers-and-ingress
 ---
 
 Within Rancher, you can set up load balancers and ingress controllers to redirect service requests.

--- a/content/rancher/v2.6/en/k8s-in-rancher/load-balancers-and-ingress/ingress-config/_index.md
+++ b/content/rancher/v2.6/en/k8s-in-rancher/load-balancers-and-ingress/ingress-config/_index.md
@@ -15,42 +15,28 @@ weight: 9999
 
 For Kubernetes v1.21 and up, the NGINX Ingress controller no longer runs in hostNetwork but uses hostPorts for port 80 and port 443. This was done so the admission webhook can be configured to be accessed using ClusterIP so it can only be reached inside the cluster.
 
-### Automatically generate a xip.io hostname
+# Ingress Rule Configuration
 
-If you choose this option, ingress routes requests to hostname to a DNS name that's automatically generated. Rancher uses [xip.io](http://xip.io/) to automatically generates the DNS name. This option is best used for testing, _not_ production environments.
-
->**Note:** To use this option, you must be able to resolve to `xip.io` addresses.
-
-1. Add a **Target Backend**. By default, a workload is added to the ingress, but you can add more targets by clicking either **Service** or **Workload**.
-1. **Optional:** If you want specify a workload or service when a request is sent to a particular hostname path, add a **Path** for the target. For example, if you want requests for `www.mysite.com/contact-us` to be sent to a different service than `www.mysite.com`, enter `/contact-us` in the **Path** field. Typically, the first rule that you create does not include a path.
-1. Select a workload or service from the **Target** drop-down list for each target you've added.
-1. Enter the **Port** number that each target operates on.
+- [Specify a hostname to use](#specify-a-hostname-to-use)
+- [Use as the default backend](#use-as-the-default-backend)
+- [Certificates](#certificates)
+- [Labels and Annotations](#labels-and-annotations)
 
 ### Specify a hostname to use
 
 If you use this option, ingress routes requests for a hostname to the service or workload that you specify.
 
-1. Enter the hostname that your ingress will handle request forwarding for. For example, `www.mysite.com`.
-1. Add a **Target Backend**. By default, a workload is added to the ingress, but you can add more targets by clicking either **Service** or **Workload**.
+1. Enter the **Request Host** that your ingress will handle request forwarding for. For example, `www.mysite.com`.
+1. Add a **Target Service**.
 1. **Optional:** If you want specify a workload or service when a request is sent to a particular hostname path, add a **Path** for the target. For example, if you want requests for `www.mysite.com/contact-us` to be sent to a different service than `www.mysite.com`, enter `/contact-us` in the **Path** field. Typically, the first rule that you create does not include a path.
-1. Select a workload or service from the **Target** drop-down list for each target you've added.
 1. Enter the **Port** number that each target operates on.
-
-### Use as the default backend
-
-Use this option to set an ingress rule for handling requests that don't match any other ingress rules. For example, use this option to route requests that can't be found to a `404` page.
-
->**Note:** If you deployed Rancher using RKE, a default backend for 404s and 202s is already configured.
-
-1. Add a **Target Backend**. Click either **Service** or **Workload** to add the target.
-1. Select a service or workload from the **Target** drop-down list.
-
 ### Certificates
 >**Note:** You must have an SSL certificate that the ingress can use to encrypt/decrypt communications. For more information see [Adding SSL Certificates]({{<baseurl>}}/rancher/v2.6/en/k8s-in-rancher/certificates/).
 
+1. When creating an ingress, click the **Certificates** tab.
 1. Click **Add Certificate**.
-1. Select a **Certificate** from the drop-down list.
-1. Enter the **Host** using encrypted communication.
+1. Select a **Certificate - Secret Name** from the drop-down list.
+1. Enter the host using encrypted communication.
 1. To add additional hosts that use the certificate, click **Add Hosts**.
 
 ### Labels and Annotations

--- a/content/rancher/v2.6/en/k8s-in-rancher/load-balancers-and-ingress/ingress/_index.md
+++ b/content/rancher/v2.6/en/k8s-in-rancher/load-balancers-and-ingress/ingress/_index.md
@@ -1,18 +1,17 @@
 ---
-title: Adding Ingresses to Your Project
-description: Ingresses can be added for workloads to provide load balancing, SSL termination and host/path-based routing. Learn how to add Rancher ingress to your project
+title: Adding Ingresses
+description: Ingresses can be added for workloads to provide load balancing, SSL termination and host/path-based routing. Learn how to add Rancher ingress
 weight: 3042
-aliases:
-  - /rancher/v2.6/en/tasks/workloads/add-ingress/
-  - /rancher/v2.6/en/k8s-in-rancher/load-balancers-and-ingress/ingress  
 ---
 
-Ingress can be added for workloads to provide load balancing, SSL termination and host/path based routing. When using ingresses in a project, you can program the ingress hostname to an external DNS by setting up a Global DNS entry.
+Ingresses can be added for workloads to provide load balancing, SSL termination and host/path based routing. When using ingresses in a project, you can program the ingress hostname to an external DNS by setting up a Global DNS entry.
 
-1. From the **Global** view, open the project that you want to add ingress to.
-1. Click **Resources** in the main navigation bar. Click the **Load Balancing** tab. Then click **Add Ingress**.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster that you want to add an ingress to and click **Explore**.
+1. Click **Service Discovery > Ingresses**.
+1. Click **Create**.
+1. Select an existing **Namespace** from the drop-down list.
 1. Enter a **Name** for the ingress.
-1. Select an existing **Namespace** from the drop-down list. Alternatively, you can create a new namespace on the fly by clicking **Add to a new namespace**.
 1. Create ingress forwarding **Rules**. For help configuring the rules, refer to [this section.](#ingress-rule-configuration) If any of your ingress rules handle requests for encrypted ports, add a certificate to encrypt/decrypt communications.
 1. **Optional:** click **Add Rule** to create additional ingress rules. For example, after you create ingress rules to direct requests for your hostname, you'll likely want to create a default backend to handle 404s. 
 

--- a/content/rancher/v2.6/en/k8s-in-rancher/load-balancers-and-ingress/load-balancers/_index.md
+++ b/content/rancher/v2.6/en/k8s-in-rancher/load-balancers-and-ingress/load-balancers/_index.md
@@ -2,9 +2,6 @@
 title: "Layer 4 and Layer 7 Load Balancing"
 description: "Kubernetes supports load balancing in two ways: Layer-4 Load Balancing and Layer-7 Load Balancing. Learn about the support for each way in different deployments"
 weight: 3041
-aliases:
-  - /rancher/v2.6/en/concepts/load-balancing/
-  - /rancher/v2.6/en/k8s-in-rancher/load-balancers-and-ingress/load-balancers
 ---
 Kubernetes supports load balancing in two ways: Layer-4 Load Balancing and Layer-7 Load Balancing.
 

--- a/content/rancher/v2.6/en/k8s-in-rancher/registries/_index.md
+++ b/content/rancher/v2.6/en/k8s-in-rancher/registries/_index.md
@@ -2,10 +2,6 @@
 title: Kubernetes Registry and Docker Registry
 description: Learn about the Docker registry and Kubernetes registry, their use cases and how to use a private registry with the Rancher UI
 weight: 3063
-aliases:
-  - /rancher/v2.6/en/tasks/projects/add-registries/
-  - /rancher/v2.6/en/k8s-in-rancher/registries
-  - /rancher/v2.6/en/k8s-resources/k8s-in-rancher/registries  
 ---
 Registries are Kubernetes secrets containing credentials used to authenticate with [private Docker registries](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/). 
 
@@ -22,17 +18,16 @@ Currently, deployments pull the private registry credentials automatically only 
 
 >**Prerequisites:** You must have a [private registry](https://docs.docker.com/registry/deploying/) available to use.
 
-1. From the **Global** view, select the project containing the namespace(s) where you want to add a registry.
-
-1. From the main menu, click **Resources > Secrets > Registry Credentials.** 
-
-1. Click **Add Registry.**
-
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster where you want to add a registry and click **Explore**.
+1. In the left navigation lick **More Resources > Core > Secrets**.
+1. Click **Create**.
+1. Click **Registry**.
 1. Enter a **Name** for the registry.
 
     >**Note:** Kubernetes classifies secrets, certificates, and registries all as [secrets](https://kubernetes.io/docs/concepts/configuration/secret/), and no two secrets in a project or namespace can have duplicate names. Therefore, to prevent conflicts, your registry must have a unique name among all secrets within your workspace.
 
-1. Select a **Scope** for the registry. You can either make the registry available for the entire project or a single namespace.
+1. Select a namespace for the registry.
 
 1. Select the website that hosts your private registry. Then enter credentials that authenticate with the registry. For example, if you use DockerHub, provide your DockerHub username and password.
 
@@ -52,12 +47,14 @@ You can deploy a workload with an image from a private registry through the Ranc
 
 To deploy a workload with an image from your private registry,
 
-1. Go to the project view,
-1. Click **Resources > Workloads.**
-1. Click **Deploy.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster where you want to deploy a workload and click **Explore**.
+1. Click **Workload**.
+1. Click **Create**.
+1. Select the type of workload you want to create.
 1. Enter a unique name for the workload and choose a namespace.
-1. In the **Docker Image** field, enter the URL of the path to the Docker image in your private registry. For example, if your private registry is on Quay.io, you could use `quay.io/<Quay profile name>/<Image name>`.
-1. Click **Launch.**
+1. In the **Container Image** field, enter the URL of the path to the image in your private registry. For example, if your private registry is on Quay.io, you could use `quay.io/<Quay profile name>/<Image name>`.
+1. Click **Create**.
 
 **Result:** Your deployment should launch, authenticate using the private registry credentials you added in the Rancher UI, and pull the Docker image that you specified.
 

--- a/content/rancher/v2.6/en/k8s-in-rancher/secrets/_index.md
+++ b/content/rancher/v2.6/en/k8s-in-rancher/secrets/_index.md
@@ -1,9 +1,6 @@
 ---
 title: Secrets
 weight: 3062
-aliases:
-  - /rancher/v2.6/en/tasks/projects/add-a-secret
-  - /rancher/v2.6/en/k8s-in-rancher/secrets   
 ---
 
 [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/#overview-of-secrets) store sensitive data like passwords, tokens, or keys. They may contain one or more key value pairs.
@@ -16,19 +13,17 @@ Mounted secrets will be updated automatically unless they are mounted as subpath
 
 # Creating Secrets
 
-When creating a secret, you can make it available for any deployment within a project, or you can limit it to a single namespace.
-
-1. From the **Global** view, select the project containing the namespace(s) where you want to add a secret.
-
-2. From the main menu, select **Resources > Secrets**. Click **Add Secret**.
-
-3. Enter a **Name** for the secret.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster where you want to add a secret and click **Explore**.
+1. Click **More Resources > Core > Secrets**.
+1. Click **Create**.
+1. Select the type of secret you want to create.
+1. Select a **Namespace** for the secret.
+1. Enter a **Name** for the secret.
 
     >**Note:** Kubernetes classifies secrets, certificates, and registries all as [secrets](https://kubernetes.io/docs/concepts/configuration/secret/), and no two secrets in a project or namespace can have duplicate names. Therefore, to prevent conflicts, your secret must have a unique name among all secrets within your workspace.
 
-4. Select a **Scope** for the secret. You can either make the registry available for the entire project or a single namespace.
-
-5. From **Secret Values**, click **Add Secret Value** to add a key value pair. Add as many values as you need.
+1. From **Data**, click **Add** to add a key-value pair. Add as many values as you need.
 
     >**Tip:** You can add multiple key value pairs to the secret by copying and pasting.
     >

--- a/content/rancher/v2.6/en/k8s-in-rancher/service-discovery/_index.md
+++ b/content/rancher/v2.6/en/k8s-in-rancher/service-discovery/_index.md
@@ -1,49 +1,26 @@
 ---
-title: Service Discovery
+title: Services
 weight: 3045
-aliases:
-  - /rancher/v2.6/en/tasks/workloads/add-a-dns-record/
-  - /rancher/v2.6/en/k8s-in-rancher/service-discovery
 ---
+
+Pod configuration is managed by Deployments, StatefulSets and Daemonsets, whereas services direct traffic to pods using selectors.
 
 For every workload created, a complementing Service Discovery entry is created. This Service Discovery entry enables DNS resolution for the workload's pods using the following naming convention:
 `<workload>.<namespace>.svc.cluster.local`.
 
-However, you also have the option of creating additional Service Discovery records. You can use these additional records so that a given namespace resolves with one or more external IP addresses, an external hostname, an alias to another DNS record, other workloads, or a set of pods that match a selector that you create.
+You can create additional services so that a given namespace resolves with one or more external IP addresses, an external hostname, an alias to another DNS record, other workloads, or a set of pods that match a selector that you create.
 
-1. From the **Global** view, open the project that you want to add a DNS record to.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster where you want to add a service and click **Explore**.
+1. Click **Service Discovery > Services**.
+1. Click **Create**.
+1. Choose the type of service you want to create.
+1. Select a **Namespace** from the drop-down list. 
+1. Enter a **Name** for the service. This name is used for DNS resolution.
+1. Fill out the rest of the form. For help, refer to the upstream Kubernetes documentation about [services.](https://kubernetes.io/docs/concepts/services-networking/service/)
+1. Click **Create**.
 
-1. Click **Resources** in the main navigation bar. Click the **Service Discovery** tab. Then click **Add Record**.
-
-1. Enter a **Name** for the DNS record. This name is used for DNS resolution.
-
-1. Select a **Namespace** from the drop-down list. Alternatively, you can create a new namespace on the fly by clicking **Add to a new namespace**.
-
-1. Select one of the **Resolves To** options to route requests to the DNS record.
-
-    1. **One or more external IP addresses**
-
-        Enter an IP address in the **Target IP Addresses** field. Add more IP addresses by clicking **Add Target IP**.
-
-    1. **An external hostname**
-
-        Enter a **Target Hostname**.
-
-    1. **Alias of another DNS record's value**
-
-        Click **Add Target Record** and select another DNS record from the **Value** drop-down.
-
-    1. **One or more workloads**
-
-        Click **Add Target Workload** and select another workload from the **Value** drop-down.
-
-    1. **The set of pods which match a selector**
-
-        Enter key value pairs of [label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) to create a record for all pods that match your parameters.
-
-1. Click **Create**
-
-**Result:** A new DNS record is created.
+**Result:** A new service is created.
 
 - You can view the record by from the project's **Service Discovery** tab.
 - When you visit the new DNS name for the new record that you created (`<recordname>.<namespace>.svc.cluster.local`), it resolves the chosen namespace.

--- a/content/rancher/v2.6/en/k8s-in-rancher/workloads/_index.md
+++ b/content/rancher/v2.6/en/k8s-in-rancher/workloads/_index.md
@@ -2,10 +2,6 @@
 title: "Kubernetes Workloads and Pods"
 description: "Learn about the two constructs with which you can build any complex containerized application in Kubernetes: Kubernetes workloads and pods"
 weight: 3025
-aliases:
-  - /rancher/v2.6/en/concepts/workloads/
-  - /rancher/v2.6/en/tasks/workloads/
-  - /rancher/v2.6/en/k8s-in-rancher/workloads
 ---
 
 You can build any complex containerized application in Kubernetes using two basic constructs: pods and workloads. Once you build an application, you can expose it for access either within the same cluster or on the Internet using a third construct: services.

--- a/content/rancher/v2.6/en/k8s-in-rancher/workloads/add-a-sidecar/_index.md
+++ b/content/rancher/v2.6/en/k8s-in-rancher/workloads/add-a-sidecar/_index.md
@@ -1,21 +1,18 @@
 ---
 title: Adding a Sidecar
 weight: 3029
-aliases:
-  - /rancher/v2.6/en/tasks/workloads/add-a-sidecar/
-  - /rancher/v2.6/en/k8s-in-rancher/workloads/add-a-sidecar
 ---
 A _sidecar_ is a container that extends or enhances the main container in a pod. The main container and the sidecar share a pod, and therefore share the same network space and storage. You can add sidecars to existing workloads by using the **Add a Sidecar** option.
 
-1. From the **Global** view, open the project running the workload you want to add a sidecar to.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster where you want to add a sidecar and click **Explore**.
+1. In the left navigation bar, click **Workload**.
 
-1. Click **Resources > Workloads.**
-
-1. Find the workload that you want to extend. Select **&#8942; icon (...) > Add a Sidecar**.
+1. Find the workload that you want to extend. Select **⋮ > + Add Sidecar**.
 
 1. Enter a **Name** for the sidecar.
 
-1. Select a **Sidecar Type**. This option determines if the sidecar container is deployed before or after the main container is deployed.
+1. In the **General** section, select a sidecar type. This option determines if the sidecar container is deployed before or after the main container is deployed.
 
     - **Standard Container:**
 
@@ -25,13 +22,13 @@ A _sidecar_ is a container that extends or enhances the main container in a pod.
 
         The sidecar container is deployed before the main container.
 
-1. From the **Docker Image** field, enter the name of the Docker image that you want to deploy in support of the main container. During deployment, Rancher pulls this image from [Docker Hub](https://hub.docker.com/explore/). Enter the name exactly as it appears on Docker Hub.
+1. From the **Container Image** field, enter the name of the container image that you want to deploy in support of the main container. During deployment, Rancher pulls this image from [Docker Hub](https://hub.docker.com/explore/). Enter the name exactly as it appears on Docker Hub.
 
 1. Set the remaining options. You can read about them in [Deploying Workloads](../deploy-workloads).
 
 1. Click **Launch**.
 
-**Result:** The sidecar is deployed according to your parameters. Following its deployment, you can view the sidecar by selecting **&#8942; icon (...) > Edit** for the main deployment.
+**Result:** The sidecar is deployed according to your parameters. Following its deployment, you can view the sidecar by selecting **⋮ icon (...) > Edit** for the main deployment.
 
 ## Related Links
 

--- a/content/rancher/v2.6/en/k8s-in-rancher/workloads/deploy-workloads/_index.md
+++ b/content/rancher/v2.6/en/k8s-in-rancher/workloads/deploy-workloads/_index.md
@@ -2,22 +2,19 @@
 title: Deploying Workloads
 description: Read this step by step guide for deploying workloads. Deploy a workload to run an application in one or more containers.
 weight: 3026
-aliases:
-  - /rancher/v2.6/en/tasks/workloads/deploy-workloads/
-  - /rancher/v2.6/en/k8s-in-rancher/workloads/deploy-workloads
 ---
 
 Deploy a workload to run an application in one or more containers.
 
-1. From the **Global** view, open the project that you want to deploy a workload to.
-
-1. 1. Click **Resources > Workloads.** From the **Workloads** view, click **Deploy**.
-
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster where you want to upgrade a workload and click **Explore**.
+1. In the left navigation bar, click **Workload**.
+1. Click **Create**.
+1. Choose the type of workload.
+1. Select the namespace where the workload will be deployed.
 1. Enter a **Name** for the workload.
 
-1. Select a [workload type]({{<baseurl>}}/rancher/v2.6/en/k8s-in-rancher/workloads/). The workload defaults to a scalable deployment, by can change the workload type by clicking **More options.**
-
-1. From the **Docker Image** field, enter the name of the Docker image that you want to deploy to the project, optionally prefacing it with the registry host (e.g. `quay.io`, `registry.gitlab.com`, etc.). During deployment, Rancher pulls this image from the specified public or private registry. If no registry host is provided, Rancher will pull the image from [Docker Hub](https://hub.docker.com/explore/). Enter the name exactly as it appears in the registry server, including any required path, and optionally including the desired tag (e.g. `registry.gitlab.com/user/path/image:tag`). If no tag is provided, the `latest` tag will be automatically used.
+1. From the **Container Image** field, enter the name of the Docker image that you want to deploy to the project, optionally prefacing it with the registry host (e.g. `quay.io`, `registry.gitlab.com`, etc.). During deployment, Rancher pulls this image from the specified public or private registry. If no registry host is provided, Rancher will pull the image from [Docker Hub](https://hub.docker.com/explore/). Enter the name exactly as it appears in the registry server, including any required path, and optionally including the desired tag (e.g. `registry.gitlab.com/user/path/image:tag`). If no tag is provided, the `latest` tag will be automatically used.
 
 1. Either select an existing namespace, or click **Add to a new namespace** and enter a new namespace.
 

--- a/content/rancher/v2.6/en/k8s-in-rancher/workloads/rollback-workloads/_index.md
+++ b/content/rancher/v2.6/en/k8s-in-rancher/workloads/rollback-workloads/_index.md
@@ -1,16 +1,14 @@
 ---
 title: Rolling Back Workloads
 weight: 3027
-aliases:
-  - /rancher/v2.6/en/tasks/workloads/rollback-workloads/
-  - /rancher/v2.6/en/k8s-in-rancher/workloads/rollback-workloads
 ---
 
 Sometimes there is a need to rollback to the previous version of the application, either for debugging purposes or because an upgrade did not go as planned.
 
-1. From the **Global** view, open the project running the workload you want to rollback.
-
-1. Find the workload that you want to rollback and select **Vertical &#8942; (... ) > Rollback**.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster where you want to upgrade a workload and click **Explore**.
+1. In the left navigation bar, click **Workload**.
+1. Find the workload that you want to rollback and select **⋮ > Rollback**.
 
 1. Choose the revision that you want to roll back to. Click **Rollback**.
 

--- a/content/rancher/v2.6/en/k8s-in-rancher/workloads/upgrade-workloads/_index.md
+++ b/content/rancher/v2.6/en/k8s-in-rancher/workloads/upgrade-workloads/_index.md
@@ -1,21 +1,18 @@
 ---
 title: Upgrading Workloads
 weight: 3028
-aliases:
-  - /rancher/v2.6/en/tasks/workloads/upgrade-workloads/
-  - /rancher/v2.6/en/k8s-in-rancher/workloads/upgrade-workloads
 ---
 When a new version of an application image is released on Docker Hub, you can upgrade any workloads running a previous version of the application to the new one.
 
-1. From the **Global** view, open the project running the workload you want to upgrade.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster where you want to upgrade a workload and click **Explore**.
+1. In the left navigation bar, click **Workload**.
 
-1. Find the workload that you want to upgrade and select **Vertical &#8942; (... ) > Edit**.
+1. Find the workload that you want to upgrade and select **⋮ > Edit Config**.
 
-1. Update the **Docker Image** to the updated version of the application image on Docker Hub.
+1. Update the **Container Image** and any options that you want to change.
 
-1. Update any other options that you want to change.
-
-1. Review and edit the workload's **Scaling/Upgrade** policy.
+1. Review and edit the workload's **Scaling and Upgrade Policy**.
 
     These options control how the upgrade rolls out to containers that are currently running. For example, for scalable deployments, you can choose whether you want to stop old pods before deploying new ones, or vice versa, as well as the upgrade batch size.
 

--- a/content/rancher/v2.6/en/logging/_index.md
+++ b/content/rancher/v2.6/en/logging/_index.md
@@ -4,10 +4,6 @@ shortTitle: Logging
 description: Rancher integrates with popular logging services. Learn the requirements and benefits of integrating with logging services, and enable logging on your cluster.
 metaDescription: "Rancher integrates with popular logging services. Learn the requirements and benefits of integrating with logging services, and enable logging on your cluster."
 weight: 15
-aliases:
-  - /rancher/v2.6/en/dashboard/logging
-  - /rancher/v2.6/en/logging/v2.5
-  - /rancher/v2.6/en/cluster-admin/tools/logging 
 ---
 
 The [Banzai Cloud Logging operator](https://banzaicloud.com/docs/one-eye/logging-operator/) now powers Rancher's logging solution in place of the former, in-house solution.
@@ -33,16 +29,15 @@ For an overview of the changes in v2.5, see [this section.](/{{<baseurl>}}/ranch
 
 You can enable the logging for a Rancher managed cluster by going to the Apps page and installing the logging app.
 
-1. In the Rancher UI, go to the cluster where you want to install logging and click **Cluster Explorer**.
-1. Click **Apps**.
-1. Click the `rancher-logging` app.
+1. Go to the cluster where you want to install logging and click **Apps & Marketplace**.
+1. Click the **Logging** app.
 1. Scroll to the bottom of the Helm chart README and click **Install**.
 
 **Result:** The logging app is deployed in the `cattle-logging-system` namespace.
 
 # Uninstall Logging
 
-1. From the **Cluster Explorer**, click **Apps & Marketplace**.
+1. Go to the cluster where you want to install logging and click **Apps & Marketplace**.
 1. Click **Installed Apps**.
 1. Go to the `cattle-logging-system` namespace and check the boxes for `rancher-logging` and `rancher-logging-crd`.
 1. Click **Delete**.
@@ -62,7 +57,11 @@ Rancher logging has two roles, `logging-admin` and `logging-view`. For more info
 
 # Configuring Logging Custom Resources
 
-To manage `Flows,` `ClusterFlows`, `Outputs`, and `ClusterOutputs`, go to the **Cluster Explorer** in the Rancher UI. In the upper left corner, click **Cluster Explorer > Logging**.
+To manage `Flows,` `ClusterFlows`, `Outputs`, and `ClusterOutputs`, 
+
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to configure logging custom resources and click **Explore**.
+1. In the left navigation bar, click **Logging**.
 
 ### Flows and ClusterFlows
 
@@ -105,26 +104,27 @@ By default, Rancher collects logs for control plane components and node componen
 
 ### The `cattle-logging` Namespace Being Recreated
 
-If your cluster previously deployed logging from the Cluster Manager UI, you may encounter an issue where its `cattle-logging` namespace is continually being recreated.
+If your cluster previously deployed logging from the global view in the legacy Rancher UI, you may encounter an issue where its `cattle-logging` namespace is continually being recreated.
 
 The solution is to delete all `clusterloggings.management.cattle.io` and `projectloggings.management.cattle.io` custom resources from the cluster specific namespace in the management cluster.
 The existence of these custom resources causes Rancher to create the `cattle-logging` namespace in the downstream cluster if it does not exist.
 
 The cluster namespace matches the cluster ID, so we need to find the cluster ID for each cluster.
 
-1. In your web browser, navigate to your cluster(s) in either the Cluster Manager UI or the Cluster Explorer UI.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster you want to get the ID of and click **Explore**.
 2. Copy the `<cluster-id>` portion from one of the URLs below. The `<cluster-id>` portion is the cluster namespace name.
 
 ```bash
 # Cluster Management UI
 https://<your-url>/c/<cluster-id>/
 
-# Cluster Explorer UI (Dashboard)
+# Cluster Dashboard
 https://<your-url>/dashboard/c/<cluster-id>/
 ```
 
 Now that we have the `<cluster-id>` namespace, we can delete the CRs that cause `cattle-logging` to be continually recreated.
-*Warning:* ensure that logging, the version installed from the Cluster Manager UI, is not currently in use.
+*Warning:* ensure that logging, the version installed from the global view in the legacy Rancher UI, is not currently in use.
 
 ```bash
 kubectl delete clusterloggings.management.cattle.io -n <cluster-id>

--- a/content/rancher/v2.6/en/logging/helm-chart-options/_index.md
+++ b/content/rancher/v2.6/en/logging/helm-chart-options/_index.md
@@ -15,7 +15,7 @@ weight: 4
 
 You can enable or disable Windows node logging by setting `global.cattle.windows.enabled` to either `true` or `false` in the `values.yaml`.
 
-By default, Windows node logging will be enabled if the Cluster Explorer UI is used to install the logging application on a Windows cluster.
+By default, Windows node logging will be enabled if the Cluster Dashboard UI is used to install the logging application on a Windows cluster.
 
 In this scenario, setting `global.cattle.windows.enabled` to `false` will disable Windows node logging on the cluster.
 When disabled, logs will still be collected from Linux nodes within the Windows cluster.
@@ -63,7 +63,7 @@ The following table summarizes the sources where additional logs may be collecte
 | EKS | ✓ | |
 | GKE | ✓ | |
 
-To enable hosted Kubernetes providers as additional logging sources, go to **Cluster Explorer > Logging > Chart Options** and select the **Enable enhanced cloud provider logging** option.
+To enable hosted Kubernetes providers as additional logging sources, enable **Enable enhanced cloud provider logging** option when installing or upgrading the Logging Helm chart.
 
 When enabled, Rancher collects all additional node and control plane logs the provider has made available, which may vary between providers
 

--- a/content/rancher/v2.6/en/logging/migrating/_index.md
+++ b/content/rancher/v2.6/en/logging/migrating/_index.md
@@ -1,14 +1,10 @@
 ---
 title: Migrating to Rancher v2.5 Logging
 weight: 2
-aliases:
-  - /rancher/v2.6/en/logging/v2.5/migrating
 ---
 Starting in v2.5, the logging feature available within Rancher has been completely overhauled. The [logging operator](https://github.com/banzaicloud/logging-operator) from Banzai Cloud has been adopted; Rancher configures this tooling for use when deploying logging.
 
 Among the many features and changes in the new logging functionality is the removal of project-specific logging configurations. Instead, one now configures logging at the namespace level. Cluster-level logging remains available, but configuration options differ. 
-
-> Note: The pre-v2.5 user interface is now referred to as the _Cluster Manager_. The v2.5+ dashboard is referred to as the _Cluster Explorer_.
 
 - [Installation](#installation)
   - [Terminology](#terminology)
@@ -29,7 +25,7 @@ To install logging in Rancher v2.5+, refer to the [installation instructions]({{
 
 ### Terminology
 
-In v2.5, logging configuration is centralized under a _Logging_ menu option available in the _Cluster Explorer_. It is from this menu option that logging for both cluster and namespace is configured. 
+In v2.5+, logging configuration in the **Cluster Dashboard**. To configure logging custom resources after the Logging application is installed, go to the left navigation bar and click **Logging**. It is from this menu option that logging for both cluster and namespace is configured. 
 
 > Note: Logging is installed on a per-cluster basis. You will need to navigate between clusters to configure logging for each cluster. 
 

--- a/content/rancher/v2.6/en/longhorn/_index.md
+++ b/content/rancher/v2.6/en/longhorn/_index.md
@@ -22,38 +22,31 @@ With Longhorn, you can:
 <figcaption>Longhorn Dashboard</figcaption>
 ![Longhorn Dashboard]({{<baseurl>}}/img/rancher/longhorn-screenshot.png)
 
-### New in Rancher v2.5
-
-Before Rancher v2.5, Longhorn could be installed as a Rancher catalog app. In Rancher v2.5, the catalog system was replaced by the **Apps & Marketplace,** and it became possible to install Longhorn as an app from that page.
-
-The **Cluster Explorer** now allows you to manipulate Longhorn's Kubernetes resources from the Rancher UI. So now you can control the Longhorn functionality with the Longhorn UI, or with kubectl, or by manipulating Longhorn's Kubernetes custom resources in the Rancher UI.
-
-These instructions assume you are using Rancher v2.5, but Longhorn can be installed with earlier Rancher versions. For documentation about installing Longhorn as a catalog app using the legacy Rancher UI, refer to the [Longhorn documentation.](https://longhorn.io/docs/1.0.2/deploy/install/install-with-rancher/)
-
 ### Installing Longhorn with Rancher
 
 1. Fulfill all [Installation Requirements.](https://longhorn.io/docs/1.1.0/deploy/install/#installation-requirements)
-1. Go to the **Cluster Explorer** in the Rancher UI.
-1. Click **Apps.**
-1. Click `longhorn`.
+1. Go to the cluster where you want to install Longhorn.
+1. Click **Apps & Marketplace**.
+1. Click **Charts**.
+1. Click **Longhorn**.
 1. Optional: To customize the initial settings, click **Longhorn Default Settings** and edit the configuration. For help customizing the settings, refer to the [Longhorn documentation.](https://longhorn.io/docs/1.0.2/references/settings/)
-1. Click **Install.**
+1. Click **Install**.
 
 **Result:** Longhorn is deployed in the Kubernetes cluster.
 
 ### Accessing Longhorn from the Rancher UI
 
-1. From the **Cluster Explorer," go to the top left dropdown menu and click **Cluster Explorer > Longhorn.**
+1. Go to the cluster where Longhorn is installed. In the left navigation menu, click **Longhorn**.
 1. On this page, you can edit Kubernetes resources managed by Longhorn. To view the Longhorn UI, click the **Longhorn** button in the **Overview** section.
 
 **Result:** You will be taken to the Longhorn UI, where you can manage your Longhorn volumes and their replicas in the Kubernetes cluster, as well as secondary backups of your Longhorn storage that may exist in another Kubernetes cluster or in S3.
 
 ### Uninstalling Longhorn from the Rancher UI
 
-1. Click **Cluster Explorer > Apps & Marketplace.**
-1. Click **Installed Apps.**
+1. Go to the cluster where Longhorn is installed and click **Apps & Marketplace**.
+1. Click **Installed Apps**.
 1. Go to the `longhorn-system` namespace and check the boxes next to the `longhorn` and `longhorn-crd` apps.
-1. Click **Delete,** and confirm **Delete.**
+1. Click **Delete,** and confirm **Delete**.
 
 **Result:** Longhorn is uninstalled.
 

--- a/content/rancher/v2.6/en/monitoring-alerting/_index.md
+++ b/content/rancher/v2.6/en/monitoring-alerting/_index.md
@@ -3,10 +3,6 @@ title: Monitoring and Alerting
 shortTitle: Monitoring/Alerting
 description: Prometheus lets you view metrics from your different Rancher and Kubernetes objects. Learn about the scope of monitoring and how to enable cluster monitoring
 weight: 13
-aliases:
-  - /rancher/v2.5/en/dashboard/monitoring-alerting
-  - /rancher/v2.5/en/dashboard/notifiers
-  - /rancher/v2.5/en/cluster-admin/tools/monitoring/
 ---
 
 Using the `rancher-monitoring` application, you can quickly deploy leading open-source monitoring and alerting solutions onto your cluster.
@@ -55,7 +51,7 @@ These default exporters automatically scrape metrics for CPU and memory from all
 
 ### Default Alerts
 
-The monitoring application deploys some alerts by default. To see the default alerts, go to the [Alertmanager UI](./dashboard/accessing-the-alertmanager-ui) and click **Expand all groups.**
+The monitoring application deploys some alerts by default. To see the default alerts, go to the [Alertmanager UI](./dashboard/accessing-the-alertmanager-ui) and click **Expand all groups**.
 
 ### Components Exposed in the Rancher UI
 

--- a/content/rancher/v2.6/en/monitoring-alerting/configuration/_index.md
+++ b/content/rancher/v2.6/en/monitoring-alerting/configuration/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Configuration
 weight: 5
-aliases:
-  - /rancher/v2.5/en/monitoring-alerting/v2.5/configuration
 ---
 
 This page captures some of the most important options for configuring Monitoring V2 in the Rancher UI.

--- a/content/rancher/v2.6/en/monitoring-alerting/configuration/advanced/prometheus/_index.md
+++ b/content/rancher/v2.6/en/monitoring-alerting/configuration/advanced/prometheus/_index.md
@@ -1,10 +1,6 @@
 ---
 title: Prometheus Configuration
 weight: 1
-aliases:
-  - /rancher/v2.5/en/monitoring-alerting/v2.5/configuration/prometheusrules
-  - /rancher/v2.5/en/monitoring-alerting/configuration/prometheusrules
-  - /rancher/v2.5/en/monitoring-alerting/configuration/advanced/prometheusrules
 ---
 
 It is usually not necessary to directly edit the Prometheus custom resource because the monitoring application automatically updates it based on changes to ServiceMonitors and PodMonitors.

--- a/content/rancher/v2.6/en/monitoring-alerting/configuration/advanced/prometheusrules/_index.md
+++ b/content/rancher/v2.6/en/monitoring-alerting/configuration/advanced/prometheusrules/_index.md
@@ -16,11 +16,11 @@ _Available as of v2.5.4_
 
 To create rule groups in the Rancher UI,
 
-1. Click **Cluster Explorer > Monitoring** and click **Prometheus Rules.** 
-1. Click **Create.**
-1. Enter a **Group Name.**
+1. Go to the cluster where you want to create rule groups. Click **Monitoring** and click **Prometheus Rules**. 
+1. Click **Create**.
+1. Enter a **Group Name**.
 1. Configure the rules. In Rancher's UI, we expect a rule group to contain either alert rules or recording rules, but not both. For help filling out the forms, refer to the configuration options below.
-1. Click **Create.**
+1. Click **Create**.
 
 **Result:** Alerts can be configured to send notifications to the receiver(s).
 

--- a/content/rancher/v2.6/en/monitoring-alerting/configuration/helm-chart-options/_index.md
+++ b/content/rancher/v2.6/en/monitoring-alerting/configuration/helm-chart-options/_index.md
@@ -38,7 +38,7 @@ If you need to add a trusted CA to your notifier, follow these steps:
 
 1. Create the `cattle-monitoring-system` namespace.
 1. Add your trusted CA secret to the `cattle-monitoring-system` namespace.
-1. Deploy or upgrade the `rancher-monitoring` Helm chart. In the chart options, reference the secret in **Alerting > Additional Secrets.**
+1. Deploy or upgrade the `rancher-monitoring` Helm chart. In the chart options, reference the secret in **Alerting > Additional Secrets**.
 
 **Result:** The default Alertmanager custom resource will have access to your trusted CA.
 

--- a/content/rancher/v2.6/en/monitoring-alerting/configuration/receiver/_index.md
+++ b/content/rancher/v2.6/en/monitoring-alerting/configuration/receiver/_index.md
@@ -2,12 +2,6 @@
 title: Receiver Configuration
 shortTitle: Receivers
 weight: 1
-aliases:
-  - /rancher/v2.5/en/monitoring-alerting/v2.5/configuration/alertmanager
-  - rancher/v2.5/en/monitoring-alerting/legacy/notifiers/
-  - /rancher/v2.5/en/cluster-admin/tools/notifiers
-  - /rancher/v2.5/en/cluster-admin/tools/alerts
-  - /rancher/v2.5/en/monitoring-alerting/configuration/alertmanager
 ---
 
 The [Alertmanager Config](https://prometheus.io/docs/alerting/latest/configuration/#configuration-file) Secret contains the configuration of an Alertmanager instance that sends out notifications based on alerts it receives from Prometheus.
@@ -43,10 +37,10 @@ _Available as of v2.5.4_
 
 To create notification receivers in the Rancher UI,
 
-1. Click **Cluster Explorer > Monitoring** and click **Receiver.** 
+1. Go to the cluster where you want to create receivers. Click **Monitoring** and click **Receiver**. 
 2. Enter a name for the receiver.
 3. Configure one or more providers for the receiver. For help filling out the forms, refer to the configuration options below.
-4. Click **Create.**
+4. Click **Create**.
 
 **Result:** Alerts can be configured to send notifications to the receiver(s).
 
@@ -158,10 +152,9 @@ The YAML provided here will be directly appended to your receiver within the Ale
 
 The Teams receiver is not a native receiver and must be enabled before it can be used. You can enable the Teams receiver for a Rancher managed cluster by going to the Apps page and installing the rancher-alerting-drivers app with the Teams option selected.
 
-1. In the Rancher UI, go to the cluster where you want to install rancher-alerting-drivers and click **Cluster Explorer**.
-1. Click **Apps**.
+1. In the Rancher UI, go to the cluster where you want to install rancher-alerting-drivers and click **Apps & Marketplace**.
 1. Click the **Alerting Drivers** app.
-1. Click the **Helm Deploy Options** tab
+1. Click the **Helm Deploy Options** tab.
 1. Select the **Teams** option and click **Install**.
 1. Take note of the namespace used as it will be required in a later step.
 
@@ -192,8 +185,9 @@ url: http://rancher-alerting-drivers-prom2teams.ns-1.svc:8089/v2/teams-instance-
 
 The SMS receiver is not a native receiver and must be enabled before it can be used. You can enable the SMS receiver for a Rancher managed cluster by going to the Apps page and installing the rancher-alerting-drivers app with the SMS option selected.
 
-1. In the Rancher UI, go to the cluster where you want to install rancher-alerting-drivers and click **Cluster Explorer**.
-1. Click **Apps**.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to install `rancher-alerting-drivers` and click **Explore**.
+1. In the left navigation bar, click 
 1. Click the **Alerting Drivers** app.
 1. Click the **Helm Deploy Options** tab
 1. Select the **SMS** option and click **Install**.

--- a/content/rancher/v2.6/en/monitoring-alerting/dashboards/_index.md
+++ b/content/rancher/v2.6/en/monitoring-alerting/dashboards/_index.md
@@ -39,7 +39,12 @@ The Alertmanager UI lets you see the most recently fired alerts.
 
 > **Prerequisite:** The `rancher-monitoring` application must be installed.
 
-To see the Alertmanager UI, go to the **Cluster Explorer.** In the top left corner, click **Cluster Explorer > Monitoring.** Then click **Alertmanager.**
+To see the Alertmanager UI,
+
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to see the Alertmanager UI, click **Explore**.
+1. In the left navigation bar, click **Monitoring**.
+1. Click **Alertmanager**.
 
 **Result:** The Alertmanager UI opens in a new tab. For help with configuration, refer to the [official Alertmanager documentation.](https://prometheus.io/docs/alerting/latest/alertmanager/)
 
@@ -51,14 +56,19 @@ For more information on configuring Alertmanager in Rancher, see [this page.](./
 
 ### Viewing Default Alerts
 
-To see alerts that are fired by default, go to the [Alertmanager UI](./alertmanager-ui) and click **Expand all groups.**
+To see alerts that are fired by default, go to the [Alertmanager UI](./alertmanager-ui) and click **Expand all groups**.
 
 
 # Prometheus UI
 
 By default, the [kube-state-metrics service](https://github.com/kubernetes/kube-state-metrics) provides a wealth of information about CPU and memory utilization to the monitoring application. These metrics cover Kubernetes resources across namespaces. This means that in order to see resource metrics for a service, you don't need to create a new ServiceMonitor for it. Because the data is already in the time series database, you can go to the Prometheus UI and run a PromQL query to get the information. The same query can be used to configure a Grafana dashboard to show a graph of those metrics over time.
 
-To see the Prometheus UI, install `rancher-monitoring`. Then go to the **Cluster Explorer.** In the top left corner, click **Cluster Explorer > Monitoring.** Then click **Prometheus Graph.**
+To see the Prometheus UI, install `rancher-monitoring`. Then:
+
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to see the Prometheus UI and click **Explore**.
+1. In the left navigation bar, click **Monitoring**.
+1. Click **Prometheus Graph**.
 
 <figcaption>Prometheus Graph UI</figcaption>
 ![Prometheus Graph UI]({{<baseurl>}}/img/rancher/prometheus-graph-ui.png)
@@ -67,7 +77,13 @@ To see the Prometheus UI, install `rancher-monitoring`. Then go to the **Cluster
 
 To see what services you are monitoring, you will need to see your targets. Targets are set up by ServiceMonitors and PodMonitors as sources to scrape metrics from. You won't need to directly edit targets, but the Prometheus UI can be useful for giving you an overview of all of the sources of metrics that are being scraped.
 
-To see the Prometheus Targets, install `rancher-monitoring`. Then go to the **Cluster Explorer.** In the top left corner, click **Cluster Explorer > Monitoring.** Then click **Prometheus Targets.**
+To see the Prometheus Targets, install `rancher-monitoring`. Then:
+
+
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to see the Prometheus targets and click **Explore**.
+1. In the left navigation bar, click **Monitoring**.
+1. Click **Prometheus Targets**.
 
 <figcaption>Targets in the Prometheus UI</figcaption>
 ![Prometheus Targets UI]({{<baseurl>}}/img/rancher/prometheus-targets-ui.png)
@@ -76,7 +92,12 @@ To see the Prometheus Targets, install `rancher-monitoring`. Then go to the **Cl
 
 When you define a Rule (which is declared within a RuleGroup in a PrometheusRule resource), the [spec of the Rule itself](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#rule) contains labels that are used by Alertmanager to figure out which Route should receive a certain Alert.
 
-To see the PrometheusRules, install `rancher-monitoring`. Then go to the **Cluster Explorer.** In the top left corner, click **Cluster Explorer > Monitoring.** Then click **Prometheus Rules.**
+To see the PrometheusRules, install `rancher-monitoring`. Then:
+
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to see the visualizations and click **Explore**.
+1. In the left navigation bar, click **Monitoring**.
+1. Click **Prometheus Rules**.
 
 You can also see the rules in the Prometheus UI:
 

--- a/content/rancher/v2.6/en/monitoring-alerting/expression/_index.md
+++ b/content/rancher/v2.6/en/monitoring-alerting/expression/_index.md
@@ -1,12 +1,6 @@
 ---
 title: PromQL Expression Reference
 weight: 6
-aliases:
-  - /rancher/v2.5/en/project-admin/tools/monitoring/expression
-  - /rancher/v2.5/en/cluster-admin/tools/monitoring/expression
-  - /rancher/v2.5/en/monitoring-alerting/legacy/monitoring/cluster-monitoring/expression
-  - /rancher/v2.5/en/monitoring-alerting/v2.5/configuration/expression
-  - /rancher/v2.5/en/monitoring/alerting/configuration/expression
 ---
 
 The PromQL expressions in this doc can be used to configure alerts.

--- a/content/rancher/v2.6/en/monitoring-alerting/guides/customize-grafana/_index.md
+++ b/content/rancher/v2.6/en/monitoring-alerting/guides/customize-grafana/_index.md
@@ -14,9 +14,9 @@ To see the links to the external monitoring UIs, including Grafana dashboards, y
 ### Signing in to Grafana
 
 1. In the Rancher UI, go to the cluster that has the dashboard you want to customize.
-1. In the left navigation menu, click **Monitoring.**
-1. Click **Grafana.** The Grafana dashboard should open in a new tab.
-1. Go to the log in icon in the lower left corner and click **Sign In.**
+1. In the left navigation menu, click **Monitoring**.
+1. Click **Grafana**. The Grafana dashboard should open in a new tab.
+1. Go to the log in icon in the lower left corner and click **Sign In**.
 1. Log in to Grafana. The default Admin username and password for the Grafana instance is `admin/prom-operator`. (Regardless of who has the password, cluster administrator permission in Rancher is still required access the Grafana instance.) Alternative credentials can also be supplied on deploying or upgrading the chart.
 
 
@@ -24,7 +24,7 @@ To see the links to the external monitoring UIs, including Grafana dashboards, y
 
 For any panel, you can click the title and click **Explore** to get the PromQL queries powering the graphic.
 
-For this example, we would like to get the CPU usage for the Alertmanager container, so we click **CPU Utilization > Inspect.**
+For this example, we would like to get the CPU usage for the Alertmanager container, so we click **CPU Utilization > Inspect**.
 1. The **Data** tab shows the underlying data as a time series, with the time in first column and the PromQL query result in the second column. Copy the PromQL query.
     
     ```

--- a/content/rancher/v2.6/en/monitoring-alerting/guides/enable-monitoring/_index.md
+++ b/content/rancher/v2.6/en/monitoring-alerting/guides/enable-monitoring/_index.md
@@ -25,16 +25,15 @@ For more information about the default limits, see [this page.](./configuration/
 
 # Install the Monitoring Application
 
-{{% tabs %}}
-{{% tab "Rancher v2.5.8" %}}
-
 ### Enable Monitoring for use without SSL
 
-1. In the Rancher UI, go to the cluster where you want to install monitoring and click **Cluster Explorer.**
-1. Click **Apps.**
-1. Click the `rancher-monitoring` app.
+1.  Click **☰ > Cluster Management**.
+1. Go to the cluster that you created and click **Explore**.
+1. Click **Apps & Marketplace**.
+1. Click **Charts**.
+1. Click the **Monitoring** app.
 1. Optional: Click **Chart Options** and configure alerting, Prometheus and Grafana. For help, refer to the [configuration reference.](./configuration)
-1. Scroll to the bottom of the Helm chart README and click **Install.**
+1. Scroll to the bottom of the Helm chart README and click **Install**.
 
 **Result:** The monitoring app is deployed in the `cattle-monitoring-system` namespace.
 
@@ -43,11 +42,14 @@ For more information about the default limits, see [this page.](./configuration/
 1. Follow the steps on [this page]({{<baseurl>}}/rancher/v2.5/en/k8s-in-rancher/secrets/) to create a secret in order for SSL to be used for alerts.
  - The secret should be created in the `cattle-monitoring-system` namespace. If it doesn't exist, create it first.
  - Add the `ca`, `cert`, and `key` files to the secret.
-1. In the Rancher UI, go to the cluster where you want to install monitoring and click **Cluster Explorer.**
-1. Click **Apps.**
-1. Click the `rancher-monitoring` app.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to enable monitoring for use with SSL and click **Explore**.
+1. Click **Apps & Marketplace > Charts**.
+1. Click **Monitoring**.
+1. Click **Install** or **Update**, depending on whether you have already installed Monitoring.
+1. Check the box for **Customize Helm options before install** and click **Next**.
 1. Click **Alerting**.
-1. Click **Additional Secrets** and add the secrets created earlier.
+1. In the **Additional Secrets** field, add the secrets created earlier.
  
 **Result:** The monitoring app is deployed in the `cattle-monitoring-system` namespace.
 
@@ -62,18 +64,3 @@ key.pfx=`base64-content`
 ```
 
 Then **Cert File Path** would be set to `/etc/alertmanager/secrets/cert.pem`.
-
-{{% /tab %}}
-{{% tab "Rancher v2.5.0-2.5.7" %}}
-
-1. In the Rancher UI, go to the cluster where you want to install monitoring and click **Cluster Explorer.**
-1. Click **Apps.**
-1. Click the `rancher-monitoring` app.
-1. Optional: Click **Chart Options** and configure alerting, Prometheus and Grafana. For help, refer to the [configuration reference.](./configuration)
-1. Scroll to the bottom of the Helm chart README and click **Install.**
-
-**Result:** The monitoring app is deployed in the `cattle-monitoring-system` namespace.
-
-{{% /tab %}}
-
-{{% /tabs %}}

--- a/content/rancher/v2.6/en/monitoring-alerting/guides/migrating/_index.md
+++ b/content/rancher/v2.6/en/monitoring-alerting/guides/migrating/_index.md
@@ -1,8 +1,6 @@
 ---
-title: Migrating to Rancher v2.5 Monitoring
+title: Migrating to Rancher v2.5+ Monitoring
 weight: 9
-aliases:
-  - /rancher/v2.5/en/monitoring-alerting/v2.5/migrating
 ---
 
 If you previously enabled Monitoring, Alerting, or Notifiers in Rancher before v2.5, there is no automatic upgrade path for switching to the new monitoring/alerting solution. Before deploying the new monitoring solution via Cluster Explore, you will need to disable and remove all existing custom alerts, notifiers and monitoring installations for the whole cluster and in all projects.
@@ -18,7 +16,7 @@ If you previously enabled Monitoring, Alerting, or Notifiers in Rancher before v
 
 # Monitoring Before Rancher v2.5
 
-As of v2.2.0, Rancher's Cluster Manager allowed users to enable Monitoring & Alerting V1 (both powered by [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator)) independently within a cluster. 
+As of v2.2.0, the global view in the legacy Rancher UI allowed users to enable Monitoring & Alerting V1 (both powered by [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator)) independently within a cluster. 
 
 When Monitoring is enabled, Monitoring V1 deploys [Prometheus](https://prometheus.io/) and [Grafana](https://grafana.com/docs/grafana/latest/getting-started/what-is-grafana/) onto a cluster to monitor the state of processes of your cluster nodes, Kubernetes components, and software deployments and create custom dashboards to make it easy to visualize collected metrics.
 

--- a/content/rancher/v2.6/en/monitoring-alerting/guides/persist-grafana/_index.md
+++ b/content/rancher/v2.6/en/monitoring-alerting/guides/persist-grafana/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Persistent Grafana Dashboards
 weight: 6
-aliases:
-  - /rancher/v2.5/en/monitoring-alerting/v2.5/persist-grafana
 ---
 
 To allow the Grafana dashboard to persist after the Grafana instance restarts, add the dashboard configuration JSON into a ConfigMap. ConfigMaps also allow the dashboards to be deployed with a GitOps or CD based approach. This allows the dashboard to be put under version control.
@@ -29,11 +27,11 @@ To use a premade dashboard, go to [https://grafana.com/grafana/dashboards](https
 
 To use your own dashboard:
 
-1. Click on the link to open Grafana. From the **Cluster Explorer,** click **Cluster Explorer > Monitoring.**
+1. Click on the link to open Grafana. On the cluster detail page, click **Monitoring**.
 1. Log in to Grafana. Note: The default Admin username and password for the Grafana instance is `admin/prom-operator`. Alternative credentials can also be supplied on deploying or upgrading the chart.
 
     > **Note:** Regardless of who has the password, in order to access the Grafana instance, you still need at least the <b>Manage Services</b> or <b>View Monitoring</b> permissions in the project that Rancher Monitoring is deployed into. Alternative credentials can also be supplied on deploying or upgrading the chart.
-1. Create a dashboard using Grafana's UI. Once complete, go to the dashboard's settings by clicking on the gear icon in the top navigation menu. In the left navigation menu, click **JSON Model.**
+1. Create a dashboard using Grafana's UI. Once complete, go to the dashboard's settings by clicking on the gear icon in the top navigation menu. In the left navigation menu, click **JSON Model**.
 1. Copy the JSON data structure that appears.
 
 ### 2. Create a ConfigMap using the Grafana JSON model
@@ -61,8 +59,9 @@ To specify that you would like Grafana to watch for ConfigMaps across all namesp
 
 To create the ConfigMap in the Rancher UI,
 
-1. Go to the Cluster Explorer.
-1. Click **Core > ConfigMaps**.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to see the visualizations and click **Explore**.
+1. Click **More Resources > Core > ConfigMaps**.
 1. Click **Create**.
 1. Set up the key-value pairs similar to the example above. When entering the value for `<dashboard-name>.json`, click **Read from File** to upload the JSON data model as the value.
 1. Click **Create**.
@@ -90,12 +89,15 @@ Note that the RBAC roles exposed by the Monitoring chart to add Grafana Dashboar
 > - The monitoring application needs to be installed.
 > - You must have the cluster-admin ClusterRole permission.
 
-1. Open the Grafana dashboard. From the **Cluster Explorer,** click **Cluster Explorer > Monitoring.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to configure the Grafana namespace and click **Explore**.
+1. In the left navigation bar, click **Monitoring**.
+1. Click **Grafana**.
 1. Log in to Grafana. Note: The default Admin username and password for the Grafana instance is `admin/prom-operator`. Alternative credentials can also be supplied on deploying or upgrading the chart.
 
     > **Note:** Regardless of who has the password, cluster administrator permission in Rancher is still required to access the Grafana instance.
 1. Go to the dashboard that you want to persist. In the top navigation menu, go to the dashboard settings by clicking the gear icon.
-1. In the left navigation menu, click **JSON Model.**
+1. In the left navigation menu, click **JSON Model**.
 1. Copy the JSON data structure that appears.
 1. Create a ConfigMap in the `cattle-dashboards` namespace. The ConfigMap needs to have the label `grafana_dashboard: "1"`. Paste the JSON into the ConfigMap in the format shown in the example below:
 

--- a/content/rancher/v2.6/en/monitoring-alerting/guides/uninstall/_index.md
+++ b/content/rancher/v2.6/en/monitoring-alerting/guides/uninstall/_index.md
@@ -3,11 +3,13 @@ title: Uninstall Monitoring
 weight: 2
 ---
 
-1. From the **Cluster Explorer,** click Apps & Marketplace.
-1. Click **Installed Apps.**
+1.  Click **☰ > Cluster Management**.
+1. Go to the cluster that you created and click **Explore**.
+1. In the left navigation bar, click **Apps & Marketplace**.
+1. Click **Installed Apps**.
 1. Go to the `cattle-monitoring-system` namespace and check the boxes for `rancher-monitoring-crd` and `rancher-monitoring`.
-1. Click **Delete.**
-1. Confirm **Delete.**
+1. Click **Delete**.
+1. Confirm **Delete**.
 
 **Result:** `rancher-monitoring` is uninstalled.
 

--- a/content/rancher/v2.6/en/monitoring-alerting/rbac/_index.md
+++ b/content/rancher/v2.6/en/monitoring-alerting/rbac/_index.md
@@ -2,10 +2,6 @@
 title: Role-based Access Control
 shortTitle: RBAC
 weight: 2
-aliases:
-  - /rancher/v2.5/en/cluster-admin/tools/monitoring/rbac
-  - /rancher/v2.5/en/monitoring-alerting/v2.5/rbac
-  - /rancher/v2.5/en/monitoring-alerting/grafana
 ---
 This section describes the expectations for RBAC for Rancher Monitoring.
 
@@ -16,7 +12,7 @@ This section describes the expectations for RBAC for Rancher Monitoring.
   - [Additional Monitoring Roles](#additional-monitoring-roles)
   - [Additional Monitoring ClusterRoles](#additional-monitoring-clusterroles)
 - [Additional Monitoring Roles](#additional-monitoring-roles)
-- [Users with Rancher Cluster Manager Based Permissions](#users-with-rancher-cluster-manager-based-permissions)
+- [Users with Rancher Based Permissions](#users-with-rancher-based-permissions)
   - [Differences in 2.5.x](#differences-in-2-5-x)
   - [Assigning Additional Access](#assigning-additional-access)
 - [Role-based Access Control for Grafana](#role-based-access-control-for-grafana)
@@ -90,13 +86,13 @@ Monitoring also creates additional `ClusterRoles` that are not assigned to users
 | ------------------------------| ---------------------------|
 | monitoring-ui-view | <a id="monitoring-ui-view"></a>_Available as of Monitoring v2 14.5.100+_ Provides read-only access to external Monitoring UIs by giving a user permission to list the Prometheus, Alertmanager, and Grafana endpoints and make GET requests to Prometheus, Grafana, and Alertmanager UIs through the Rancher proxy. |
 
-# Users with Rancher Cluster Manager Based Permissions
+# Users with Rancher Based Permissions
 
-The relationship between the default roles deployed by Rancher Cluster Manager (i.e. cluster-owner, cluster-member, project-owner, project-member), the default k8s roles, and the roles deployed by the rancher-monitoring chart are detailed in the table below:
+The relationship between the default roles deployed by Rancher (i.e. cluster-owner, cluster-member, project-owner, project-member), the default Kubernetes roles, and the roles deployed by the rancher-monitoring chart are detailed in the table below:
 
 <figcaption>Default Rancher Permissions and Corresponding Kubernetes ClusterRoles</figcaption>
 
-| Cluster Manager Role | k8s Role | Monitoring ClusterRole / Role | ClusterRoleBinding or RoleBinding? |
+| Rancher Role | Kubernetes Role | Monitoring ClusterRole / Role | ClusterRoleBinding or RoleBinding? |
 | --------- | --------- | --------- | --------- |
 | cluster-owner | cluster-admin | N/A | ClusterRoleBinding |
 | cluster-member | admin | monitoring-admin | ClusterRoleBinding |
@@ -107,11 +103,11 @@ In addition to these default Roles, the following additional Rancher project rol
 
 <figcaption>Non-default Rancher Permissions and Corresponding Kubernetes ClusterRoles</figcaption>
 
-| Cluster Manager Role  |  Kubernetes ClusterRole | Available In Rancher From | Available in Monitoring v2 From |
+| Rancher Role  |  Kubernetes ClusterRole | Available In Rancher From | Available in Monitoring v2 From |
 |--------------------------|-------------------------------|-------|------|
 | View Monitoring* | [monitoring-ui-view](#monitoring-ui-view)    |    2.4.8+    |  9.4.204+ |
 
-\* A User bound to the **View Monitoring** Rancher Role only has permissions to access external Monitoring UIs if provided links to those UIs. In order to access the Monitoring Pane on Cluster Explorer to get those links, the User must be a Project Member of at least one Project.
+\* A User bound to the **View Monitoring** Rancher Role only has permissions to access external Monitoring UIs if provided links to those UIs. In order to access the Monitoring Pane to get those links, the User must be a Project Member of at least one Project.
 
 ### Differences in 2.5.x
 
@@ -143,7 +139,12 @@ Rancher allows any users who are authenticated by Kubernetes and have access the
 
 However, users can choose to log in to Grafana as an [Admin](https://grafana.com/docs/grafana/latest/permissions/organization_roles/#admin-role) if necessary. The default Admin username and password for the Grafana instance will be `admin`/`prom-operator`, but alternative credentials can also be supplied on deploying or upgrading the chart.
 
-To see the Grafana UI, install `rancher-monitoring`. Then go to the **Cluster Explorer.** In the top left corner, click **Cluster Explorer > Monitoring.** Then click **Grafana.
+To see the Grafana UI, install `rancher-monitoring`. Then:
+
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to see the visualizations and click **Explore**.
+1. In the left navigation bar, click **Monitoring**.
+1. Click **Grafana**.
 
 <figcaption>Cluster Compute Resources Dashboard in Grafana</figcaption>
 ![Cluster Compute Resources Dashboard in Grafana]({{<baseurl>}}/img/rancher/cluster-compute-resources-dashboard.png)

--- a/content/rancher/v2.6/en/opa-gatekeper/_index.md
+++ b/content/rancher/v2.6/en/opa-gatekeper/_index.md
@@ -1,9 +1,6 @@
 ---
 title: OPA Gatekeeper
 weight: 16
-aliases:
- - /rancher/v2.6/en/cluster-admin/tools/opa-gatekeeper
- - /rancher/v2.6/en/opa-gatekeeper/Open%20Policy%20Agent
 ---
 
 To ensure consistency and compliance, every organization needs the ability to define and enforce policies in its environment in an automated way. [OPA (Open Policy Agent)](https://www.openpolicyagent.org/) is a policy engine that facilitates policy-based control for cloud native environments. Rancher provides the ability to enable OPA Gatekeeper in Kubernetes clusters, and also installs a couple of built-in policy definitions, which are also called constraint templates. 
@@ -31,25 +28,17 @@ OPA Gatekeeper is made available via Rancher's Helm system chart, and it is inst
 
 > **Prerequisite:** Only administrators and cluster owners can enable OPA Gatekeeper.
 
-OPA Gatekeeper can be installed from the new **Cluster Explorer** view in Rancher v2.5, or from the cluster manager view.
+The OPA Gatekeeper Helm chart can be installed from **Apps & Marketplace**.
 
-### Enabling OPA Gatekeeper from Cluster Explorer
+### Enabling OPA Gatekeeper
 
-1. Go to the cluster view in the Rancher UI. Click **Cluster Explorer.**
-1. Click **Apps** in the top navigation bar.
-1. Click **rancher-gatekeeper.**
-1. Click **Install.**
-
-**Result:** OPA Gatekeeper is deployed in your Kubernetes cluster.
-
-### Enabling OPA Gatekeeper from the Cluster Manager View
-
-1. Go to the cluster view in the Rancher UI.
-1. Click **Tools > OPA Gatekeeper.**
-1. Click **Install.**
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. In the **Clusters** page, go to the cluster where you want to enable OPA Gatekeeper and click **Explore**.
+1. In the left navigation bar, click **Apps & Marketplace**.
+1. Click **Charts** and click **OPA Gatekeeper**.
+1. Click **Install**.
 
 **Result:** OPA Gatekeeper is deployed in your Kubernetes cluster.
-
 
 # Constraint Templates
 
@@ -57,7 +46,7 @@ OPA Gatekeeper can be installed from the new **Cluster Explorer** view in Ranche
 
 When OPA Gatekeeper is enabled, Rancher installs some templates by default.
 
-To list the constraint templates installed in the cluster, go to the left side menu under OPA Gatekeeper and click on **Templates.**
+To list the constraint templates installed in the cluster, go to the left side menu under OPA Gatekeeper and click on **Templates**.
 
 Rancher also provides the ability to create your own constraint templates by importing YAML definitions.
    
@@ -67,7 +56,7 @@ Rancher also provides the ability to create your own constraint templates by imp
 
 > **Prerequisites:** OPA Gatekeeper must be enabled in the cluster.
 
-To list the constraints installed, go to the left side menu under OPA Gatekeeper, and click on **Constraints.**
+To list the constraints installed, go to the left side menu under OPA Gatekeeper, and click on **Constraints**.
 
 New constraints can be created from a constraint template.
 
@@ -85,11 +74,11 @@ Also, the constraint may interfere with other Rancher functionality and deny sys
    
 # Enforcing Constraints in your Cluster
 
-When the **Enforcement Action** is **Deny,** the constraint is immediately enabled and will deny any requests that violate the policy defined. By default, the enforcement value is **Deny.**
+When the **Enforcement Action** is **Deny,** the constraint is immediately enabled and will deny any requests that violate the policy defined. By default, the enforcement value is **Deny**.
 
 When the **Enforcement Action** is **Dryrun,** then any resources that violate the policy are only recorded under the constraint's status field.
 
-To enforce constraints, create a constraint using the form. In the **Enforcement Action** field, choose **Deny.** 
+To enforce constraints, create a constraint using the form. In the **Enforcement Action** field, choose **Deny**. 
 
 # Audit and Violations in your Cluster
 
@@ -104,8 +93,8 @@ The detail view of each constraint lists information about the resource that vio
 # Disabling Gatekeeper
 
 1. Navigate to the cluster's Dashboard view
-1. On the left side menu, expand the cluster menu and click on **OPA Gatekeeper.**
-1. Click the **&#8942; > Disable**.
+1. On the left side menu, expand the cluster menu and click on **OPA Gatekeeper**.
+1. Click the **⋮ > Disable**.
 
 **Result:** Upon disabling OPA Gatekeeper, all constraint templates and constraints will also be deleted.
 

--- a/content/rancher/v2.6/en/pipelines/_index.md
+++ b/content/rancher/v2.6/en/pipelines/_index.md
@@ -1,11 +1,9 @@
 ---
 title: Pipelines
 weight: 10
-aliases:
-  - /rancher/v2.6/en/k8s-in-rancher/pipelines  
 ---
 
-> As of Rancher v2.5, Git-based deployment pipelines are now recommended to be handled with Rancher Continuous Delivery powered by [Fleet,]({{<baseurl>}}/rancher/v2.6/en/deploy-across-clusters/fleet) available in Cluster Explorer.
+> As of Rancher v2.5, Git-based deployment pipelines are now deprecated. We recommend handling pipelines with Rancher Continuous Delivery powered by [Fleet.](https://fleet.rancher.io/) To get to Fleet in Rancher, click **☰ > Continuous Delivery**. Note that pipelines in Kubernetes 1.21+ are no longer supported.
 
 Rancher's pipeline provides a simple CI/CD experience. Use it to automatically checkout code, run builds or scripts, publish Docker images or catalog applications, and deploy the updated software to users.
 
@@ -75,7 +73,13 @@ Project members can only configure repositories and pipelines.
 
 # Setting up Pipelines
 
-To set up pipelines, you will need to do the following:
+### Prerequisite
+
+> **Prerequisite:** Because the pipelines app was deprecated in favor of Fleet, you will need to turn on the feature flag for legacy features before using pipelines. Note that pipelines in Kubernetes 1.21+ are no longer supported.
+>
+> 1. In the upper left corner, click **☰ > Global Settings**.
+> 1. Click **Feature Flags**.
+> 1. Go to the `legacy` feature flag and click **⋮ > Activate**.
 
 1. [Configure version control providers](#1-configure-version-control-providers)
 2. [Configure repositories](#2-configure-repositories)
@@ -93,31 +97,29 @@ Select your provider's tab below and follow the directions.
 
 {{% tabs %}}
 {{% tab "GitHub" %}}
-1. From the **Global** view, navigate to the project that you want to configure pipelines.
 
-1. Select **Tools > Pipelines** in the navigation bar.
-
-1. Follow the directions displayed to **Setup a Github application**. Rancher redirects you to Github to setup an OAuth App in Github.
-
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster where you want to configure pipelines and click **Explore**.
+1. In the dropdown menu in the top navigation bar, select the project where you want to configure pipelines.
+1. In the left navigation bar, click **Legacy > Project > Pipelines**.
+1. Click the **Configuration** tab.
+1. Follow the directions displayed to **Setup a Github application**. Rancher redirects you to Github to set up an OAuth App in Github.
 1. From GitHub, copy the **Client ID** and **Client Secret**. Paste them into Rancher.
-
 1. If you're using GitHub for enterprise, select **Use a private github enterprise installation**. Enter the host address of your GitHub installation.
-
 1. Click **Authenticate**.
 
 {{% /tab %}}
 {{% tab "GitLab" %}}
 
-1. From the **Global** view, navigate to the project that you want to configure pipelines.
-
-1. Select **Tools > Pipelines** in the navigation bar.
-
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster where you want to configure pipelines and click **Explore**.
+1. In the dropdown menu in the top navigation bar, select the project where you want to configure pipelines.
+1. In the left navigation bar, click **Legacy > Project > Pipelines**.
+1. Click the **Configuration** tab.
+1. Click **GitLab**.
 1. Follow the directions displayed to **Setup a GitLab application**. Rancher redirects you to GitLab.
-
 1. From GitLab, copy the **Application ID** and **Secret**. Paste them into Rancher.
-
 1. If you're using GitLab for enterprise setup, select **Use a private gitlab enterprise installation**. Enter the host address of your GitLab installation.
-
 1. Click **Authenticate**.
 
 >**Note:**
@@ -126,31 +128,27 @@ Select your provider's tab below and follow the directions.
 {{% /tab %}}
 {{% tab "Bitbucket Cloud" %}}
 
-1. From the **Global** view, navigate to the project that you want to configure pipelines.
-
-1. Select **Tools > Pipelines** in the navigation bar.
-
-1. Choose the **Use public Bitbucket Cloud** option.
-
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster where you want to configure pipelines and click **Explore**.
+1. In the dropdown menu in the top navigation bar, select the project where you want to configure pipelines.
+1. In the left navigation bar, click **Legacy > Project > Pipelines**.
+1. Click the **Configuration** tab.
+1. Click **Bitbucket** and leave **Use Bitbucket Cloud** selected by default.
 1. Follow the directions displayed to **Setup a Bitbucket Cloud application**. Rancher redirects you to Bitbucket to setup an OAuth consumer in Bitbucket.
-
 1. From Bitbucket, copy the consumer **Key** and **Secret**. Paste them into Rancher.
-
 1. Click **Authenticate**.
 
 {{% /tab %}}
 {{% tab "Bitbucket Server" %}}
 
-1. From the **Global** view, navigate to the project that you want to configure pipelines.
-
-1. Select **Tools > Pipelines** in the navigation bar.
-
-1. Choose the **Use private Bitbucket Server setup** option.
-
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster where you want to configure pipelines and click **Explore**.
+1. In the dropdown menu in the top navigation bar, select the project where you want to configure pipelines.
+1. In the left navigation bar, click **Legacy > Project > Pipelines**.
+1. Click the **Configuration** tab.
+1. Click **Bitbucket** and choose the **Use private Bitbucket Server setup** option.
 1. Follow the directions displayed to **Setup a Bitbucket Server application**.
-
 1. Enter the host address of your Bitbucket server installation.
-
 1. Click **Authenticate**.
 
 >**Note:**
@@ -168,10 +166,10 @@ Select your provider's tab below and follow the directions.
 
 After the version control provider is authorized, you are automatically re-directed to start configuring which repositories that you want start using pipelines with. Even if someone else has set up the version control provider, you will see their repositories and can build a pipeline.
 
-1. From the **Global** view, navigate to the project that you want to configure pipelines.
-
-1. Click **Resources > Pipelines.**
-
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster where you want to configure pipelines and click **Explore**.
+1. In the dropdown menu in the top navigation bar, select the project where you want to configure pipelines.
+1. In the left navigation bar, click **Legacy > Project > Pipelines**.
 1. Click on **Configure Repositories**.
 
 1. A list of repositories are displayed. If you are configuring repositories the first time, click on **Authorize & Fetch Your Own Repositories** to fetch your repository list.
@@ -186,16 +184,15 @@ After the version control provider is authorized, you are automatically re-direc
 
 Now that repositories are added to your project, you can start configuring the pipeline by adding automated stages and steps. For your convenience, there are multiple built-in step types for dedicated tasks.
 
-1. From the **Global** view, navigate to the project that you want to configure pipelines.
-
-1. Click **Resources > Pipelines.**
-
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster where you want to configure pipelines and click **Explore**.
+1. In the dropdown menu in the top navigation bar, select the project where you want to configure pipelines.
+1. In the left navigation bar, click **Legacy > Project > Pipelines**.
 1. Find the repository that you want to set up a pipeline for.
-
 1. Configure the pipeline through the UI or using a yaml file in the repository, i.e. `.rancher-pipeline.yml` or `.rancher-pipeline.yaml`. Pipeline configuration is split into stages and steps. Stages must fully complete before moving onto the next stage, but steps in a stage run concurrently. For each stage, you can add different step types. Note: As you build out each step, there are different advanced options based on the step type. Advanced options include trigger rules, environment variables, and secrets. For more information on configuring the pipeline through the UI or the YAML file, refer to the [pipeline configuration reference.]({{<baseurl>}}/rancher/v2.6/en/k8s-in-rancher/pipelines/config)
 
-   * If you are going to use the UI, select the vertical **&#8942; > Edit Config** to configure the pipeline using the UI. After the pipeline is configured, you must view the YAML file and push it to the repository.
-   * If you are going to use the YAML file, select the vertical **&#8942; > View/Edit YAML** to configure the pipeline. If you choose to use a YAML file, you need to push it to the repository after any changes in order for it to be updated in the repository. When editing the pipeline configuration, it takes a few moments for Rancher to check for an existing pipeline configuration.
+   * If you are going to use the UI, select the vertical **⋮ > Edit Config** to configure the pipeline using the UI. After the pipeline is configured, you must view the YAML file and push it to the repository.
+   * If you are going to use the YAML file, select the vertical **⋮ > View/Edit YAML** to configure the pipeline. If you choose to use a YAML file, you need to push it to the repository after any changes in order for it to be updated in the repository. When editing the pipeline configuration, it takes a few moments for Rancher to check for an existing pipeline configuration.
 
 1. Select which `branch` to use from the list of branches.
 
@@ -231,7 +228,7 @@ The configuration reference also covers how to configure:
 
 # Running your Pipelines
 
-Run your pipeline for the first time. From the project view in Rancher, go to **Resources > Pipelines.** Find your pipeline and select the vertical **&#8942; > Run**.
+Run your pipeline for the first time. Find your pipeline and select the vertical **⋮ > Run**.
 
 During this initial run, your pipeline is tested, and the following pipeline components are deployed to your project as workloads in a new namespace dedicated to the pipeline:
 
@@ -255,12 +252,10 @@ Available Events:
 
 ### Modifying the Event Triggers for the Repository
 
-1. From the **Global** view, navigate to the project that you want to modify the event trigger for the pipeline.
-
-1. 1. Click **Resources > Pipelines.**
-
-1. Find the repository that you want to modify the event triggers. Select the vertical **&#8942; > Setting**.
-
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster where you want to configure pipelines and click **Explore**.
+1. In the dropdown menu in the top navigation bar, select the project where you want to configure pipelines.
+1. In the left navigation bar, click **Legacy > Project > Pipelines**.
+1. Find the repository where you want to modify the event triggers. Select the vertical **⋮ > Setting**.
 1. Select which event triggers (**Push**, **Pull Request** or **Tag**) you want for the repository.
-
 1. Click **Save**.

--- a/content/rancher/v2.6/en/pipelines/concepts/_index.md
+++ b/content/rancher/v2.6/en/pipelines/concepts/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Concepts
 weight: 1
-aliases:
-  - /rancher/v2.6/en/k8s-in-rancher/pipelines/concepts
 ---
 
 The purpose of this page is to explain common concepts and terminology related to pipelines.

--- a/content/rancher/v2.6/en/pipelines/config/_index.md
+++ b/content/rancher/v2.6/en/pipelines/config/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Pipeline Configuration Reference
 weight: 1
-aliases:
-  - /rancher/v2.6/en/k8s-in-rancher/pipelines/config
 ---
 
 In this section, you'll learn how to configure pipelines.
@@ -382,34 +380,29 @@ This section covers the following topics:
 
 ### Configuring Pipeline Triggers
 
-1. From the **Global** view, navigate to the project that you want to configure a pipeline trigger rule.
-
-1. Click **Resources > Pipelines.**
-
-1. From the repository for which you want to manage trigger rules, select the vertical **&#8942; > Edit Config**.
-
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster where you want to configure pipelines and click **Explore**.
+1. In the dropdown menu in the top navigation bar, select the project where you want to configure pipelines.
+1. In the left navigation bar, click **Legacy > Project > Pipelines**.
+1. From the repository for which you want to manage trigger rules, select the vertical **⋮ > Edit Config**.
 1. Click on **Show Advanced Options**.
-
 1. In the **Trigger Rules** section, configure rules to run or skip the pipeline.
 
     1.  Click **Add Rule**. In the **Value** field, enter the name of the branch that triggers the pipeline.
 
     1. **Optional:** Add more branches that trigger a build.
 
-1. Click **Done.**
+1. Click **Done**.
 
 ### Configuring Stage Triggers
 
-1. From the **Global** view, navigate to the project that you want to configure a stage trigger rule.
-
-1. Click **Resources > Pipelines.**
-
-1. From the repository for which you want to manage trigger rules, select the vertical **&#8942; > Edit Config**.
-
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster where you want to configure pipelines and click **Explore**.
+1. In the dropdown menu in the top navigation bar, select the project where you want to configure pipelines.
+1. In the left navigation bar, click **Legacy > Project > Pipelines**.
+1. From the repository for which you want to manage trigger rules, select the vertical **⋮ > Edit Config**.
 1. Find the **stage** that you want to manage trigger rules, click the **Edit** icon for that stage.
-
 1. Click **Show advanced options**.
-
 1. In the **Trigger Rules** section, configure rules to run or skip the stage.
 
     1.  Click **Add Rule**.
@@ -425,16 +418,13 @@ This section covers the following topics:
 
 ### Configuring Step Triggers
 
-1. From the **Global** view, navigate to the project that you want to configure a stage trigger rule.
-
-1. Click **Resources > Pipelines.**
-
-1. From the repository for which you want to manage trigger rules, select the vertical **&#8942; > Edit Config**.
-
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster where you want to configure pipelines and click **Explore**.
+1. In the dropdown menu in the top navigation bar, select the project where you want to configure pipelines.
+1. In the left navigation bar, click **Legacy > Project > Pipelines**.
+1. From the repository for which you want to manage trigger rules, select the vertical **⋮ > Edit Config**.
 1. Find the **step** that you want to manage trigger rules, click the **Edit** icon for that step.
-
 1. Click **Show advanced options**.
-
 1. In the **Trigger Rules** section, configure rules to run or skip the step.
 
     1.  Click **Add Rule**.
@@ -480,20 +470,15 @@ When configuring a pipeline, certain [step types](#step-types) allow you to use 
 
 ### Configuring Environment Variables by UI
 
-1. From the **Global** view, navigate to the project that you want to configure pipelines.
-
-1. Click **Resources > Pipelines.**
-
-1. From the pipeline for which you want to edit build triggers, select **&#8942; > Edit Config**.
-
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster where you want to configure pipelines and click **Explore**.
+1. In the dropdown menu in the top navigation bar, select the project where you want to configure pipelines.
+1. In the left navigation bar, click **Legacy > Project > Pipelines**.
+1. From the pipeline for which you want to edit build triggers, select **⋮ > Edit Config**.
 1. Within one of the stages, find the **step** that you want to add an environment variable for, click the **Edit** icon.
-
 1. Click **Show advanced options**.
-
 1. Click **Add Variable**, and then enter a key and value in the fields that appear. Add more variables if needed.
-
 1. Add your environment variable(s) into either the script or file.
-
 1. Click **Save**.
 
 ### Configuring Environment Variables by YAML
@@ -523,18 +508,14 @@ Create a secret in the same project as your pipeline, or explicitly in the names
 
 ### Configuring Secrets by UI
 
-1. From the **Global** view, navigate to the project that you want to configure pipelines.
-
-1. Click **Resources > Pipelines.**
-
-1. From the pipeline for which you want to edit build triggers, select **&#8942; > Edit Config**.
-
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster where you want to configure pipelines and click **Explore**.
+1. In the dropdown menu in the top navigation bar, select the project where you want to configure pipelines.
+1. In the left navigation bar, click **Legacy > Project > Pipelines**.
+1. From the pipeline for which you want to edit build triggers, select **⋮ > Edit Config**.
 1. Within one of the stages, find the **step** that you want to use a secret for, click the **Edit** icon.
-
 1. Click **Show advanced options**.
-
 1. Click **Add From Secret**. Select the secret file that you want to use. Then choose a key. Optionally, you can enter an alias for the key.
-
 1. Click **Save**.
 
 ### Configuring Secrets by YAML
@@ -575,7 +556,22 @@ Variable Name           | Description
 
 # Global Pipeline Execution Settings
 
-After configuring a version control provider, there are several options that can be configured globally on how pipelines are executed in Rancher. These settings can be edited by selecting **Tools > Pipelines** in the navigation bar.
+After configuring a version control provider, there are several options that can be configured globally on how pipelines are executed in Rancher. 
+
+### Changing Pipeline Settings
+
+> **Prerequisite:** Because the pipelines app was deprecated in favor of Fleet, you will need to turn on the feature flag for legacy features before using pipelines. Note that pipelines in Kubernetes 1.21+ are no longer supported.
+>
+> 1. In the upper left corner, click **☰ > Global Settings**.
+> 1. Click **Feature Flags**.
+> 1. Go to the `legacy` feature flag and click **⋮ > Activate**.
+
+To edit these settings:
+
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster where you want to configure pipelines and click **Explore**.
+1. In the dropdown menu in the top navigation bar, select the project where you want to configure pipelines.
+1. In the left navigation bar, click **Legacy > Project > Pipelines**.
 
 - [Executor Quota](#executor-quota)
 - [Resource Quota for Executors](#resource-quota-for-executors)

--- a/content/rancher/v2.6/en/pipelines/example-repos/_index.md
+++ b/content/rancher/v2.6/en/pipelines/example-repos/_index.md
@@ -1,9 +1,6 @@
 ---
 title: Example Repositories
 weight: 500
-aliases:
-  - /rancher/v2.6/en/tools/pipelines/quick-start-guide/
-  - /rancher/v2.6/en/k8s-in-rancher/pipelines/example-repos  
 ---
 
 Rancher ships with several example repositories that you can use to familiarize yourself with pipelines. We recommend configuring and testing the example repository that most resembles your environment before using pipelines with your own repositories in a production environment. Use this example repository as a sandbox for repo configuration, build demonstration, etc. Rancher includes example repositories for:
@@ -12,7 +9,15 @@ Rancher ships with several example repositories that you can use to familiarize 
 - Maven
 - php
 
-> **Note:** The example repositories are only available if you have not [configured a version control provider]({{<baseurl>}}/rancher/v2.6/en/project-admin/pipelines).
+> **Prerequisites:**
+> 
+> - The example repositories are only available if you have not [configured a version control provider]({{<baseurl>}}/rancher/v2.6/en/project-admin/pipelines).
+> - Because the pipelines app was deprecated in favor of Fleet, you will need to turn on the feature flag for legacy features before using pipelines.
+> - Note that pipelines in Kubernetes 1.21+ are no longer supported.
+>
+>   1. In the upper left corner, click **☰ > Global Settings**.
+>   1. Click **Feature Flags**.
+>   1. Go to the `legacy` feature flag and click **⋮ > Activate**.
 
 To start using these example repositories,
 
@@ -24,13 +29,11 @@ To start using these example repositories,
 
 By default, the example pipeline repositories are disabled. Enable one (or more) to test out the pipeline feature and see how it works.
 
-1. From the **Global** view, navigate to the project that you want to test out pipelines.
-
-1. Click **Resources > Pipelines.**
-
-1. Click **Configure Repositories**.
-
-    **Step Result:** A list of example repositories displays.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster where you want to configure pipelines and click **Explore**.
+1. In the dropdown menu in the top navigation bar, select the project where you want to configure pipelines.
+1. In the left navigation bar, click **Legacy > Project > Pipelines**.
+1. In the **Pipelines** tab, click **Configure Repositories**.
 
     >**Note:** Example repositories only display if you haven't fetched your own repos.
 
@@ -50,23 +53,23 @@ By default, the example pipeline repositories are disabled. Enable one (or more)
 
 After enabling an example repository, review the pipeline to see how it is set up.
 
-1. From the **Global** view, navigate to the project that you want to test out pipelines.
-
-1. Click **Resources > Pipelines.**
-
-1. Find the example repository, select the vertical **&#8942;**. There are two ways to view the pipeline:
-  * **Rancher UI**: Click on **Edit Config** to view the stages and steps of the pipeline.
-  * **YAML**: Click on View/Edit YAML to view the `./rancher-pipeline.yml` file.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster where you want to configure pipelines and click **Explore**.
+1. In the dropdown menu in the top navigation bar, select the project where you want to configure pipelines.
+1. In the left navigation bar, click **Legacy > Project > Pipelines**.
+1. In the **Pipelines** tab, click **Configure Repositories**.
+1. Find the example repository, select **⋮ > Edit Config**. There are two ways to view the pipeline:
+  * **Rancher UI**: Click on **Edit Config** or **View/Edit YAML** to view the stages and steps of the pipeline. The YAML view shows the `./rancher-pipeline.yml` file.
 
 ### 3. Run the Example Pipeline
 
 After enabling an example repository, run the pipeline to see how it works.
 
-1. From the **Global** view, navigate to the project that you want to test out pipelines.
-
-1. Click **Resources > Pipelines.**
-
-1. Find the example repository, select the vertical **&#8942; > Run**.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. Go to the cluster where you want to configure pipelines and click **Explore**.
+1. In the dropdown menu in the top navigation bar, select the project where you want to configure pipelines.
+1. In the left navigation bar, click **Legacy > Project > Pipelines**.
+1. In the **Pipelines** tab, go to the pipeline and select the vertical **⋮ > Run**.
 
     >**Note:** When you run a pipeline the first time, it takes a few minutes to pull relevant images and provision necessary pipeline components.
 

--- a/content/rancher/v2.6/en/pipelines/example/_index.md
+++ b/content/rancher/v2.6/en/pipelines/example/_index.md
@@ -1,9 +1,6 @@
 ---
 title: Example YAML File
 weight: 501
-aliases:
-  - /rancher/v2.6/en/tools/pipelines/reference/
-  - /rancher/v2.6/en/k8s-in-rancher/pipelines/example
 ---
 
 Pipelines can be configured either through the UI or using a yaml file in the repository, i.e. `.rancher-pipeline.yml` or `.rancher-pipeline.yaml`.

--- a/content/rancher/v2.6/en/pipelines/storage/_index.md
+++ b/content/rancher/v2.6/en/pipelines/storage/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Configuring Persistent Data for Pipeline Components
 weight: 600
-aliases:
-  - /rancher/v2.6/en/k8s-in-rancher/pipelines/storage
 ---
 
 The pipelines' internal Docker registry and the Minio workloads use ephemeral volumes by default. This default storage works out-of-the-box and makes testing easy, but you lose the build images and build logs if the node running the Docker Registry or Minio fails. In most cases this is fine. If you want build images and logs to survive node failures, you can configure the Docker Registry and Minio to use persistent volumes.
@@ -15,9 +13,11 @@ This section assumes that you understand how persistent storage works in Kuberne
 
 ### A. Configuring Persistent Data for Docker Registry
 
-1. From the project that you're configuring a pipeline for, and click **Resources > Workloads.**
+1.  Click **☰ > Cluster Management**.
+1. Go to the cluster that you created and click **Explore**.
+1. Click **Workload**.
 
-1. Find the `docker-registry` workload and select **&#8942; > Edit**.
+1. Find the `docker-registry` workload and select **⋮ > Edit**.
 
 1. Scroll to the **Volumes** section and expand it. Make one of the following selections from the **Add Volume** menu, which is near the bottom of the section:
 
@@ -45,7 +45,7 @@ This section assumes that you understand how persistent storage works in Kuberne
 <br/>
 1. Enter a **Name** for the volume claim.
 
-1. Choose a **Persistent Volume Claim** from the drop-down.
+1. Choose a **Persistent Volume Claim** from the dropdown.
 
 1. From the **Customize** section, choose the read/write access for the volume.
 
@@ -61,7 +61,10 @@ This section assumes that you understand how persistent storage works in Kuberne
 
 ### B. Configuring Persistent Data for Minio
 
-1. From the project view, click **Resources > Workloads.** Find the `minio` workload and select **&#8942; > Edit**.
+1.  Click **☰ > Cluster Management**.
+1. Go to the cluster that you created and click **Explore**.
+1. Click **Workload**.
+1. Go to the `minio` workload and select **⋮ > Edit**.
 
 1. Scroll to the **Volumes** section and expand it. Make one of the following selections from the **Add Volume** menu, which is near the bottom of the section:
 

--- a/content/rancher/v2.6/en/project-admin/_index.md
+++ b/content/rancher/v2.6/en/project-admin/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Project Administration
 weight: 9
-aliases:
-  - /rancher/v2.6/en/project-admin/editing-projects/
 ---
 
 _Projects_ are objects introduced in Rancher that help organize namespaces in your Kubernetes cluster. You can use projects to create multi-tenant clusters, which allows a group of users to share the same underlying resources without interacting with each other's applications.
@@ -36,8 +34,6 @@ Whoever creates the project automatically becomes a [project owner]({{<baseurl>}
 
 To switch between projects, use the drop-down available in the navigation bar. Alternatively, you can switch between projects directly in the navigation bar.
 
-1. From the **Global** view, navigate to the project that you want to configure.
-
-1. Select **Projects/Namespaces** from the navigation bar.
-
-1. Select the link for the project that you want to open.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to switch projects and click **Explore**.
+1. In the top navigation bar, select the project that you want to open.

--- a/content/rancher/v2.6/en/project-admin/namespaces/_index.md
+++ b/content/rancher/v2.6/en/project-admin/namespaces/_index.md
@@ -29,11 +29,10 @@ Create a new namespace to isolate apps and resources in a project.
 
 >**Tip:** When working with project resources that you can assign to a namespace (i.e., [workloads]({{<baseurl>}}/rancher/v2.6/en/k8s-in-rancher/workloads/deploy-workloads/), [certificates]({{<baseurl>}}/rancher/v2.6/en/k8s-in-rancher/certificates/), [ConfigMaps]({{<baseurl>}}/rancher/v2.6/en/k8s-in-rancher/configmaps), etc.) you can create a namespace on the fly.
 
-1. From the **Global** view, open the project where you want to create a namespace.
-
-    >**Tip:** As a best practice, we recommend creating namespaces from the project level. However, cluster owners and members can create them from the cluster level as well.
-
-1. From the main menu, select **Namespace**. The click **Add Namespace**.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to create a namespace and click **Explore**.
+1. Click **Cluster > Projects/Namespaces**.
+1. Go to the project where you want to add a namespace and click **Create Namespace**. Alternately, go to **Not in a Project** to create a namespace not associated with a project.
 
 1. **Optional:** If your project has [Resource Quotas]({{<baseurl>}}/rancher/v2.6/en/k8s-in-rancher/projects-and-namespaces/resource-quotas) in effect, you can override the default resource **Limits** (which places a cap on the resources that the namespace can consume).  
 
@@ -45,9 +44,10 @@ Create a new namespace to isolate apps and resources in a project.
 
 Cluster admins and members may occasionally need to move a namespace to another project, such as when you want a different team to start using the application.
 
-1. From the **Global** view, open the cluster that contains the namespace you want to move.
-
-1. From the main menu, select **Projects/Namespaces**.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to move a namespace and click **Explore**.
+1. Click **Cluster > Projects/Namespaces**.
+1. Go to the namespace you want to move and click **⋮ > Move**.
 
 1. Select the namespace(s) that you want to move to a different project. Then click **Move**. You can move multiple namespaces at one.
 

--- a/content/rancher/v2.6/en/project-admin/pipelines/_index.md
+++ b/content/rancher/v2.6/en/project-admin/pipelines/_index.md
@@ -2,10 +2,6 @@
 title:  Rancher's CI/CD Pipelines
 description: Use Rancher’s CI/CD pipeline to automatically checkout code, run builds or scripts, publish Docker images, and deploy software to users
 weight: 4000
-aliases:
-  - /rancher/v2.6/en/concepts/ci-cd-pipelines/
-  - /rancher/v2.6/en/tasks/pipelines/
-  - /rancher/v2.6/en/tools/pipelines/configurations/
 ---
 Using Rancher, you can integrate with a GitHub repository to setup a continuous integration (CI) pipeline.
 

--- a/content/rancher/v2.6/en/project-admin/pod-security-policies/_index.md
+++ b/content/rancher/v2.6/en/project-admin/pod-security-policies/_index.md
@@ -14,9 +14,10 @@ You can always assign a pod security policy (PSP) to an existing project if you 
 
 ### Applying a Pod Security Policy
 
-1. From the **Global** view, find the cluster containing the project you want to apply a PSP to.
-1. From the main menu, select **Projects/Namespaces**.
-1. Find the project that you want to add a PSP to. From that project, select **&#8942; > Edit**.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to move a namespace and click **Explore**.
+1. Click **Cluster > Projects/Namespaces**.
+1. Find the project that you want to add a PSP to. From that project, select **⋮ > Edit Config**.
 1. From the **Pod Security Policy** drop-down, select the PSP you want to apply to the project.
   Assigning a PSP to a project will:
 

--- a/content/rancher/v2.6/en/project-admin/project-members/_index.md
+++ b/content/rancher/v2.6/en/project-admin/project-members/_index.md
@@ -1,9 +1,6 @@
 ---
 title: Adding Users to Projects
 weight: 2505
-aliases:
-  - /rancher/v2.6/en/tasks/projects/add-project-members/
-  - /rancher/v2.6/en/k8s-in-rancher/projects-and-namespaces/project-members/
 ---
 
 If you want to provide a user with access and permissions to _specific_ projects and resources within a cluster, assign the user a project membership.
@@ -20,11 +17,12 @@ You can add members to a project as you create it (recommended if possible). For
 
 Following project creation, you can add users as project members so that they can access its resources.
 
-1. From the **Global** view, open the project that you want to add members to.
-
-2. From the main menu, select **Members**. Then click **Add Member**.
-
-3. Search for the user or group that you want to add to the project.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to add members to a project and click **Explore**.
+1. Click **Cluster > Projects/Namespaces**.
+1. Go to the project where you want to add members and click **⋮ > Edit Config**.
+1. In the **Members** tab, click **Add**.
+1. Search for the user or group that you want to add to the project.
 
  	If external authentication is configured:
 

--- a/content/rancher/v2.6/en/project-admin/resource-quotas/_index.md
+++ b/content/rancher/v2.6/en/project-admin/resource-quotas/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Project Resource Quotas
 weight: 2515
-aliases:
-  - /rancher/v2.6/en/k8s-in-rancher/projects-and-namespaces/resource-quotas 
 ---
 
 In situations where several teams share a cluster, one team may overconsume the resources available: CPU, memory, storage, services, Kubernetes objects like pods or secrets, and so on.  To prevent this overconsumption, you can apply a _resource quota_, which is a Rancher feature that limits the resources available to a project or namespace.
@@ -20,13 +18,12 @@ Edit [resource quotas]({{<baseurl>}}/rancher/v2.6/en/k8s-in-rancher/projects-and
 - You want to limit the resources that a project and its namespaces can use.
 - You want to scale the resources available to a project up or down when a research quota is already in effect.
 
-1. From the **Global** view, open the cluster containing the project to which you want to apply a resource quota.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to apply a resource quota and click **Explore**.
+1. Click **Cluster > Projects/Namespaces**.
+1. Find the project that you want to add a resource quota to. From that project, select **⋮ > Edit Config**.
 
-1. From the main menu, select **Projects/Namespaces**.
-
-1. Find the project that you want to add a resource quota to. From that project, select **&#8942; > Edit**.
-
-1. Expand **Resource Quotas** and click **Add Quota**. Alternatively, you can edit existing quotas.
+1. Expand **Resource Quotas** and click **Add Resource**. Alternatively, you can edit existing quotas.
 
 1. Select a Resource Type. For more information on types, see the [quota type reference.](./quota-type-reference)
 

--- a/content/rancher/v2.6/en/project-admin/resource-quotas/override-container-default/_index.md
+++ b/content/rancher/v2.6/en/project-admin/resource-quotas/override-container-default/_index.md
@@ -14,9 +14,10 @@ Edit [container default resource limit]({{<baseurl>}}/rancher/v2.6/en/k8s-in-ran
 - You have a CPU or Memory resource quota set on a project, and want to supply the corresponding default values for a container.
 - You want to edit the default container resource limit.
 
-1. From the **Global** view, open the cluster containing the project to which you want to edit the container default resource limit.
-1. From the main menu, select **Projects/Namespaces**.
-1. Find the project that you want to edit the container default resource limit. From that project, select **&#8942; > Edit**.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to edit the default resource limit and click **Explore**.
+1. Click **Cluster > Projects/Namespaces**.
+1. Find the project that you want to edit the container default resource limit. From that project, select **⋮ > Edit Config**.
 1. Expand **Container Default Resource Limit** and edit the values.
 
 ### Resource Limit Propagation

--- a/content/rancher/v2.6/en/project-admin/resource-quotas/override-namespace-default/_index.md
+++ b/content/rancher/v2.6/en/project-admin/resource-quotas/override-namespace-default/_index.md
@@ -16,13 +16,11 @@ How to: [Editing Namespace Resource Quotas]({{<baseurl>}}/rancher/v2.6/en/k8s-in
 
 If there is a [resource quota]({{<baseurl>}}/rancher/v2.6/en/k8s-in-rancher/projects-and-namespaces/resource-quotas) configured for a project, you can override the namespace default limit to provide a specific namespace with access to more (or less) project resources.
 
-1. From the **Global** view, open the cluster that contains the namespace for which you want to edit the resource quota.
-
-1. From the main menu, select **Projects/Namespaces**.
-
-1. Find the namespace for which you want to edit the resource quota. Select **&#8942; > Edit**.
-
-1. Edit the Resource Quota **Limits**.  These limits determine the resources available to the namespace. The limits must be set within the configured project limits.
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, go to the cluster where you want to edit a namespace resource quota and click **Explore**.
+1. Click **Cluster > Projects/Namespaces**.
+1. Find the namespace for which you want to edit the resource quota. Click **⋮ > Edit Config**.
+1. Edit the resource limits.  These limits determine the resources available to the namespace. The limits must be set within the configured project limits.
 
     For more information about each **Resource Type**, see [Resource Quotas]({{<baseurl>}}/rancher/v2.6/en/k8s-in-rancher/projects-and-namespaces/resource-quotas/).
 

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/quickstart-manual-setup/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/quickstart-manual-setup/_index.md
@@ -74,9 +74,9 @@ Welcome to Rancher! You are now able to create your first Kubernetes cluster.
 
 In this task, you can use the versatile **Custom** option. This option lets you add _any_ Linux host (cloud-hosted VM, on-prem VM, or bare-metal) to be used in a cluster.
 
-1. From the **Clusters** page, click **Add Cluster**.
-
-2. Choose **Existing Nodes**.
+1.  Click **☰ > Cluster Management**.
+1. From the **Clusters** page, click **Create**.
+2. Choose **Custom**.
 
 3. Enter a **Cluster Name**.
 
@@ -98,9 +98,9 @@ In this task, you can use the versatile **Custom** option. This option lets you 
 
 **Result:** 
 
-Your cluster is created and assigned a state of **Provisioning.** Rancher is standing up your cluster.
+Your cluster is created and assigned a state of **Provisioning**. Rancher is standing up your cluster.
 
-You can access your cluster after its state is updated to **Active.**
+You can access your cluster after its state is updated to **Active**.
 
 **Active** clusters are assigned two Projects: 
 

--- a/content/rancher/v2.6/en/quick-start-guide/workload/quickstart-deploy-workload-ingress/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/workload/quickstart-deploy-workload-ingress/_index.md
@@ -13,25 +13,14 @@ You're ready to create your first Kubernetes [workload](https://kubernetes.io/do
 
 For this workload, you'll be deploying the application Rancher Hello-World.
 
-1.  From the **Clusters** page, open the cluster that you just created.
-
-2.  From the main menu of the **Dashboard**, select **Projects/Namespaces**.
-
-3.  Open the **Project: Default** project.
-
-4.  Click **Resources > Workloads.**
-
-5.  Click **Deploy**.
-
-	**Step Result:** The **Deploy Workload** page opens.
-
-6.  Enter a **Name** for your workload.
-
-7.  From the **Docker Image** field, enter `rancher/hello-world`. This field is case-sensitive.
-
-8. Leave the remaining options on their default setting. We'll tell you about them later.
-
-9. Click **Launch**.
+1.  Click **☰ > Cluster Management**.
+1. Go to the cluster that you created and click **Explore**.
+1. Click **Workload**.
+1. Click **Create**.
+1. Click **Deployment**.
+1. Enter a **Name** for your workload.
+1. From the **Docker Image** field, enter `rancher/hello-world`. This field is case-sensitive.
+1. Click **Create**.
 
 **Result:**
 
@@ -43,13 +32,14 @@ For this workload, you'll be deploying the application Rancher Hello-World.
 
 Now that the application is up and running it needs to be exposed so that other services can connect.
 
-1.  From the **Clusters** page, open the cluster that you just created.
+1.  Click **☰ > Cluster Management**.
+1. Go to the cluster that you created and click **Explore**.
 
 2.  From the main menu of the **Dashboard**, select **Projects**.
 
 3.  Open the **Default** project.
 
-4.  Click **Resources > Workloads > Load Balancing.** Click on the **Load Balancing** tab.
+4.  Click **Resources > Workloads > Load Balancing**. Click on the **Load Balancing** tab.
 
 5.  Click **Add Ingress**.
 

--- a/content/rancher/v2.6/en/quick-start-guide/workload/quickstart-deploy-workload-nodeport/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/workload/quickstart-deploy-workload-nodeport/_index.md
@@ -13,39 +13,22 @@ You're ready to create your first Kubernetes [workload](https://kubernetes.io/do
 
 For this workload, you'll be deploying the application Rancher Hello-World.
 
-1.  From the **Clusters** page, open the cluster that you just created.
-
-2.  From the main menu of the **Dashboard**, select **Projects/Namespaces**.
-
-3.  Open the **Project: Default** project.
-
-4.  Click **Resources > Workloads.**
-
-5.  Click **Deploy**.
-
-	**Step Result:** The **Deploy Workload** page opens.
-
-6.  Enter a **Name** for your workload.
-
-7.  From the **Docker Image** field, enter `rancher/hello-world`. This field is case-sensitive.
-
-8.  From **Port Mapping**, click **Add Port**.
-
-9.  From the **As a** drop-down, make sure that **NodePort (On every node)** is selected.
+1. Click **☰ > Cluster Management**.
+1.  From the **Clusters** page, go to the cluster where the workload should be deployed and click **Explore**.
+1. Click **Workload**.
+1. Click **Create**.
+1.  Enter a **Name** for your workload.
+1.  From the **Container Image** field, enter `rancher/hello-world`. This field is case-sensitive.
+1.  Click **Add Port**.
+1.  From the **Service Type** drop-down, make sure that **NodePort** is selected.
 
 	![As a dropdown, NodePort (On every node selected)]({{<baseurl>}}/img/rancher/nodeport-dropdown.png)
 
-10.  From the **On Listening Port** field, leave the **Random** value in place.
-
-	![On Listening Port, Random selected]({{<baseurl>}}/img/rancher/listening-port-field.png)
-
-11. From the **Publish the container port** field, enter port `80`.
+1. From the **Publish the container port** field, enter port `80`.
 
 	![Publish the container port, 80 entered]({{<baseurl>}}/img/rancher/container-port-field.png)
 
-12. Leave the remaining options on their default setting. We'll tell you about them later.
-
-13. Click **Launch**.
+1. Click **Create**.
 
 **Result:**
 

--- a/content/rancher/v2.6/en/user-settings/_index.md
+++ b/content/rancher/v2.6/en/user-settings/_index.md
@@ -1,8 +1,6 @@
 ---
 title: User Settings
 weight: 23
-aliases:
-  - /rancher/v2.6/en/tasks/user-settings/
 ---
 
 Within Rancher, each user has a number of settings associated with their login: personal preferences, API keys, etc. You can configure these settings by choosing from the **User Settings** menu. You can open this menu by clicking your avatar, located within the main menu.

--- a/content/rancher/v2.6/en/user-settings/api-keys/_index.md
+++ b/content/rancher/v2.6/en/user-settings/api-keys/_index.md
@@ -1,9 +1,6 @@
 ---
 title: API Keys
 weight: 7005
-aliases:
-  - /rancher/v2.6/en/concepts/api-keys/
-  - /rancher/v2.6/en/tasks/user-settings/api-keys/
 ---
 
 ## API Keys and User Authentication
@@ -23,9 +20,9 @@ API Keys are composed of four components:
 
 ## Creating an API Key
 
-1. Select **User Avatar** > **API & Keys** from the **User Settings** menu in the upper-right.
+1. Select **User Avatar > Account & API Keys** from upper right corner.
 
-2. Click **Add Key**.
+2. Click **Create API Key**.
 
 3. **Optional:** Enter a description for the API key and select an expiration period or a scope. We recommend setting an expiration date.
 

--- a/content/rancher/v2.6/en/user-settings/cloud-credentials/_index.md
+++ b/content/rancher/v2.6/en/user-settings/cloud-credentials/_index.md
@@ -18,10 +18,11 @@ All cloud credentials are bound to the user profile of who created it. They **ca
 
 ## Creating a Cloud Credential from User Settings
 
-1. From your user settings, select **User Avatar > Cloud Credentials**.
-1. Click **Add Cloud Credential**.
+1. Click **☰ > Cluster Management**.
+1. Click **Cloud Credentials**.
+1. Click **Create**.
+1. Click a cloud credential type. The values of this dropdown is based on the `active` [node drivers]({{<baseurl>}}/rancher/v2.6/en/admin-settings/drivers/node-drivers/) in Rancher.
 1. Enter a name for the cloud credential.
-1. Select a **Cloud Credential Type** from the drop down. The values of this dropdown is based on the `active` [node drivers]({{<baseurl>}}/rancher/v2.6/en/admin-settings/drivers/node-drivers/) in Rancher.
 1. Based on the selected cloud credential type, enter the required values to authenticate with the infrastructure provider.
 1. Click **Create**.
 
@@ -31,8 +32,9 @@ All cloud credentials are bound to the user profile of who created it. They **ca
 
 When access credentials are changed or compromised, updating a cloud credential allows you to rotate those credentials while keeping the same node template.  
 
-1. From your user settings, select **User Avatar > Cloud Credentials**.
-1. Choose the cloud credential you want to edit and click the **&#8942; > Edit**.
+1. Click **☰ > Cluster Management**.
+1. Click **Cloud Credentials**.
+1. Choose the cloud credential you want to edit and click the **⋮ > Edit Config**.
 1. Update the credential information and click **Save**.
 
 **Result:** The cloud credential is updated with the new access credentials. All existing node templates using this cloud credential will automatically use the updated information whenever [new nodes are added]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/).
@@ -41,9 +43,10 @@ When access credentials are changed or compromised, updating a cloud credential 
 
 In order to delete cloud credentials, there must not be any node template associated with it. If you are unable to delete the cloud credential, [delete any node templates]({{<baseurl>}}/rancher/v2.6/en/user-settings/node-templates/#deleting-a-node-template) that are still associated to that cloud credential.
 
-1. From your user settings, select **User Avatar > Cloud Credentials**.
+1. Click **☰ > Cluster Management**.
+1. Click **Cloud Credentials**.
 1. You can either individually delete a cloud credential or bulk delete.
 
-	- To individually delete one, choose the cloud credential you want to edit and click the **&#8942; > Delete**.
+	- To individually delete one, choose the cloud credential you want to edit and click the **⋮ > Delete**.
 	- To bulk delete cloud credentials, select one or more cloud credentials from the list. Click **Delete**.
 1. Confirm that you want to delete these cloud credentials.

--- a/content/rancher/v2.6/en/user-settings/node-templates/_index.md
+++ b/content/rancher/v2.6/en/user-settings/node-templates/_index.md
@@ -10,9 +10,10 @@ When you provision a cluster [hosted by an infrastructure provider]({{<baseurl>}
 
 When you create a node template, it is bound to your user profile. Node templates cannot be shared among users. You can delete stale node templates that you no longer user from your user settings.
 
-## Creating a Node Template from User Settings
+## Creating a Node Template
 
-1. From your user settings, select **User Avatar > Node Templates**.
+1. Click **☰ > Cluster Management**.
+1. Click **RKE1 Configuration > Node Templates**.
 1. Click **Add Template**.
 1. Select one of the cloud providers available. Then follow the instructions on screen to configure the template.
 
@@ -20,8 +21,9 @@ When you create a node template, it is bound to your user profile. Node template
 
 ## Updating a Node Template
 
-1. From your user settings, select **User Avatar > Node Templates**.
-1. Choose the node template that you want to edit and click the **&#8942; > Edit**.
+1. Click **☰ > Cluster Management**.
+1. Click **RKE1 Configuration > Node Templates**.
+1. Choose the node template that you want to edit and click the **⋮ > Edit**.
 
 	   > **Note:** The default `active` [node drivers]({{<baseurl>}}/rancher/v2.6/en/admin-settings/drivers/node-drivers/) and any node driver, that has fields marked as `password`, are required to use [cloud credentials]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/#cloud-credentials).
 
@@ -33,8 +35,9 @@ When you create a node template, it is bound to your user profile. Node template
 
 When creating new node templates from your user settings, you can clone an existing template and quickly update its settings rather than creating a new one from scratch. Cloning templates saves you the hassle of re-entering access keys for the cloud provider.
 
-1. From your user settings, select **User Avatar > Node Templates**.
-1. Find the template you want to clone. Then select **&#8942; > Clone**.
+1. Click **☰ > Cluster Management**.
+1. Click **RKE1 Configuration > Node Templates**.
+1. Find the template you want to clone. Then select **⋮ > Clone**.
 1. Complete the rest of the form.
 
 **Result:** The template is cloned and configured. You can use the template later when you [provision a node pool cluster]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools).
@@ -43,5 +46,6 @@ When creating new node templates from your user settings, you can clone an exist
 
 When you no longer use a node template, you can delete it from your user settings.
 
-1. From your user settings, select **User Avatar > Node Templates**.
+1. Click **☰ > Cluster Management**.
+1. Click **RKE1 Configuration > Node Templates**.
 1. Select one or more template from the list. Then click **Delete**. Confirm the delete when prompted.


### PR DESCRIPTION
https://github.com/rancher/docs/issues/3344

To make this PR, I did the following:

- Systematically checked all the step-by-step instructions for Rancher v2.5 and looked in the Rancher UI to find the equivalent steps. 
- Tested all the steps in the Rancher UI, except for the details of the deprecated pipeline docs and the items in the outstanding questions below.
- When I noticed discrepancies in field names, button text or Helm chart app names, I updated those as well.
- Removed references to Cluster Manager and Cluster Explorer from the docs.

In addition to navigation changes, I also documented functionality changes that I found out about as part of this process:

- There are several Kubernetes resources that used to be able to be created at both the namespace level and the project level, which can now only be created at the namespace level. For example, ingresses.
- Previously you could lock any role, whereas now only cluster-level and project/namespace roles can be locked and global roles can't.
- Previously you could clone any role, whereas now only cluster-level and project/namespace roles can inherit and global roles can't.
- Now you need to create a secret containing a certificate before creating an ingress, whereas previously you would configure the certificate at the same time as you create the ingress.
- Ingresses only target a Service now. We used to have workloads automatically create a service (whether you want it or not) and the "Target a Workload" option for an ingress's Target Backend gave you a choice of just those services that were created for a workload.
- The option "use as a default backend" is no longer available for ingress configuration.
- Previously, we documented that you enable Istio in a namespace by applying a label with kubectl. Now we do it through the UI.
- Previously, when provisioning vSphere clusters, you could select the out-of-tree cloud provider for vSphere. Now instead of checking that box, you click enable vSphere and then go into the Add-on config tab and configure CPI and CSI options.
- Storage is handled differently now, as users need to configure Volume Claim Templates from a StatefulSet. Previously you would select a PersistentVolumeClaim when configuring the StatefulSet, whereas now you select a PersistentVolume or StorageClass in the Volume Claim Template.
- The Maximum Worker Nodes Unavailable is now configured using Worker Concurrency.
- The UI no longer refers to aggressive and safe draining options. We now let you "delete pods using EmptyDir volumes" and "Delete standalone pods."
- Node pools are now called machine pools, although we still have node templates.
- Previously, when editing YAML for an RKE cluster in the Rancher UI, you would click **Edit as YAML** and edit the YAML nested under `rancher_kubernetes_engine_config`. Now you have to click **Edit Config**, then click **Edit as YAML** (because the two buttons that both say Edit as YAML yield different results for RKE clusters), then edit the options nested under `rancher_kubernetes_engine_config`.
- You used to be able to **Read from File** when configuring an RKE cluster YAML. Now you can't.

I found out that the feature to configure a pod security policy for a project is missing from the UI. Vincent said the feature will be added, so I didn't remove the docs about configuring PSP for a project.
