### PR TITLE
New service creation behaviour (needs Port configuration)

### DIFF
--- a/content/rancher/v2.6/en/k8s-in-rancher/service-discovery/_index.md
+++ b/content/rancher/v2.6/en/k8s-in-rancher/service-discovery/_index.md
@@ -5,7 +5,7 @@ weight: 3045
 
 Pod configuration is managed by Deployments, StatefulSets and Daemonsets, whereas services direct traffic to pods using selectors.
 
-For every workload created, a complementing Service Discovery entry is created. This Service Discovery entry enables DNS resolution for the workload's pods using the following naming convention:
+For every workload (with at least one port configured) created, a complementing Service Discovery entry is created. This Service Discovery entry enables DNS resolution for the workload's pods using the following naming convention:
 `<workload>.<namespace>.svc.cluster.local`.
 
 You can create additional services so that a given namespace resolves with one or more external IP addresses, an external hostname, an alias to another DNS record, other workloads, or a set of pods that match a selector that you create.


### PR DESCRIPTION
Update documentation according to the new "Explorer" UI behaviour.
Creating a new workload alone is not enough that a Kubernetes service is created in the background.
The new workload needs to have at least one port configured.
See also https://github.com/rancher/rancher/issues/34653

### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
