### PR TITLE
Update advanced TLS settings page

### DIFF
--- a/content/rancher/v2.5/en/installation/install-rancher-on-k8s/chart-options/_index.md
+++ b/content/rancher/v2.5/en/installation/install-rancher-on-k8s/chart-options/_index.md
@@ -99,14 +99,9 @@ You can set extra environment variables for Rancher server using `extraEnv`. Thi
 
 ### TLS Settings
 
-To set a different TLS configuration, you can use the `CATTLE_TLS_MIN_VERSION` and `CATTLE_TLS_CIPHERS` environment variables. For example, to configure TLS 1.0 as minimum accepted TLS version:
+When you install Rancher inside of a Kubernetes cluster, TLS is offloaded at the cluster's ingress controller. The possible TLS settings depend on the used ingress controller.
 
-```plain
---set 'extraEnv[0].name=CATTLE_TLS_MIN_VERSION'
---set 'extraEnv[0].value=1.0'
-```
-
-See [TLS settings]({{<baseurl>}}/rancher/v2.5/en/admin-settings/tls-settings) for more information and options.
+See [TLS settings]({{<baseurl>}}/rancher/v2.5/en/installation/resources/tls-settings) for more information and options.
 
 ### Import `local` Cluster
 

--- a/content/rancher/v2.5/en/installation/resources/chart-options/_index.md
+++ b/content/rancher/v2.5/en/installation/resources/chart-options/_index.md
@@ -1,8 +1,0 @@
----
-title: Rancher Helm Chart Options
-weight: 50
-aliases:
-  - /rancher/v2.x/en/installation/resources/chart-options/
----
-
-The Rancher Helm chart options reference moved to [this page.]({{<baseurl>}}/rancher/v2.5/en/installation/install-rancher-on-k8s/chart-options/)

--- a/content/rancher/v2.5/en/installation/resources/tls-settings/_index.md
+++ b/content/rancher/v2.5/en/installation/resources/tls-settings/_index.md
@@ -8,30 +8,20 @@ aliases:
   - /rancher/v2.x/en/installation/resources/tls-settings/
 ---
 
-The default TLS configuration only accepts TLS 1.2 and secure TLS cipher suites. TLS 1.3 and TLS 1.3 exclusive cipher suites are not supported.
+Changing the default TLS settings depends on the chosen installation method.
 
-# Configuring TLS settings
+# Running Rancher in a highly available Kubernetes cluster
 
-The Audit Log is enabled and configured by passing environment variables to the Rancher server container. See the following to enable on your installation.
+When you install Rancher inside of a Kubernetes cluster, TLS is offloaded at the cluster's ingress controller. The possible TLS settings depend on the used ingress controller:
 
