### PR TITLE
Add missing TOC entry

### DIFF
--- a/content/rancher/v2.5/en/deploy-across-clusters/fleet/_index.md
+++ b/content/rancher/v2.5/en/deploy-across-clusters/fleet/_index.md
@@ -15,6 +15,7 @@ Fleet is a separate project from Rancher, and can be installed on any Kubernetes
 - [Accessing Fleet in the Rancher UI](#accessing-fleet-in-the-rancher-ui)
 - [Windows Support](#windows-support)
 - [GitHub Repository](#github-repository)
+- [Using Fleet Behind a Proxy](#using-fleet-behind-a-proxy)
 - [Documentation](#documentation)
 
 # Architecture

--- a/content/rancher/v2.6/en/deploy-across-clusters/fleet/_index.md
+++ b/content/rancher/v2.6/en/deploy-across-clusters/fleet/_index.md
@@ -11,6 +11,7 @@ Fleet is a separate project from Rancher, and can be installed on any Kubernetes
 - [Accessing Fleet in the Rancher UI](#accessing-fleet-in-the-rancher-ui)
 - [Windows Support](#windows-support)
 - [GitHub Repository](#github-repository)
+- [Using Fleet Behind a Proxy](#using-fleet-behind-a-proxy)
 - [Documentation](#documentation)
 
 # Architecture


### PR DESCRIPTION
### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
