### PR TITLE
Document RKE2 cluster provisioning, node pools, Windows features

### DIFF
--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/_index.md
@@ -13,6 +13,28 @@ Rancher can install Kubernetes on existing nodes, or it can dynamically provisio
 
 RKE clusters include clusters that Rancher launched on Windows nodes or other existing custom nodes, as well as clusters that Rancher launched with new nodes on Azure, Digital Ocean, EC2, or vSphere.
 
+### Changes in Rancher v2.6
+
+_Tech Preview_
+
+Rancher v2.6 introduces provisioning for [RKE2](https://docs.rke2.io/) clusters directly from the Rancher UI. RKE2, also known as RKE Government, is a fully conformant Kubernetes distribution that focuses on security and compliance within the U.S. Federal Government sector.
+
+RKE2 provisioning is built on top of a new provisioning framework that leverages the upstream [Cluster API](https://github.com/kubernetes-sigs/cluster-api) project. With this new provisioning framework, you can:
+
+- Provision RKE2 clusters on Digital Ocean, AWS EC2, Azure, and vSphere
+- Fully configure RKE2 clusters within Rancher
+- Choose CNI options Calico, Cilium, and Multus in addition to Canal
+- Install custom RKE2 clusters on pre-provisioned VMs or bare metal nodes
+
+The RKE2 provisioning tech preview also includes installing RKE2 on Windows clusters. Windows features for RKE2 include:
+
+- Windows Containers with RKE2 powered by containerd
+- Added provisioning of Windows RKE2 custom clusters directly from the Rancher UI
+- Calico CNI for Windows RKE2 custom clusters. 
+- SAC releases of Windows Server (2004 and 20H2) are included in the technical preview.
+
+Windows Support for RKE2 Custom Clusters requires choosing Calico as the CNI.
+
 ### Requirements
 
 If you use RKE to set up a cluster, your nodes must meet the [requirements]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/node-requirements) for nodes in downstream user clusters.

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/_index.md
@@ -24,7 +24,7 @@ RKE2 provisioning is built on top of a new provisioning framework that leverages
 - Provision RKE2 clusters on Digital Ocean, AWS EC2, Azure, and vSphere
 - Fully configure RKE2 clusters within Rancher
 - Choose CNI options Calico, Cilium, and Multus in addition to Canal
-- Install custom RKE2 clusters on pre-provisioned VMs or bare metal nodes
+- Install custom RKE2 clusters on pre-provisioned VMs or bare-metal nodes
 
 The RKE2 provisioning tech preview also includes installing RKE2 on Windows clusters. Windows features for RKE2 include:
 

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/_index.md
@@ -11,6 +11,7 @@ The available cloud providers to create a node template are decided based on act
 
 This section covers the following topics:
 
+- [Changes in Rancher v2.6](#changes-in-rancher-v2-6)
 - [Node templates](#node-templates)
   - [Node labels](#node-labels)
   - [Node taints](#node-taints)
@@ -22,6 +23,18 @@ This section covers the following topics:
   - [Disabling node auto-replace](#disabling-node-auto-replace)
 - [Cloud credentials](#cloud-credentials)
 - [Node drivers](#node-drivers)
+- [Node roles in RKE2](#node-roles-in-rke2)
+
+# Changes in Rancher v2.6
+
+_Tech Preview_
+
+Rancher v2.6 introduces provisioning for [RKE2](https://docs.rke2.io/) clusters directly from the Rancher UI. RKE2, also known as RKE Government, is a fully conformant Kubernetes distribution that focuses on security and compliance within the U.S. Federal Government sector.
+
+When you create an RKE or RKE2 cluster using a node template in Rancher, each resulting node pool is shown in a new **Machine Pools** tab. You can see the machine pools by doing the following:
+
+1. Click  **☰ > Cluster Management**.
+1. Click the name of the RKE or RKE2 cluster.
 
 # Node Templates
 
@@ -122,3 +135,17 @@ After cloud credentials are created, the user can start [managing the cloud cred
 # Node Drivers
 
 If you don't find the node driver that you want to use, you can see if it is available in Rancher's built-in [node drivers and activate it]({{<baseurl>}}/rancher/v2.6/en/admin-settings/drivers/node-drivers/#activating-deactivating-node-drivers), or you can [add your own custom node driver]({{<baseurl>}}/rancher/v2.6/en/admin-settings/drivers/node-drivers/#adding-custom-node-drivers).
+
+# Node Roles in RKE2
+
+The RKE2 CLI has two roles, `server` and `agent`.  RKE2 CLI was designed not to expose node roles as a first-class concept. After RKE2 was fully integrated into Rancher v2.6, RKE2 node pools can use `etcd`, `controlplane` or `worker` roles within Rancher.
+
+The same functionality of using `etcd`, `controlplane` and `worker` nodes is possible in the RKE2 CLI by using flags and node tainting to control where workloads and the Kubernetes master were scheduled. The reason those roles were not implemented as first-class roles in the RKE CLI is that RKE2 is conceptualized as a set of raw building blocks that are best leveraged through an orchestration system such as Rancher.
+
+In our [recommended cluster architecture]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/production/recommended-architecture/), we outline how many nodes of each role clusters should have:
+
+- At least three nodes with the role etcd to survive losing one node
+- At least two nodes with the role controlplane for master component high availability
+- At least two nodes with the role worker for workload rescheduling upon node failure
+
+The implementation of the three node roles in Rancher means that Rancher managed RKE2 clusters are able to easily leverage all of the same architectural best practices that are recommended for RKE clusters.

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/_index.md
@@ -138,7 +138,7 @@ If you don't find the node driver that you want to use, you can see if it is ava
 
 # Node Roles in RKE2
 
-The RKE2 CLI has two roles, `server` and `agent`.  RKE2 CLI was designed not to expose node roles as a first-class concept. With RKE2 integration in Rancher v2.6, RKE2 node pools can use `etcd`, `controlplane` or `worker` roles within Rancher.
+The RKE2 CLI exposes two roles, `server` and `agent`, which represent the Kubernetes node-roles `etcd` + `control-plane` and `worker` respectively. With RKE2 integration in Rancher v2.6, RKE2 node pools can represent more fine-grained role assignments such that `etcd` and `control-plane` roles can be represented.
 
 The same functionality of using `etcd`, `controlplane` and `worker` nodes is possible in the RKE2 CLI by using flags and node tainting to control where workloads and the Kubernetes master were scheduled. The reason those roles were not implemented as first-class roles in the RKE2 CLI is that RKE2 is conceptualized as a set of raw building blocks that are best leveraged through an orchestration system such as Rancher.
 

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/_index.md
@@ -138,7 +138,7 @@ If you don't find the node driver that you want to use, you can see if it is ava
 
 # Node Roles in RKE2
 
-The RKE2 CLI has two roles, `server` and `agent`.  RKE2 CLI was designed not to expose node roles as a first-class concept. After RKE2 was fully integrated into Rancher v2.6, RKE2 node pools can use `etcd`, `controlplane` or `worker` roles within Rancher.
+The RKE2 CLI has two roles, `server` and `agent`.  RKE2 CLI was designed not to expose node roles as a first-class concept. With RKE2 integration in Rancher v2.6, RKE2 node pools can use `etcd`, `controlplane` or `worker` roles within Rancher.
 
 The same functionality of using `etcd`, `controlplane` and `worker` nodes is possible in the RKE2 CLI by using flags and node tainting to control where workloads and the Kubernetes master were scheduled. The reason those roles were not implemented as first-class roles in the RKE2 CLI is that RKE2 is conceptualized as a set of raw building blocks that are best leveraged through an orchestration system such as Rancher.
 

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/_index.md
@@ -140,7 +140,7 @@ If you don't find the node driver that you want to use, you can see if it is ava
 
 The RKE2 CLI has two roles, `server` and `agent`.  RKE2 CLI was designed not to expose node roles as a first-class concept. After RKE2 was fully integrated into Rancher v2.6, RKE2 node pools can use `etcd`, `controlplane` or `worker` roles within Rancher.
 
-The same functionality of using `etcd`, `controlplane` and `worker` nodes is possible in the RKE2 CLI by using flags and node tainting to control where workloads and the Kubernetes master were scheduled. The reason those roles were not implemented as first-class roles in the RKE CLI is that RKE2 is conceptualized as a set of raw building blocks that are best leveraged through an orchestration system such as Rancher.
+The same functionality of using `etcd`, `controlplane` and `worker` nodes is possible in the RKE2 CLI by using flags and node tainting to control where workloads and the Kubernetes master were scheduled. The reason those roles were not implemented as first-class roles in the RKE2 CLI is that RKE2 is conceptualized as a set of raw building blocks that are best leveraged through an orchestration system such as Rancher.
 
 In our [recommended cluster architecture]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/production/recommended-architecture/), we outline how many nodes of each role clusters should have:
 

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/windows-clusters/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/windows-clusters/_index.md
@@ -22,10 +22,26 @@ This guide covers the following topics:
 
 <!-- TOC -->
 
+- [Changes in Rancher v2.6](#changes-in-rancher-v2-6)
 - [Requirements](#requirements-for-windows-clusters)
 - [Tutorial: How to Create a Cluster with Windows Support](#tutorial-how-to-create-a-cluster-with-windows-support)
 - [Configuration for Storage Classes in Azure](#configuration-for-storage-classes-in-azure)
   <!-- /TOC -->
+
+  # Changes in Rancher v2.6
+
+_Tech Preview_
+
+Rancher v2.6 introduces provisioning for [RKE2](https://docs.rke2.io/) clusters directly from the Rancher UI. RKE2, also known as RKE Government, is a fully conformant Kubernetes distribution that focuses on security and compliance within the U.S. Federal Government sector.
+
+The RKE2 provisioning tech preview also includes installing RKE2 on Windows clusters. Windows features for RKE2 include:
+
+- Windows Containers with RKE2 powered by containerd
+- Added provisioning of Windows RKE2 custom clusters directly from the Rancher UI
+- Calico CNI for Windows RKE2 custom clusters
+- SAC releases of Windows Server (2004 and 20H2) are included in the technical preview
+
+Windows Support for RKE2 Custom Clusters requires choosing Calico as the CNI.
 
 # Requirements for Windows Clusters
 


### PR DESCRIPTION
Closes https://github.com/rancher/docs/issues/3369
and https://github.com/rancher/rke2/issues/1215

This PR uses Craig's comment as a source for explaining why node roles are different in RKE2 CLI vs Rancher UI. https://rancher.slack.com/archives/C01CS9VA86L/p1624974808272400?thread_ts=1624969792.272300&cid=C01CS9VA86L