### PR TITLE
Revert "support matrix url"

### DIFF
--- a/content/k3s/latest/en/installation/installation-requirements/_index.md
+++ b/content/k3s/latest/en/installation/installation-requirements/_index.md
@@ -25,7 +25,7 @@ Some OSs have specific requirements:
 - If you are using **Alpine Linux**, follow [these steps]({{<baseurl>}}/k3s/latest/en/advanced/#additional-preparation-for-alpine-linux-setup) for additional setup.
 - If you are using **(Red Hat/CentOS) Enterprise Linux**, follow [these steps]({{<baseurl>}}/k3s/latest/en/advanced/#additional-preparation-for-red-hat-centos-enterprise-linux) for additional setup.
 
-For more information on which OSs were tested with Rancher managed K3s clusters, refer to the [Rancher support and maintenance terms.](https://rancher.com/support-matrix/)
+For more information on which OSs were tested with Rancher managed K3s clusters, refer to the [Rancher support and maintenance terms.](https://rancher.com/support-maintenance-terms/)
 
 ## Hardware
 

--- a/content/rancher/v2.0-v2.4/en/admin-settings/k8s-metadata/_index.md
+++ b/content/rancher/v2.0-v2.4/en/admin-settings/k8s-metadata/_index.md
@@ -77,7 +77,7 @@ However, if you have an [air gap setup,](#air-gap-setups) you will need to mirro
 
 ### Air Gap Setups
 
-Rancher relies on a periodic refresh of the `rke-metadata-config` to download new Kubernetes version metadata if it is supported with the current version of the Rancher server. For a table of compatible Kubernetes and Rancher versions, refer to the [service terms section.](https://rancher.com/support-matrix/all-supported-versions/rancher-v2.2.8/)
+Rancher relies on a periodic refresh of the `rke-metadata-config` to download new Kubernetes version metadata if it is supported with the current version of the Rancher server. For a table of compatible Kubernetes and Rancher versions, refer to the [service terms section.](https://rancher.com/support-maintenance-terms/all-supported-versions/rancher-v2.2.8/)
 
 If you have an air gap setup, you might not be able to get the automatic periodic refresh of the Kubernetes metadata from Rancher's Git repository. In that case, you should disable the periodic refresh to prevent your logs from showing errors. Optionally, you can configure your metadata settings so that Rancher can sync with a local copy of the RKE metadata.
 

--- a/content/rancher/v2.0-v2.4/en/best-practices/management/_index.md
+++ b/content/rancher/v2.0-v2.4/en/best-practices/management/_index.md
@@ -62,7 +62,7 @@ Make sure the feature version you are upgrading to is considered "stable" as det
 
 Keep in mind that Rancher does End of Life support for old versions, so you will eventually want to upgrade if you want to continue to receive patches.
 
-For more detail on what happens during the Rancher product lifecycle, refer to the [Support Maintenance Terms](https://rancher.com/support-matrix/).
+For more detail on what happens during the Rancher product lifecycle, refer to the [Support Maintenance Terms](https://rancher.com/support-maintenance-terms/).
 
 # Network Topology
 These tips can help Rancher work more smoothly with your network.

--- a/content/rancher/v2.0-v2.4/en/cluster-admin/upgrading-kubernetes/_index.md
+++ b/content/rancher/v2.0-v2.4/en/cluster-admin/upgrading-kubernetes/_index.md
@@ -33,7 +33,7 @@ As of Rancher v2.4.0,
 
 # Tested Kubernetes Versions
 
-Before a new version of Rancher is released, it's tested with the latest minor versions of Kubernetes to ensure compatibility. For details on which versions of Kubernetes were tested on each Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-matrix/all-supported-versions/rancher-v2.4.17/)
+Before a new version of Rancher is released, it's tested with the latest minor versions of Kubernetes to ensure compatibility. For details on which versions of Kubernetes were tested on each Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/all-supported-versions/rancher-v2.4.17/)
 
 # How Upgrades Work
 

--- a/content/rancher/v2.0-v2.4/en/cluster-provisioning/node-requirements/_index.md
+++ b/content/rancher/v2.0-v2.4/en/cluster-provisioning/node-requirements/_index.md
@@ -18,7 +18,7 @@ Make sure the nodes for the Rancher server fulfill the following requirements:
 
 Rancher should work with any modern Linux distribution and any modern Docker version. Linux is required for the etcd and controlplane nodes of all downstream clusters. Worker nodes may run Linux or [Windows Server.](#windows-nodes) The capability to use Windows worker nodes in downstream clusters was added in Rancher v2.3.0.
 
-For details on which OS and Docker versions were tested with each Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-matrix/)
+For details on which OS and Docker versions were tested with each Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/)
 
 All supported operating systems are 64-bit x86.
 

--- a/content/rancher/v2.0-v2.4/en/faq/_index.md
+++ b/content/rancher/v2.0-v2.4/en/faq/_index.md
@@ -51,7 +51,7 @@ At this time, we only support Docker.
 
 **Does Rancher v2.x support Calico, Contiv, Contrail, Flannel, Weave net, etc., for embedded and imported Kubernetes?**
 
-Out-of-the-box, Rancher provides the following CNI network providers for Kubernetes clusters: Canal, Flannel, Calico and Weave (Weave is available as of v2.2.0).  Always refer to the [Rancher Support Matrix](https://rancher.com/support-matrix/) for details about what is officially supported.
+Out-of-the-box, Rancher provides the following CNI network providers for Kubernetes clusters: Canal, Flannel, Calico and Weave (Weave is available as of v2.2.0).  Always refer to the [Rancher Support Matrix](https://rancher.com/support-maintenance-terms/) for details about what is officially supported.
 
 <br>
 

--- a/content/rancher/v2.0-v2.4/en/installation/other-installation-methods/air-gap/launch-kubernetes/_index.md
+++ b/content/rancher/v2.0-v2.4/en/installation/other-installation-methods/air-gap/launch-kubernetes/_index.md
@@ -65,7 +65,7 @@ For more information on private registries configuration file for K3s, refer to 
 
 ### 3. Install K3s
 
-Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-matrix/)
+Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/)
 
 To specify the K3s version, use the INSTALL_K3S_VERSION environment variable when running the K3s installation script.
 

--- a/content/rancher/v2.0-v2.4/en/installation/requirements/_index.md
+++ b/content/rancher/v2.0-v2.4/en/installation/requirements/_index.md
@@ -27,7 +27,7 @@ The Rancher UI works best in Firefox or Chrome.
 
 Rancher should work with any modern Linux distribution.
 
-For details on which OS, Docker, and Kubernetes versions were tested with each Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-matrix/)
+For details on which OS, Docker, and Kubernetes versions were tested with each Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/)
 
 All supported operating systems are 64-bit x86.
 
@@ -45,7 +45,7 @@ For the container runtime, RKE should work with any modern Docker version.
 
 For the container runtime, K3s should work with any modern version of Docker or containerd.
 
-Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-matrix/) To specify the K3s version, use the INSTALL_K3S_VERSION environment variable when running the K3s installation script.
+Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/) To specify the K3s version, use the INSTALL_K3S_VERSION environment variable when running the K3s installation script.
 
 If you are installing Rancher on a K3s cluster with **Raspbian Buster**, follow [these steps]({{<baseurl>}}/k3s/latest/en/advanced/#enabling-legacy-iptables-on-raspbian-buster) to switch to legacy iptables.
 

--- a/content/rancher/v2.0-v2.4/en/installation/resources/k8s-tutorials/ha-with-external-db/_index.md
+++ b/content/rancher/v2.0-v2.4/en/installation/resources/k8s-tutorials/ha-with-external-db/_index.md
@@ -19,7 +19,7 @@ For systems without direct internet access, refer to the air gap installation in
 
 These instructions assume you have set up two nodes, a load balancer, a DNS record, and an external MySQL database as described in [this section.]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/resources/k8s-tutorials/infrastructure-tutorials/infra-for-ha-with-external-db/)
 
-Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-matrix/) To specify the K3s version, use the INSTALL_K3S_VERSION environment variable when running the K3s installation script.
+Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/) To specify the K3s version, use the INSTALL_K3S_VERSION environment variable when running the K3s installation script.
 # Installing Kubernetes
 
 ### 1. Install Kubernetes and Set up the K3s Server

--- a/content/rancher/v2.5/en/admin-settings/k8s-metadata/_index.md
+++ b/content/rancher/v2.5/en/admin-settings/k8s-metadata/_index.md
@@ -57,7 +57,7 @@ If you don't have an air gap setup, you don't need to specify the URL where Ranc
 However, if you have an [air gap setup,](#air-gap-setups) you will need to mirror the Kubernetes metadata repository in a location available to Rancher. Then you need to change the URL to point to the new location of the JSON file.
 ### Air Gap Setups
 
-Rancher relies on a periodic refresh of the `rke-metadata-config` to download new Kubernetes version metadata if it is supported with the current version of the Rancher server. For a table of compatible Kubernetes and Rancher versions, refer to the [service terms section.](https://rancher.com/support-matrix/all-supported-versions/rancher-v2.2.8/)
+Rancher relies on a periodic refresh of the `rke-metadata-config` to download new Kubernetes version metadata if it is supported with the current version of the Rancher server. For a table of compatible Kubernetes and Rancher versions, refer to the [service terms section.](https://rancher.com/support-maintenance-terms/all-supported-versions/rancher-v2.2.8/)
 
 If you have an air gap setup, you might not be able to get the automatic periodic refresh of the Kubernetes metadata from Rancher's Git repository. In that case, you should disable the periodic refresh to prevent your logs from showing errors. Optionally, you can configure your metadata settings so that Rancher can sync with a local copy of the RKE metadata.
 

--- a/content/rancher/v2.5/en/cluster-admin/upgrading-kubernetes/_index.md
+++ b/content/rancher/v2.5/en/cluster-admin/upgrading-kubernetes/_index.md
@@ -26,7 +26,7 @@ This section covers the following topics:
 
 # Tested Kubernetes Versions
 
-Before a new version of Rancher is released, it's tested with the latest minor versions of Kubernetes to ensure compatibility. For details on which versions of Kubernetes were tested on each Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-matrix/all-supported-versions/rancher-v2.5.9/)
+Before a new version of Rancher is released, it's tested with the latest minor versions of Kubernetes to ensure compatibility. For details on which versions of Kubernetes were tested on each Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/all-supported-versions/rancher-v2.5.9/)
 
 # How Upgrades Work
 

--- a/content/rancher/v2.5/en/cluster-provisioning/node-requirements/_index.md
+++ b/content/rancher/v2.5/en/cluster-provisioning/node-requirements/_index.md
@@ -20,7 +20,7 @@ Make sure the nodes for the Rancher server fulfill the following requirements:
 
 Rancher should work with any modern Linux distribution and any modern Docker version. Linux is required for the etcd and controlplane nodes of all downstream clusters. Worker nodes may run Linux or [Windows Server.](#windows-nodes)
 
-For details on which OS and Docker versions were tested with each Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-matrix/)
+For details on which OS and Docker versions were tested with each Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/)
 
 All supported operating systems are 64-bit x86.
 

--- a/content/rancher/v2.5/en/faq/_index.md
+++ b/content/rancher/v2.5/en/faq/_index.md
@@ -52,7 +52,7 @@ At this time, we only support Docker.
 
 **Does Rancher v2.x support Calico, Contiv, Contrail, Flannel, Weave net, etc., for embedded and registered Kubernetes?**
 
-Out-of-the-box, Rancher provides the following CNI network providers for Kubernetes clusters: Canal, Flannel, Calico and Weave.  Always refer to the [Rancher Support Matrix](https://rancher.com/support-matrix/) for details about what is officially supported.
+Out-of-the-box, Rancher provides the following CNI network providers for Kubernetes clusters: Canal, Flannel, Calico and Weave.  Always refer to the [Rancher Support Matrix](https://rancher.com/support-maintenance-terms/) for details about what is officially supported.
 
 <br>
 

--- a/content/rancher/v2.5/en/faq/deprecated-features-25x/_index.md
+++ b/content/rancher/v2.5/en/faq/deprecated-features-25x/_index.md
@@ -7,7 +7,7 @@ aliases:
 
 ### What is Rancher's Deprecation policy?
 
-Starting in Rancher 2.5 we have published our official deprecation policy in the support [terms of service](https://rancher.com/support-matrix).
+Starting in Rancher 2.5 we have published our official deprecation policy in the support [terms of service](https://rancher.com/support-maintenance-terms).
 
 ### Where can I find out which features have been deprecated in Rancher 2.5?
 

--- a/content/rancher/v2.5/en/installation/other-installation-methods/air-gap/launch-kubernetes/_index.md
+++ b/content/rancher/v2.5/en/installation/other-installation-methods/air-gap/launch-kubernetes/_index.md
@@ -64,7 +64,7 @@ For more information on private registries configuration file for K3s, refer to 
 
 ### 3. Install K3s
 
-Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-matrix/)
+Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/)
 
 To specify the K3s version, use the INSTALL_K3S_VERSION environment variable when running the K3s installation script.
 

--- a/content/rancher/v2.5/en/installation/requirements/_index.md
+++ b/content/rancher/v2.5/en/installation/requirements/_index.md
@@ -44,9 +44,9 @@ Rancher should work with any modern Linux distribution.
 
 Docker is required for nodes that will run RKE Kubernetes clusters. It is not required for RancherD or RKE2 Kubernetes installs.
 
-Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-matrix/)
+Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/)
 
-For details on which OS and Docker versions were tested with each Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-matrix/)
+For details on which OS and Docker versions were tested with each Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/)
 
 All supported operating systems are 64-bit x86.
 
@@ -66,7 +66,7 @@ For the container runtime, RKE should work with any modern Docker version.
 
 For the container runtime, K3s should work with any modern version of Docker or containerd.
 
-Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-matrix/) To specify the K3s version, use the INSTALL_K3S_VERSION environment variable when running the K3s installation script. 
+Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/) To specify the K3s version, use the INSTALL_K3S_VERSION environment variable when running the K3s installation script. 
 
 If you are installing Rancher on a K3s cluster with **Raspbian Buster**, follow [these steps]({{<baseurl>}}/k3s/latest/en/advanced/#enabling-legacy-iptables-on-raspbian-buster) to switch to legacy iptables.
 
@@ -86,7 +86,7 @@ Docker is not required for RancherD installs.
 
 _The RKE2 install is available as of v2.5.6._
 
-For details on which OS versions were tested with RKE2, refer to the [support maintenance terms.](https://rancher.com/support-matrix/)
+For details on which OS versions were tested with RKE2, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/)
 
 Docker is not required for RKE2 installs.
 

--- a/content/rancher/v2.5/en/installation/resources/k8s-tutorials/ha-rke2/_index.md
+++ b/content/rancher/v2.5/en/installation/resources/k8s-tutorials/ha-rke2/_index.md
@@ -16,7 +16,7 @@ These instructions assume you have set up three nodes, a load balancer, and a DN
 
 Note that in order for RKE2 to work correctly with the load balancer, you need to set up two listeners: one for the supervisor on port 9345, and one for the Kubernetes API on port 6443.
 
-Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-matrix/) To specify the RKE2 version, use the INSTALL_RKE2_VERSION environment variable when running the RKE2 installation script.
+Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/) To specify the RKE2 version, use the INSTALL_RKE2_VERSION environment variable when running the RKE2 installation script.
 # Installing Kubernetes
 
 ### 1. Install Kubernetes and Set up the RKE2 Server

