### PR TITLE
Update _index.md

### DIFF
--- a/content/rancher/v2.6/en/installation/requirements/ports/_index.md
+++ b/content/rancher/v2.6/en/installation/requirements/ports/_index.md
@@ -35,6 +35,7 @@ Rancher can be installed on any Kubernetes cluster. For Rancher installs on a K3
 > - Rancher nodes may also require additional outbound access for any external authentication provider which is configured (LDAP for example).
 > - Kubernetes recommends TCP 30000-32767 for node port services.
 > - For firewalls, traffic may need to be enabled within the cluster and pod CIDR.
+> - Rancher nodes may also need outbound access to an external S3 location which is used for storing cluster backups (Minio for example).
 
 ### Ports for Rancher Server Nodes on K3s
 


### PR DESCRIPTION
In the case when the cluster admin spins up new cluster and configure an external S3 location for storing the backups.

### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