-- [TLS settings in Docker options]({{<baseurl>}}/rancher/v2.5/en/installation/other-installation-methods/single-node-docker/advanced/#tls-settings)
+* nginx-ingress-controller (default for RKE1 and RKE2): [Default TLS Version and Ciphers](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#default-tls-version-and-ciphers).
+* traefik (default for K3s): [TLS Options](https://doc.traefik.io/traefik/https/tls/#tls-options).
 
-- [TLS settings in Helm chart options]({{<baseurl>}}/rancher/v2.5/en/installation/install-rancher-on-k8s/chart-options/#tls-settings)
+# Running Rancher in a single Docker container
 
-# TLS Environment Variables
+The default TLS configuration only accepts TLS 1.2 and secure TLS cipher suites. You can change this by setting the following environment variables:
 
 | Parameter | Description | Default | Available options |
 |-----|-----|-----|-----|
-| `CATTLE_TLS_MIN_VERSION` | Minimum TLS version | `1.2` | `1.0`, `1.1`, `1.2` |
-| `CATTLE_TLS_CIPHERS` | Allowed TLS cipher suites | `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,`<br/>`TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,`<br/>`TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,`<br/>`TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,`<br/>`TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,`<br/>`TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305` | See [Golang tls constants](https://golang.org/pkg/crypto/tls/#pkg-constants) |
-
-
-# Legacy configuration
-
-If you need to configure TLS the same way as it was before Rancher v2.1.7, please use the following settings:
-
-
-| Parameter | Legacy value |
-|-----|-----|
-| `CATTLE_TLS_MIN_VERSION` | `1.0` |
-| `CATTLE_TLS_CIPHERS` | `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,`<br/>`TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,`<br/>`TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,`<br/>`TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,`<br/>`TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,`<br/>`TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,`<br/>`TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,`<br/>`TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,`<br/>`TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,`<br/>`TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,`<br/>`TLS_RSA_WITH_AES_128_GCM_SHA256,`<br/>`TLS_RSA_WITH_AES_256_GCM_SHA384,`<br/>`TLS_RSA_WITH_AES_128_CBC_SHA,`<br/>`TLS_RSA_WITH_AES_256_CBC_SHA,`<br/>`TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,`<br/>`TLS_RSA_WITH_3DES_EDE_CBC_SHA`
+| `CATTLE_TLS_MIN_VERSION` | Minimum TLS version | `1.2` | `1.0`, `1.1`, `1.2`, `1.3` |
+| `CATTLE_TLS_CIPHERS` | Allowed TLS cipher suites | `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`,<br/>`TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`,<br/>`TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305`,<br/>`TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`,<br/>`TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`,<br/>`TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305` | See [Golang tls constants](https://golang.org/pkg/crypto/tls/#pkg-constants) |

--- a/content/rancher/v2.6/en/installation/install-rancher-on-k8s/chart-options/_index.md
+++ b/content/rancher/v2.6/en/installation/install-rancher-on-k8s/chart-options/_index.md
@@ -1,6 +1,8 @@
 ---
 title: Rancher Helm Chart Options
 weight: 1
+aliases:
+  - /rancher/v2.6/en/installation/resources/chart-options
 ---
 
 This page is a configuration reference for the Rancher Helm chart.
@@ -110,12 +112,7 @@ You can set extra environment variables for Rancher server using `extraEnv`. Thi
 
 ### TLS Settings
 
-To set a different TLS configuration, you can use the `CATTLE_TLS_MIN_VERSION` and `CATTLE_TLS_CIPHERS` environment variables. For example, to configure TLS 1.0 as minimum accepted TLS version:
-
-```plain
---set 'extraEnv[0].name=CATTLE_TLS_MIN_VERSION'
---set 'extraEnv[0].value=1.0'
-```
+When you install Rancher inside of a Kubernetes cluster, TLS is offloaded at the cluster's ingress controller. The possible TLS settings depend on the used ingress controller.
 
 See [TLS settings]({{<baseurl>}}/rancher/v2.6/en/installation/resources/tls-settings) for more information and options.
 

--- a/content/rancher/v2.6/en/installation/resources/chart-options/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/chart-options/_index.md
@@ -1,6 +1,0 @@
----
-title: Rancher Helm Chart Options
-weight: 50
----
-
-The Rancher Helm chart options reference moved to [this page.]({{<baseurl>}}/rancher/v2.6/en/installation/install-rancher-on-k8s/chart-options/)

--- a/content/rancher/v2.6/en/installation/resources/tls-settings/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/tls-settings/_index.md
@@ -3,30 +3,20 @@ title: TLS Settings
 weight: 3
 ---
 
-The default TLS configuration only accepts TLS 1.2 and secure TLS cipher suites. TLS 1.3 and TLS 1.3 exclusive cipher suites are not supported.
+Changing the default TLS settings depends on the chosen installation method.
 
-# Configuring TLS settings
+# Running Rancher in a highly available Kubernetes cluster
 
-The Audit Log is enabled and configured by passing environment variables to the Rancher server container. See the following to enable on your installation.
+When you install Rancher inside of a Kubernetes cluster, TLS is offloaded at the cluster's ingress controller. The possible TLS settings depend on the used ingress controller:
 
-- [TLS settings in Docker options]({{<baseurl>}}/rancher/v2.6/en/installation/other-installation-methods/single-node-docker/advanced/#tls-settings)
+* nginx-ingress-controller (default for RKE1 and RKE2): [Default TLS Version and Ciphers](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#default-tls-version-and-ciphers).
+* traefik (default for K3s): [TLS Options](https://doc.traefik.io/traefik/https/tls/#tls-options).
 
-- [TLS settings in Helm chart options]({{<baseurl>}}/rancher/v2.6/en/installation/install-rancher-on-k8s/chart-options/#tls-settings)
+# Running Rancher in a single Docker container
 
-# TLS Environment Variables
+The default TLS configuration only accepts TLS 1.2 and secure TLS cipher suites. You can change this by setting the following environment variables:
 
 | Parameter | Description | Default | Available options |
 |-----|-----|-----|-----|
-| `CATTLE_TLS_MIN_VERSION` | Minimum TLS version | `1.2` | `1.0`, `1.1`, `1.2` |
-| `CATTLE_TLS_CIPHERS` | Allowed TLS cipher suites | `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,`<br/>`TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,`<br/>`TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,`<br/>`TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,`<br/>`TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,`<br/>`TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305` | See [Golang tls constants](https://golang.org/pkg/crypto/tls/#pkg-constants) |
-
-
-# Legacy configuration
-
-If you need to configure TLS the same way as it was before Rancher v2.1.7, please use the following settings:
-
-
-| Parameter | Legacy value |
-|-----|-----|
-| `CATTLE_TLS_MIN_VERSION` | `1.0` |
-| `CATTLE_TLS_CIPHERS` | `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,`<br/>`TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,`<br/>`TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,`<br/>`TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,`<br/>`TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,`<br/>`TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,`<br/>`TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,`<br/>`TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,`<br/>`TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,`<br/>`TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,`<br/>`TLS_RSA_WITH_AES_128_GCM_SHA256,`<br/>`TLS_RSA_WITH_AES_256_GCM_SHA384,`<br/>`TLS_RSA_WITH_AES_128_CBC_SHA,`<br/>`TLS_RSA_WITH_AES_256_CBC_SHA,`<br/>`TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,`<br/>`TLS_RSA_WITH_3DES_EDE_CBC_SHA`
+| `CATTLE_TLS_MIN_VERSION` | Minimum TLS version | `1.2` | `1.0`, `1.1`, `1.2`, `1.3` |
+| `CATTLE_TLS_CIPHERS` | Allowed TLS cipher suites | `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`,<br/>`TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384`,<br/>`TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305`,<br/>`TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`,<br/>`TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384`,<br/>`TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305` | See [Golang tls constants](https://golang.org/pkg/crypto/tls/#pkg-constants) |


### PR DESCRIPTION
This adds a detailed description on how to configure tls version and ciphers when Rancher is installed in a Kubernetes cluster. TLS is offloaded at the ingress controller, which means these settings need to be set there instead of the Rancher Pod/Container.

For running Rancher as a single Docker container, the default values have been updated to the ones currently supported.