--- a/content/rancher/v2.5/en/installation/resources/k8s-tutorials/ha-with-external-db/_index.md
+++ b/content/rancher/v2.5/en/installation/resources/k8s-tutorials/ha-with-external-db/_index.md
@@ -19,7 +19,7 @@ For systems without direct internet access, refer to the air gap installation in
 
 These instructions assume you have set up two nodes, a load balancer, a DNS record, and an external MySQL database as described in [this section.]({{<baseurl>}}/rancher/v2.5/en/installation/resources/k8s-tutorials/infrastructure-tutorials/infra-for-ha-with-external-db/)
 
-Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-matrix/) To specify the K3s version, use the INSTALL_K3S_VERSION environment variable when running the K3s installation script.
+Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/) To specify the K3s version, use the INSTALL_K3S_VERSION environment variable when running the K3s installation script.
 # Installing Kubernetes
 
 ### 1. Install Kubernetes and Set up the K3s Server

--- a/content/rancher/v2.6/en/admin-settings/k8s-metadata/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/k8s-metadata/_index.md
@@ -61,7 +61,7 @@ However, if you have an [air gap setup,](#air-gap-setups) you will need to mirro
 
 ### Air Gap Setups
 
-Rancher relies on a periodic refresh of the `rke-metadata-config` to download new Kubernetes version metadata if it is supported with the current version of the Rancher server. For a table of compatible Kubernetes and Rancher versions, refer to the [service terms section.](https://rancher.com/support-matrix/all-supported-versions/rancher-v2.2.8/)
+Rancher relies on a periodic refresh of the `rke-metadata-config` to download new Kubernetes version metadata if it is supported with the current version of the Rancher server. For a table of compatible Kubernetes and Rancher versions, refer to the [service terms section.](https://rancher.com/support-maintenance-terms/all-supported-versions/rancher-v2.2.8/)
 
 If you have an air gap setup, you might not be able to get the automatic periodic refresh of the Kubernetes metadata from Rancher's Git repository. In that case, you should disable the periodic refresh to prevent your logs from showing errors. Optionally, you can configure your metadata settings so that Rancher can sync with a local copy of the RKE metadata.
 

--- a/content/rancher/v2.6/en/cluster-admin/editing-clusters/rke-config-reference/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/editing-clusters/rke-config-reference/_index.md
@@ -169,7 +169,7 @@ Configures whether nodes are allowed to run versions of Docker that Rancher does
 
 If you choose to require a supported Docker version, Rancher will stop pods from running on nodes that don't have a supported Docker version installed.
 
-For details on which Docker versions were tested with each Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-matrix/)
+For details on which Docker versions were tested with each Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/)
 
 ### Docker Root Directory
 

--- a/content/rancher/v2.6/en/cluster-admin/upgrading-kubernetes/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/upgrading-kubernetes/_index.md
@@ -24,7 +24,7 @@ This section covers the following topics:
 
 # Tested Kubernetes Versions
 
-Before a new version of Rancher is released, it's tested with the latest minor versions of Kubernetes to ensure compatibility. For details on which versions of Kubernetes were tested on each Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-matrix/all-supported-versions/rancher-v2.6.0/)
+Before a new version of Rancher is released, it's tested with the latest minor versions of Kubernetes to ensure compatibility. For details on which versions of Kubernetes were tested on each Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/all-supported-versions/rancher-v2.6.0/)
 
 # How Upgrades Work
 

--- a/content/rancher/v2.6/en/cluster-provisioning/node-requirements/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/node-requirements/_index.md
@@ -18,7 +18,7 @@ Make sure the nodes for the Rancher server fulfill the following requirements:
 
 Rancher should work with any modern Linux distribution and any modern Docker version. Linux is required for the etcd and controlplane nodes of all downstream clusters. Worker nodes may run Linux or [Windows Server.](#windows-nodes)
 
-For details on which OS and Docker versions were tested with each Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-matrix/)
+For details on which OS and Docker versions were tested with each Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/)
 
 All supported operating systems are 64-bit x86.
 

