### PR TITLE
Fix cert-manager installation docs

### DIFF
--- a/content/rancher/v2.5/en/installation/install-rancher-on-k8s/_index.md
+++ b/content/rancher/v2.5/en/installation/install-rancher-on-k8s/_index.md
@@ -135,8 +135,7 @@ helm repo update
 helm install cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.5.1 \
-  --set installCRDs=true
+  --version v1.5.1
 ```
 
 Once you’ve installed cert-manager, you can verify it is deployed correctly by checking the cert-manager namespace for running pods:

--- a/content/rancher/v2.6/en/installation/install-rancher-on-k8s/_index.md
+++ b/content/rancher/v2.6/en/installation/install-rancher-on-k8s/_index.md
@@ -127,8 +127,7 @@ helm repo update
 helm install cert-manager jetstack/cert-manager \
   --namespace cert-manager \
   --create-namespace \
-  --version v1.5.1 \
-  --set installCRDs=true
+  --version v1.5.1
 ```
 
 Once you’ve installed cert-manager, you can verify it is deployed correctly by checking the cert-manager namespace for running pods:

--- a/content/rancher/v2.6/en/installation/other-installation-methods/behind-proxy/install-rancher/_index.md
+++ b/content/rancher/v2.6/en/installation/other-installation-methods/behind-proxy/install-rancher/_index.md
@@ -24,14 +24,14 @@ kubectl create namespace cert-manager
 Install the CustomResourceDefinitions of cert-manager:
 
 ```
-kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.15.2/cert-manager.crds.yaml
+kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.1/cert-manager.crds.yaml
 ```
 
 And install it with Helm. Note that cert-manager also needs your proxy configured in case it needs to communicate with Let's Encrypt or other external certificate issuers:
 
 ```
 helm upgrade --install cert-manager jetstack/cert-manager \
-  --namespace cert-manager --version v0.15.2 \
+  --namespace cert-manager --version v1.5.1 \
   --set http_proxy=http://${proxy_host} \
   --set https_proxy=http://${proxy_host} \
   --set no_proxy=127.0.0.0/8\\,10.0.0.0/8\\,cattle-system.svc\\,172.16.0.0/12\\,192.168.0.0/16\\,.svc\\,.cluster.local


### PR DESCRIPTION
* Fix cert-manager installation docs: the installation fails with `installCRDs=true`, if you applied the crds before
* Change cert-manager version for proxy installation docs to match version in normal docs
