### PR TITLE
kube-dashboard: Add missing steps to delete the dashboard.

### DIFF
--- a/content/k3s/latest/en/installation/kube-dashboard/_index.md
+++ b/content/k3s/latest/en/installation/kube-dashboard/_index.md
@@ -87,5 +87,5 @@ sudo k3s kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard
 ```bash
 sudo k3s kubectl delete ns kubernetes-dashboard
 sudo k3s kubectl delete clusterrolebinding kubernetes-dashboard
-sudo k3s kubectl delete clusterroles kubernetes-dashboard
+sudo k3s kubectl delete clusterrole kubernetes-dashboard
 ```

--- a/content/k3s/latest/en/installation/kube-dashboard/_index.md
+++ b/content/k3s/latest/en/installation/kube-dashboard/_index.md
@@ -86,4 +86,6 @@ sudo k3s kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard
 
 ```bash
 sudo k3s kubectl delete ns kubernetes-dashboard
+sudo k3s kubectl delete clusterrolebinding kubernetes-dashboard
+sudo k3s kubectl delete clusterroles kubernetes-dashboard
 ```


### PR DESCRIPTION
In addition to the namespace deletion, the clusterrolebinding and the clusterroles must be deleted.