--- a/content/rancher/v2.6/en/faq/_index.md
+++ b/content/rancher/v2.6/en/faq/_index.md
@@ -49,7 +49,7 @@ At this time, we only support Docker.
 
 **Does Rancher v2.x support Calico, Contiv, Contrail, Flannel, Weave net, etc., for embedded and registered Kubernetes?**
 
-Out-of-the-box, Rancher provides the following CNI network providers for Kubernetes clusters: Canal, Flannel, Calico and Weave.  Always refer to the [Rancher Support Matrix](https://rancher.com/support-matrix/) for details about what is officially supported.
+Out-of-the-box, Rancher provides the following CNI network providers for Kubernetes clusters: Canal, Flannel, Calico and Weave.  Always refer to the [Rancher Support Matrix](https://rancher.com/support-maintenance-terms/) for details about what is officially supported.
 
 <br>
 

--- a/content/rancher/v2.6/en/faq/deprecated-features-25x/_index.md
+++ b/content/rancher/v2.6/en/faq/deprecated-features-25x/_index.md
@@ -5,7 +5,7 @@ weight: 100
 
 ### What is Rancher's Deprecation policy?
 
-Starting in Rancher 2.5 we have published our official deprecation policy in the support [terms of service](https://rancher.com/support-matrix).
+Starting in Rancher 2.5 we have published our official deprecation policy in the support [terms of service](https://rancher.com/support-maintenance-terms).
 
 ### Where can I find out which features have been deprecated in Rancher 2.5?
 

--- a/content/rancher/v2.6/en/installation/other-installation-methods/air-gap/launch-kubernetes/_index.md
+++ b/content/rancher/v2.6/en/installation/other-installation-methods/air-gap/launch-kubernetes/_index.md
@@ -61,7 +61,7 @@ For more information on private registries configuration file for K3s, refer to 
 
 ### 3. Install K3s
 
-Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-matrix/)
+Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/)
 
 To specify the K3s version, use the INSTALL_K3S_VERSION environment variable when running the K3s installation script.
 

--- a/content/rancher/v2.6/en/installation/requirements/_index.md
+++ b/content/rancher/v2.6/en/installation/requirements/_index.md
@@ -40,9 +40,9 @@ Rancher should work with any modern Linux distribution.
 
 Docker is required for nodes that will run RKE Kubernetes clusters. It is not required for Kubernetes installs.
 
-Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-matrix/)
+Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/)
 
