### PR TITLE
Removed outdated verbiage on Kubernetes clusters

### DIFF
--- a/content/rancher/v2.5/en/installation/resources/k8s-tutorials/ha-RKE/_index.md
+++ b/content/rancher/v2.5/en/installation/resources/k8s-tutorials/ha-RKE/_index.md
@@ -12,8 +12,6 @@ This section describes how to install a Kubernetes cluster. This cluster should 
 
 > As of Rancher v2.5, Rancher can run on any Kubernetes cluster, included hosted Kubernetes solutions such as Amazon EKS. The below instructions represent only one possible way to install Kubernetes.
 
-The Rancher management server can only be run on Kubernetes cluster in an infrastructure provider where Kubernetes is installed using RKE or K3s. Use of Rancher on hosted Kubernetes providers, such as EKS, is not supported.
-
 For systems without direct internet access, refer to [Air Gap: Kubernetes install.]({{<baseurl>}}/rancher/v2.5/en/installation/air-gap-high-availability/)
 
 > **Single-node Installation Tip:**

--- a/content/rancher/v2.6/en/installation/resources/k8s-tutorials/ha-RKE/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/k8s-tutorials/ha-RKE/_index.md
@@ -9,8 +9,6 @@ This section describes how to install a Kubernetes cluster. This cluster should 
 
 > Rancher can run on any Kubernetes cluster, included hosted Kubernetes solutions such as Amazon EKS. The below instructions represent only one possible way to install Kubernetes.
 
-The Rancher management server can only be run on Kubernetes cluster in an infrastructure provider where Kubernetes is installed using RKE or K3s. Use of Rancher on hosted Kubernetes providers, such as EKS, is not supported.
-
 For systems without direct internet access, refer to [Air Gap: Kubernetes install.]({{<baseurl>}}/rancher/v2.6/en/installation/other-installation-methods/air-gap/)
 
 > **Single-node Installation Tip:**


### PR DESCRIPTION
Reference: 

https://rancher.com/docs/rancher/v2.5/en/installation/resources/k8s-tutorials/ha-rke/ https://rancher.com/docs/rancher/v2.6/en/installation/resources/k8s-tutorials/ha-rke/