### PR TITLE
Update _index.md

### DIFF
--- a/content/k3s/latest/en/upgrades/automated/_index.md
+++ b/content/k3s/latest/en/upgrades/automated/_index.md
@@ -36,9 +36,15 @@ To automate upgrades in this manner, you must do the following:
 
 
 ### Install the system-upgrade-controller
- The system-upgrade-controller can be installed as a deployment into your cluster. The deployment requires a service-account, clusterRoleBinding, and a configmap. To install these components, run the following command:
+ The system-upgrade-controller can be installed as a deployment into your cluster. The deployment requires a service-account, clusterRoleBinding, and a configmap. To install these components, run the following commands:
+
+* Get the latest release tag
 ```
-kubectl apply -f https://github.com/rancher/system-upgrade-controller/releases/download/v0.6.2/system-upgrade-controller.yaml
+release_tag=$(curl -s "https://api.github.com/repos/rancher/system-upgrade-controller/releases/latest" | awk -F '"' '/tag_name/{print $4}')
+```
+* Apply the controller manifest with the release tag
+```
+kubectl apply -f https://github.com/rancher/system-upgrade-controller/releases/download/$release_tag/system-upgrade-controller.yaml
 ```
 The controller can be configured and customized via the previously mentioned configmap, but the controller must be redeployed for the changes to be applied.
 


### PR DESCRIPTION
`v0.6.2` fails with a 'crashback loop' error - version `0.8.0` installs without issue

the suse.com page (where I found the hint) should probably also be changed:

https://www.suse.com/c/rancher_blog/upgrade-a-k3s-kubernetes-cluster-with-system-upgrade-controller/

### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