-For details on which OS and Docker versions were tested with each Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-matrix/)
+For details on which OS and Docker versions were tested with each Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/)
 
 All supported operating systems are 64-bit x86.
 
@@ -62,7 +62,7 @@ For the container runtime, RKE should work with any modern Docker version.
 
 For the container runtime, K3s should work with any modern version of Docker or containerd.
 
-Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-matrix/) To specify the K3s version, use the INSTALL_K3S_VERSION environment variable when running the K3s installation script. 
+Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/) To specify the K3s version, use the INSTALL_K3S_VERSION environment variable when running the K3s installation script. 
 
 If you are installing Rancher on a K3s cluster with **Raspbian Buster**, follow [these steps]({{<baseurl>}}/k3s/latest/en/advanced/#enabling-legacy-iptables-on-raspbian-buster) to switch to legacy iptables.
 
@@ -72,7 +72,7 @@ If you are installing Rancher on a K3s cluster with Alpine Linux, follow [these 
 
 ### RKE2 Specific Requirements
 
-For details on which OS versions were tested with RKE2, refer to the [support maintenance terms.](https://rancher.com/support-matrix/)
+For details on which OS versions were tested with RKE2, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/)
 
 Docker is not required for RKE2 installs.
 

--- a/content/rancher/v2.6/en/installation/resources/k8s-tutorials/ha-rke2/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/k8s-tutorials/ha-rke2/_index.md
@@ -13,7 +13,7 @@ These instructions assume you have set up three nodes, a load balancer, and a DN
 
 Note that in order for RKE2 to work correctly with the load balancer, you need to set up two listeners: one for the supervisor on port 9345, and one for the Kubernetes API on port 6443.
 
-Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-matrix/) To specify the RKE2 version, use the INSTALL_RKE2_VERSION environment variable when running the RKE2 installation script.
+Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/) To specify the RKE2 version, use the INSTALL_RKE2_VERSION environment variable when running the RKE2 installation script.
 # Installing Kubernetes
 
 ### 1. Install Kubernetes and Set up the RKE2 Server

