### PR TITLE
Update links for tested K8s versions

### DIFF
--- a/content/rancher/v2.0-v2.4/en/cluster-admin/upgrading-kubernetes/_index.md
+++ b/content/rancher/v2.0-v2.4/en/cluster-admin/upgrading-kubernetes/_index.md
@@ -33,7 +33,7 @@ As of Rancher v2.4.0,
 
 # Tested Kubernetes Versions
 
-Before a new version of Rancher is released, it's tested with the latest minor versions of Kubernetes to ensure compatibility. For example, Rancher v2.3.0 is was tested with Kubernetes v1.15.4, v1.14.7, and v1.13.11. For details on which versions of Kubernetes were tested on each Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/all-supported-versions/rancher-v2.3.0/)
+Before a new version of Rancher is released, it's tested with the latest minor versions of Kubernetes to ensure compatibility. For details on which versions of Kubernetes were tested on each Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/all-supported-versions/rancher-v2.4.17/)
 
 # How Upgrades Work
 

--- a/content/rancher/v2.5/en/cluster-admin/upgrading-kubernetes/_index.md
+++ b/content/rancher/v2.5/en/cluster-admin/upgrading-kubernetes/_index.md
@@ -26,7 +26,7 @@ This section covers the following topics:
 
 # Tested Kubernetes Versions
 
-Before a new version of Rancher is released, it's tested with the latest minor versions of Kubernetes to ensure compatibility. For example, Rancher v2.3.0 is was tested with Kubernetes v1.15.4, v1.14.7, and v1.13.11. For details on which versions of Kubernetes were tested on each Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/all-supported-versions/rancher-v2.3.0/)
+Before a new version of Rancher is released, it's tested with the latest minor versions of Kubernetes to ensure compatibility. For details on which versions of Kubernetes were tested on each Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/all-supported-versions/rancher-v2.5.9/)
 
 # How Upgrades Work
 

--- a/content/rancher/v2.6/en/cluster-admin/upgrading-kubernetes/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/upgrading-kubernetes/_index.md
@@ -24,7 +24,7 @@ This section covers the following topics:
 
 # Tested Kubernetes Versions
 
-Before a new version of Rancher is released, it's tested with the latest minor versions of Kubernetes to ensure compatibility. For example, Rancher v2.3.0 is was tested with Kubernetes v1.15.4, v1.14.7, and v1.13.11. For details on which versions of Kubernetes were tested on each Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/all-supported-versions/rancher-v2.3.0/)
+Before a new version of Rancher is released, it's tested with the latest minor versions of Kubernetes to ensure compatibility. For details on which versions of Kubernetes were tested on each Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/all-supported-versions/rancher-v2.6.0/)
 
 # How Upgrades Work
 


### PR DESCRIPTION
Closes https://github.com/rancher/docs/issues/3516

Based on the reported issue, some users are expecting to use the listed example versions to verify whether a given version was used for testing. This PR removes the explicit listing of versions as the support matrix should be used for that purpose. Links to the support matrix have been updated as well.