### PR TITLE
Fix reset password command

### DIFF
--- a/content/rancher/v2.6/en/faq/technical/_index.md
+++ b/content/rancher/v2.6/en/faq/technical/_index.md
@@ -15,7 +15,7 @@ New password for default administrator (user-xxxxx):
 Kubernetes install (Helm):
 ```
 $ KUBECONFIG=./kube_config_rancher-cluster.yml
-$ kubectl --kubeconfig $KUBECONFIG -n cattle-system exec $(kubectl --kubeconfig $KUBECONFIG -n cattle-system get pods -l app=rancher | grep '1/1' | head -1 | awk '{ print $1 }') -- reset-password
+$ kubectl --kubeconfig $KUBECONFIG -n cattle-system exec $(kubectl --kubeconfig $KUBECONFIG -n cattle-system get pods -l app=rancher --no-headers | head -1 | awk '{ print $1 }') -c rancher -- reset-password
 New password for default administrator (user-xxxxx):
 <new_password>
 ```


### PR DESCRIPTION
Command in doc currently doesn't work if you have rancher audit logs enabled because "grep 1/1" will not grab any results:
```
$ kubectl --kubeconfig $KUBECONFIG -n cattle-system exec $(kubectl --kubeconfig $KUBECONFIG -n cattle-system get pods -l app=rancher | grep '1/1' | head -1 | awk '{ print $1 }') -- reset-password
error: pod, type/name or --filename must be specified
```
Example of what pod results look like when audit logs are enabled:
```
$ kubectl get pods -l app=rancher -n cattle-system
NAME                       READY   STATUS    RESTARTS   AGE
rancher-79c8ffd84b-cjxb4   2/2     Running   0          13m
rancher-79c8ffd84b-tcpc5   2/2     Running   0          10m
```