--- a/content/rancher/v2.6/en/installation/resources/k8s-tutorials/ha-with-external-db/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/k8s-tutorials/ha-with-external-db/_index.md
@@ -19,7 +19,7 @@ For systems without direct internet access, refer to the air gap installation in
 
 These instructions assume you have set up two nodes, a load balancer, a DNS record, and an external MySQL database as described in [this section.]({{<baseurl>}}/rancher/v2.6/en/installation/resources/k8s-tutorials/infrastructure-tutorials/infra-for-ha-with-external-db/)
 
-Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-matrix/) To specify the K3s version, use the INSTALL_K3S_VERSION environment variable when running the K3s installation script.
+Rancher needs to be installed on a supported Kubernetes version. To find out which versions of Kubernetes are supported for your Rancher version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/) To specify the K3s version, use the INSTALL_K3S_VERSION environment variable when running the K3s installation script.
 # Installing Kubernetes
 
 ### 1. Install Kubernetes and Set up the K3s Server

--- a/content/rke/latest/en/installation/_index.md
+++ b/content/rke/latest/en/installation/_index.md
@@ -96,7 +96,7 @@ $ port upgrade rke
 
 The Kubernetes cluster components are launched using Docker on a Linux distro. You can use any Linux you want, as long as you can install Docker on it.
 
