### PR TITLE
lets encrypt requirements

### DIFF
--- a/content/rancher/v2.5/en/installation/install-rancher-on-k8s/_index.md
+++ b/content/rancher/v2.5/en/installation/install-rancher-on-k8s/_index.md
@@ -190,6 +190,8 @@ deployment "rancher" successfully rolled out
 
 This option uses `cert-manager` to automatically request and renew [Let's Encrypt](https://letsencrypt.org/) certificates. This is a free service that provides you with a valid certificate as Let's Encrypt is a trusted CA.
 
+>**Note:**: You need to have port 80 open as the HTTP-01 challenge can only be done on port 80.
+
 In the following command,
 
 - Set `hostname` to the public DNS record that resolves to your load balancer.

--- a/content/rancher/v2.6/en/installation/install-rancher-on-k8s/_index.md
+++ b/content/rancher/v2.6/en/installation/install-rancher-on-k8s/_index.md
@@ -181,7 +181,7 @@ deployment "rancher" successfully rolled out
 
 This option uses `cert-manager` to automatically request and renew [Let's Encrypt](https://letsencrypt.org/) certificates. This is a free service that provides you with a valid certificate as Let's Encrypt is a trusted CA.
 
-Note: You need to have port 80 open as the HTTP-01 challenge can only be done on port 80.
+>**Note:**: You need to have port 80 open as the HTTP-01 challenge can only be done on port 80.
 
 In the following command,
 

--- a/content/rancher/v2.6/en/installation/install-rancher-on-k8s/_index.md
+++ b/content/rancher/v2.6/en/installation/install-rancher-on-k8s/_index.md
@@ -181,6 +181,8 @@ deployment "rancher" successfully rolled out
 
 This option uses `cert-manager` to automatically request and renew [Let's Encrypt](https://letsencrypt.org/) certificates. This is a free service that provides you with a valid certificate as Let's Encrypt is a trusted CA.
 
+Note: You need to have port 80 open as the HTTP-01 challenge can only be done on port 80.
+
 In the following command,
 
 - `hostname` is set to the public DNS record,


### PR DESCRIPTION
Port 80 is required for lets encrypt certificate to be generated.