### PR TITLE
Update _index.md

### DIFF
--- a/content/rancher/v2.5/en/istio/resources/_index.md
+++ b/content/rancher/v2.5/en/istio/resources/_index.md
@@ -19,7 +19,7 @@ Before enabling Istio, we recommend that you confirm that your Rancher worker no
 
 The table below shows a summary of the minimum recommended resource requests and limits for the CPU and memory of each core Istio component.
 
-In Kubernetes, the resource request indicates that the workload will not deployed on a node unless the node has at least the specified amount of memory and CPU available. If the workload surpasses the limit for CPU or memory, it can be terminated or evicted from the node. For more information on managing resource limits for containers, refer to the [Kubernetes documentation.](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/)
+In Kubernetes, the resource request indicates that the workload will not be deployed on a node unless the node has at least the specified amount of memory and CPU available. If the workload surpasses the limit for CPU or memory, it can be terminated or evicted from the node. For more information on managing resource limits for containers, refer to the [Kubernetes documentation.](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/)
 
 {{% tabs %}}
 {{% tab "v2.5.6+" %}}


### PR DESCRIPTION
added 'be" on line 22:

In Kubernetes, the resource request indicates that the workload will not be deployed on a node...

### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
