### PR TITLE
Remove superfluous proxy section

### DIFF
--- a/content/rancher/v2.5/en/deploy-across-clusters/fleet/_index.md
+++ b/content/rancher/v2.5/en/deploy-across-clusters/fleet/_index.md
@@ -46,8 +46,3 @@ For details on using Fleet behind a proxy, see [this page.](./proxy)
 # Documentation
 
 The Fleet documentation is at [https://fleet.rancher.io/.](https://fleet.rancher.io/)
-
-
-### Using Fleet Behind a Proxy
-
-For details on using Fleet with a proxy, see [this page.](./proxy)


### PR DESCRIPTION
It's just the same info twice. Seems as if it's already removed from the v2.6 docs. 

### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
