### PR TITLE
Harvester feature flag is off by default now

### DIFF
--- a/content/rancher/v2.6/en/installation/resources/feature-flags/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/feature-flags/_index.md
@@ -48,7 +48,7 @@ The below table shows the availability and default value for feature flags in Ra
 | `token-hashing` | `false` for new installs, `true` for upgrades | GA* | v2.6.0 | |
 | `legacy` | `false` for new installs, `true` for upgrades | GA* | v2.6.0 | |
 | `multi-cluster-management` | `false` | GA* | v2.5.0 | |
-| `harvester` | `true` | Experimental | v2.6.1 | |
+| `harvester` | `false` | Experimental | v2.6.1 | |
 | `rke2` | `true` | Experimental | v2.6.0 | |
 
 \* Generally Available. This feature is included in Rancher and it is not experimental.

--- a/content/rancher/v2.6/en/virtualization-admin/_index.md
+++ b/content/rancher/v2.6/en/virtualization-admin/_index.md
@@ -9,7 +9,7 @@ New in Rancher v2.6.1, [Harvester v0.3.0](https://docs.harvesterhci.io/v0.3/) is
 
 ### Feature Flag
 
-The Harvester feature flag is used to manage access to the Virtualization Management (VM) page in Rancher where users can navigate directly to Harvester clusters and access the Harvester UI. The Harvester feature flag is enabled by default. Click [here]({{<baseurl>}}/rancher/v2.6/en/installation/resources/feature-flags/) for more information on feature flags in Rancher.
+The Harvester feature flag is used to manage access to the Virtualization Management (VM) page in Rancher where users can navigate directly to Harvester clusters and access the Harvester UI. The Harvester feature flag is disabled by default. Click [here]({{<baseurl>}}/rancher/v2.6/en/installation/resources/feature-flags/) for more information on feature flags in Rancher.
 
 To navigate to the Harvester cluster, click **☰ > Virtualization Management**. From Harvester Clusters page, click one of the clusters listed to go to the single Harvester cluster view. 
 


### PR DESCRIPTION
### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
