### PR TITLE
Port missing in mirrors example

### DIFF
--- a/content/k3s/latest/en/installation/private-registry/_index.md
+++ b/content/k3s/latest/en/installation/private-registry/_index.md
@@ -25,7 +25,7 @@ Mirrors is a directive that defines the names and endpoints of the private regis
 
 ```
 mirrors:
-  mycustomreg.com:
+  "mycustomreg.com:5000":
     endpoint:
       - "https://mycustomreg.com:5000"
 ```


### PR DESCRIPTION
Without port specify the private registry is unreachable.
I found solution here : https://github.com/k3s-io/k3s/issues/1713#issuecomment-742398187

### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