-> For information on which Docker versions were tested with your version of RKE, refer to the [terms of service](https://rancher.com/support-matrix) for installing Rancher on RKE.
+> For information on which Docker versions were tested with your version of RKE, refer to the [terms of service](https://rancher.com/support-maintenance-terms) for installing Rancher on RKE.
 
 Review the [OS requirements]({{<baseurl>}}/rke/latest/en/installation/os/) and configure each node appropriately.
 

--- a/content/rke/latest/en/os/_index.md
+++ b/content/rke/latest/en/os/_index.md
@@ -38,7 +38,7 @@ weight: 5
 
 ### General Linux Requirements
 
-RKE runs on almost any Linux OS with Docker installed. For details on which OS and Docker versions were tested with each version, refer to the [support maintenance terms.](https://rancher.com/support-matrix/).
+RKE runs on almost any Linux OS with Docker installed. For details on which OS and Docker versions were tested with each version, refer to the [support maintenance terms.](https://rancher.com/support-maintenance-terms/).
 
 - [SSH user]({{<baseurl>}}/rke/latest/en/config-options/nodes/#ssh-user) - The SSH user used for node access must be a member of the `docker` group on the node:
 


### PR DESCRIPTION
Reverts rancher/docs#3616

Redirects have been added to the old URL but not the new URL yet. Several users are using the links and hitting 404s so temporarily reverting this. Will change back once the redirects have been added.