### PR TITLE
Rename kube_config_rancher-cluster to kube_config_cluster

### DIFF
--- a/content/rancher/v2.5/en/contributing/_index.md
+++ b/content/rancher/v2.5/en/contributing/_index.md
@@ -81,7 +81,7 @@ Please follow this checklist when filing an issue which will helps us investigat
         ```
       - Kubernetes install using `kubectl`
 
-        > **Note:** Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_rancher-cluster.yml` if Rancher is installed on a Kubernetes cluster) or are using the embedded kubectl via the UI.
+        > **Note:** Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_cluster.yml` if Rancher is installed on a Kubernetes cluster) or are using the embedded kubectl via the UI.
 
         ```
         kubectl -n cattle-system \
@@ -98,7 +98,7 @@ Please follow this checklist when filing an issue which will helps us investigat
         ```
       - Kubernetes Install with RKE Add-On
 
-        > **Note:** Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_rancher-cluster.yml` if the Rancher server is installed on a Kubernetes cluster) or are using the embedded kubectl via the UI.
+        > **Note:** Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_cluster.yml` if the Rancher server is installed on a Kubernetes cluster) or are using the embedded kubectl via the UI.
 
         ```
         kubectl -n cattle-system \

--- a/content/rancher/v2.5/en/faq/technical/_index.md
+++ b/content/rancher/v2.5/en/faq/technical/_index.md
@@ -16,7 +16,7 @@ New password for default administrator (user-xxxxx):
 
 Kubernetes install (Helm):
 ```
-$ KUBECONFIG=./kube_config_rancher-cluster.yml
+$ KUBECONFIG=./kube_config_cluster.yml
 $ kubectl --kubeconfig $KUBECONFIG -n cattle-system exec $(kubectl --kubeconfig $KUBECONFIG -n cattle-system get pods -l app=rancher | grep '1/1' | head -1 | awk '{ print $1 }') -- reset-password
 New password for default administrator (user-xxxxx):
 <new_password>
@@ -35,7 +35,7 @@ New password for default administrator (user-xxxxx):
 
 Kubernetes install (Helm):
 ```
-$ KUBECONFIG=./kube_config_rancher-cluster.yml
+$ KUBECONFIG=./kube_config_cluster.yml
 $ kubectl --kubeconfig $KUBECONFIG -n cattle-system exec $(kubectl --kubeconfig $KUBECONFIG -n cattle-system get pods -l app=rancher | grep '1/1' | head -1 | awk '{ print $1 }') -- ensure-default-admin
 New password for default administrator (user-xxxxx):
 <new_password>

--- a/content/rancher/v2.5/en/installation/other-installation-methods/air-gap/launch-kubernetes/_index.md
+++ b/content/rancher/v2.5/en/installation/other-installation-methods/air-gap/launch-kubernetes/_index.md
@@ -209,7 +209,7 @@ rke up --config ./rancher-cluster.yml
 Save a copy of the following files in a secure location:
 
 - `rancher-cluster.yml`: The RKE cluster configuration file.
-- `kube_config_rancher-cluster.yml`: The [Kubeconfig file]({{<baseurl>}}/rke/latest/en/kubeconfig/) for the cluster, this file contains credentials for full access to the cluster.
+- `kube_config_cluster.yml`: The [Kubeconfig file]({{<baseurl>}}/rke/latest/en/kubeconfig/) for the cluster, this file contains credentials for full access to the cluster.
 - `rancher-cluster.rkestate`: The [Kubernetes Cluster State file]({{<baseurl>}}/rke/latest/en/installation/#kubernetes-cluster-state), this file contains the current state of the cluster including the RKE configuration and the certificates.<br/><br/>_The Kubernetes Cluster State file is only created when using RKE v0.2.0 or higher._
 {{% /tab %}}
 {{% /tabs %}}

--- a/content/rancher/v2.5/en/installation/other-installation-methods/behind-proxy/launch-kubernetes/_index.md
+++ b/content/rancher/v2.5/en/installation/other-installation-methods/behind-proxy/launch-kubernetes/_index.md
@@ -114,12 +114,12 @@ After that, you can create the Kubernetes cluster by running:
 rke up --config rancher-cluster.yaml
 ```
 
-RKE creates a state file called `rancher-cluster.rkestate`, this is needed if you want to perform updates, modify your cluster configuration or restore it from a backup. It also creates a `kube_config_rancher-cluster.yaml` file, that you can use to connect to the remote Kubernetes cluster locally with tools like kubectl or Helm. Make sure to save all of these files in a secure location, for example by putting them into a version control system.
+RKE creates a state file called `rancher-cluster.rkestate`, this is needed if you want to perform updates, modify your cluster configuration or restore it from a backup. It also creates a `kube_config_cluster.yaml` file, that you can use to connect to the remote Kubernetes cluster locally with tools like kubectl or Helm. Make sure to save all of these files in a secure location, for example by putting them into a version control system.
 
 To have a look at your cluster run:
 
 ```
-export KUBECONFIG=kube_config_rancher-cluster.yaml
+export KUBECONFIG=kube_config_cluster.yaml
 kubectl cluster-info
 kubectl get pods --all-namespaces
 ```
@@ -141,7 +141,7 @@ default backend - 404
 Save a copy of the following files in a secure location:
 
 - `rancher-cluster.yml`: The RKE cluster configuration file.
-- `kube_config_rancher-cluster.yml`: The [Kubeconfig file]({{<baseurl>}}/rke/latest/en/kubeconfig/) for the cluster, this file contains credentials for full access to the cluster.
+- `kube_config_cluster.yml`: The [Kubeconfig file]({{<baseurl>}}/rke/latest/en/kubeconfig/) for the cluster, this file contains credentials for full access to the cluster.
 - `rancher-cluster.rkestate`: The [Kubernetes Cluster State file]({{<baseurl>}}/rke/latest/en/installation/#kubernetes-cluster-state), this file contains the current state of the cluster including the RKE configuration and the certificates.
 
 > **Note:** The "rancher-cluster" parts of the two latter file names are dependent on how you name the RKE cluster configuration file.

--- a/content/rancher/v2.5/en/installation/resources/k8s-tutorials/ha-RKE/_index.md
+++ b/content/rancher/v2.5/en/installation/resources/k8s-tutorials/ha-RKE/_index.md
@@ -98,14 +98,14 @@ This section describes how to set up your workspace so that you can interact wit
 
 Assuming you have installed `kubectl`, you need to place the `kubeconfig` file in a location where `kubectl` can reach it. The `kubeconfig` file contains the credentials necessary to access your cluster with `kubectl`.
 
-When you ran `rke up`, RKE should have created a `kubeconfig` file named `kube_config_rancher-cluster.yml`. This file has the credentials for `kubectl` and `helm`.
+When you ran `rke up`, RKE should have created a `kubeconfig` file named `kube_config_cluster.yml`. This file has the credentials for `kubectl` and `helm`.
 
 > **Note:** If you have used a different file name from `rancher-cluster.yml`, then the kube config file will be named `kube_config_<FILE_NAME>.yml`.
 
-Move this file to `$HOME/.kube/config`, or if you are working with multiple Kubernetes clusters, set the `KUBECONFIG` environmental variable to the path of `kube_config_rancher-cluster.yml`:
+Move this file to `$HOME/.kube/config`, or if you are working with multiple Kubernetes clusters, set the `KUBECONFIG` environmental variable to the path of `kube_config_cluster.yml`:
 
 ```
-export KUBECONFIG=$(pwd)/kube_config_rancher-cluster.yml
+export KUBECONFIG=$(pwd)/kube_config_cluster.yml
 ```
 
 Test your connectivity with `kubectl` and see if all your nodes are in `Ready` state:
@@ -156,7 +156,7 @@ This confirms that you have successfully installed a Kubernetes cluster that the
 Save a copy of the following files in a secure location:
 
 - `rancher-cluster.yml`: The RKE cluster configuration file.
-- `kube_config_rancher-cluster.yml`: The [Kubeconfig file]({{<baseurl>}}/rke/latest/en/kubeconfig/) for the cluster, this file contains credentials for full access to the cluster.
+- `kube_config_cluster.yml`: The [Kubeconfig file]({{<baseurl>}}/rke/latest/en/kubeconfig/) for the cluster, this file contains credentials for full access to the cluster.
 - `rancher-cluster.rkestate`: The [Kubernetes Cluster State file]({{<baseurl>}}/rke/latest/en/installation/#kubernetes-cluster-state), this file contains credentials for full access to the cluster.<br/><br/>_The Kubernetes Cluster State file is only created when using RKE v0.2.0 or higher._
 
 > **Note:** The "rancher-cluster" parts of the two latter file names are dependent on how you name the RKE cluster configuration file.

--- a/content/rancher/v2.5/en/overview/architecture/_index.md
+++ b/content/rancher/v2.5/en/overview/architecture/_index.md
@@ -77,7 +77,7 @@ The authentication proxy forwards all Kubernetes API calls to downstream cluster
 
 Rancher communicates with Kubernetes clusters using a [service account,](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) which provides an identity for processes that run in a pod.
 
-By default, Rancher generates a [kubeconfig file]({{<baseurl>}}/rancher/v2.5/en/cluster-admin/cluster-access/kubectl/) that contains credentials for proxying through the Rancher server to connect to the Kubernetes API server on a downstream user cluster. The kubeconfig file (`kube_config_rancher-cluster.yml`) contains full access to the cluster.
+By default, Rancher generates a [kubeconfig file]({{<baseurl>}}/rancher/v2.5/en/cluster-admin/cluster-access/kubectl/) that contains credentials for proxying through the Rancher server to connect to the Kubernetes API server on a downstream user cluster. The kubeconfig file (`kube_config_cluster.yml`) contains full access to the cluster.
 
 ### 2. Cluster Controllers and Cluster Agents
 
@@ -131,7 +131,7 @@ You will need to use a context defined in this kubeconfig file to access the clu
 The files mentioned below are needed to maintain, troubleshoot and upgrade your cluster:
 
 - `rancher-cluster.yml`: The RKE cluster configuration file.
-- `kube_config_rancher-cluster.yml`: The Kubeconfig file for the cluster, this file contains credentials for full access to the cluster. You can use this file to authenticate with a Rancher-launched Kubernetes cluster if Rancher goes down.
+- `kube_config_cluster.yml`: The Kubeconfig file for the cluster, this file contains credentials for full access to the cluster. You can use this file to authenticate with a Rancher-launched Kubernetes cluster if Rancher goes down.
 - `rancher-cluster.rkestate`: The Kubernetes cluster state file. This file contains credentials for full access to the cluster. Note: This state file is only created when using RKE v0.2.0 or higher.
 
 > **Note:** The "rancher-cluster" parts of the two latter file names are dependent on how you name the RKE cluster configuration file.

--- a/content/rancher/v2.5/en/troubleshooting/dns/_index.md
+++ b/content/rancher/v2.5/en/troubleshooting/dns/_index.md
@@ -7,7 +7,7 @@ aliases:
 
 The commands/steps listed on this page can be used to check name resolution issues in your cluster.
 
-Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_rancher-cluster.yml` for Rancher HA) or are using the embedded kubectl via the UI.
+Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_cluster.yml` for Rancher HA) or are using the embedded kubectl via the UI.
 
 Before running the DNS checks, check the [default DNS provider]({{<baseurl>}}/rancher/v2.5/en/cluster-provisioning/rke-clusters/options/#default-dns-provider) for your cluster and make sure that [the overlay network is functioning correctly]({{<baseurl>}}/rancher/v2.5/en/troubleshooting/networking/#check-if-overlay-network-is-functioning-correctly) as this can also be the reason why DNS resolution (partly) fails.
 

--- a/content/rancher/v2.5/en/troubleshooting/kubernetes-resources/_index.md
+++ b/content/rancher/v2.5/en/troubleshooting/kubernetes-resources/_index.md
@@ -7,7 +7,7 @@ aliases:
 
 The commands/steps listed on this page can be used to check the most important Kubernetes resources and apply to [Rancher Launched Kubernetes]({{<baseurl>}}/rancher/v2.5/en/cluster-provisioning/rke-clusters/) clusters.
 
-Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_rancher-cluster.yml` for Rancher HA) or are using the embedded kubectl via the UI.
+Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_cluster.yml` for Rancher HA) or are using the embedded kubectl via the UI.
 
 - [Nodes](#nodes)
   - [Get nodes](#get-nodes)

--- a/content/rancher/v2.5/en/troubleshooting/logging/_index.md
+++ b/content/rancher/v2.5/en/troubleshooting/logging/_index.md
@@ -18,7 +18,7 @@ The following log levels are used in Rancher:
 * Kubernetes install
  * Configure debug log level
 ```
-$ KUBECONFIG=./kube_config_rancher-cluster.yml
+$ KUBECONFIG=./kube_config_cluster.yml
 $ kubectl -n cattle-system get pods -l app=rancher --no-headers -o custom-columns=name:.metadata.name | while read rancherpod; do kubectl -n cattle-system exec $rancherpod -c rancher -- loglevel --set debug; done
 OK
 OK
@@ -28,7 +28,7 @@ $ kubectl -n cattle-system logs -l app=rancher -c rancher
 
  * Configure info log level
 ```
-$ KUBECONFIG=./kube_config_rancher-cluster.yml
+$ KUBECONFIG=./kube_config_cluster.yml
 $ kubectl -n cattle-system get pods -l app=rancher --no-headers -o custom-columns=name:.metadata.name | while read rancherpod; do kubectl -n cattle-system exec $rancherpod -c rancher -- loglevel --set info; done
 OK
 OK

--- a/content/rancher/v2.5/en/troubleshooting/networking/_index.md
+++ b/content/rancher/v2.5/en/troubleshooting/networking/_index.md
@@ -7,7 +7,7 @@ aliases:
 
 The commands/steps listed on this page can be used to check networking related issues in your cluster.
 
-Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_rancher-cluster.yml` for Rancher HA) or are using the embedded kubectl via the UI.
+Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_cluster.yml` for Rancher HA) or are using the embedded kubectl via the UI.
 
 ### Double check if all the required ports are opened in your (host) firewall
 

--- a/content/rancher/v2.5/en/troubleshooting/rancherha/_index.md
+++ b/content/rancher/v2.5/en/troubleshooting/rancherha/_index.md
@@ -7,7 +7,7 @@ aliases:
 
 The commands/steps listed on this page can be used to check your Rancher Kubernetes Installation.
 
-Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_rancher-cluster.yml`).
+Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_cluster.yml`).
 
 ### Check Rancher pods
 

--- a/content/rancher/v2.6/en/contributing/_index.md
+++ b/content/rancher/v2.6/en/contributing/_index.md
@@ -78,7 +78,7 @@ Please follow this checklist when filing an issue which will helps us investigat
         ```
       - Kubernetes install using `kubectl`
 
-        > **Note:** Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_rancher-cluster.yml` if Rancher is installed on a Kubernetes cluster) or are using the embedded kubectl via the UI.
+        > **Note:** Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_cluster.yml` if Rancher is installed on a Kubernetes cluster) or are using the embedded kubectl via the UI.
 
         ```
         kubectl -n cattle-system \
@@ -95,7 +95,7 @@ Please follow this checklist when filing an issue which will helps us investigat
         ```
       - Kubernetes Install with RKE Add-On
 
-        > **Note:** Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_rancher-cluster.yml` if the Rancher server is installed on a Kubernetes cluster) or are using the embedded kubectl via the UI.
+        > **Note:** Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_cluster.yml` if the Rancher server is installed on a Kubernetes cluster) or are using the embedded kubectl via the UI.
 
         ```
         kubectl -n cattle-system \

--- a/content/rancher/v2.6/en/faq/technical/_index.md
+++ b/content/rancher/v2.6/en/faq/technical/_index.md
@@ -14,7 +14,7 @@ New password for default administrator (user-xxxxx):
 
 Kubernetes install (Helm):
 ```
-$ KUBECONFIG=./kube_config_rancher-cluster.yml
+$ KUBECONFIG=./kube_config_cluster.yml
 $ kubectl --kubeconfig $KUBECONFIG -n cattle-system exec $(kubectl --kubeconfig $KUBECONFIG -n cattle-system get pods -l app=rancher --no-headers | head -1 | awk '{ print $1 }') -c rancher -- reset-password
 New password for default administrator (user-xxxxx):
 <new_password>
@@ -33,7 +33,7 @@ New password for default administrator (user-xxxxx):
 
 Kubernetes install (Helm):
 ```
-$ KUBECONFIG=./kube_config_rancher-cluster.yml
+$ KUBECONFIG=./kube_config_cluster.yml
 $ kubectl --kubeconfig $KUBECONFIG -n cattle-system exec $(kubectl --kubeconfig $KUBECONFIG -n cattle-system get pods -l app=rancher | grep '1/1' | head -1 | awk '{ print $1 }') -- ensure-default-admin
 New password for default administrator (user-xxxxx):
 <new_password>

--- a/content/rancher/v2.6/en/installation/other-installation-methods/air-gap/launch-kubernetes/_index.md
+++ b/content/rancher/v2.6/en/installation/other-installation-methods/air-gap/launch-kubernetes/_index.md
@@ -206,7 +206,7 @@ rke up --config ./rancher-cluster.yml
 Save a copy of the following files in a secure location:
 
 - `rancher-cluster.yml`: The RKE cluster configuration file.
-- `kube_config_rancher-cluster.yml`: The [Kubeconfig file]({{<baseurl>}}/rke/latest/en/kubeconfig/) for the cluster, this file contains credentials for full access to the cluster.
+- `kube_config_cluster.yml`: The [Kubeconfig file]({{<baseurl>}}/rke/latest/en/kubeconfig/) for the cluster, this file contains credentials for full access to the cluster.
 - `rancher-cluster.rkestate`: The [Kubernetes Cluster State file]({{<baseurl>}}/rke/latest/en/installation/#kubernetes-cluster-state), this file contains the current state of the cluster including the RKE configuration and the certificates.<br/><br/>_The Kubernetes Cluster State file is only created when using RKE v0.2.0 or higher._
 {{% /tab %}}
 {{% /tabs %}}

--- a/content/rancher/v2.6/en/installation/other-installation-methods/behind-proxy/launch-kubernetes/_index.md
+++ b/content/rancher/v2.6/en/installation/other-installation-methods/behind-proxy/launch-kubernetes/_index.md
@@ -112,12 +112,12 @@ After that, you can create the Kubernetes cluster by running:
 rke up --config rancher-cluster.yaml
 ```
 
-RKE creates a state file called `rancher-cluster.rkestate`, this is needed if you want to perform updates, modify your cluster configuration or restore it from a backup. It also creates a `kube_config_rancher-cluster.yaml` file, that you can use to connect to the remote Kubernetes cluster locally with tools like kubectl or Helm. Make sure to save all of these files in a secure location, for example by putting them into a version control system.
+RKE creates a state file called `rancher-cluster.rkestate`, this is needed if you want to perform updates, modify your cluster configuration or restore it from a backup. It also creates a `kube_config_cluster.yaml` file, that you can use to connect to the remote Kubernetes cluster locally with tools like kubectl or Helm. Make sure to save all of these files in a secure location, for example by putting them into a version control system.
 
 To have a look at your cluster run:
 
 ```
-export KUBECONFIG=kube_config_rancher-cluster.yaml
+export KUBECONFIG=kube_config_cluster.yaml
 kubectl cluster-info
 kubectl get pods --all-namespaces
 ```
@@ -139,7 +139,7 @@ default backend - 404
 Save a copy of the following files in a secure location:
 
 - `rancher-cluster.yml`: The RKE cluster configuration file.
-- `kube_config_rancher-cluster.yml`: The [Kubeconfig file]({{<baseurl>}}/rke/latest/en/kubeconfig/) for the cluster, this file contains credentials for full access to the cluster.
+- `kube_config_cluster.yml`: The [Kubeconfig file]({{<baseurl>}}/rke/latest/en/kubeconfig/) for the cluster, this file contains credentials for full access to the cluster.
 - `rancher-cluster.rkestate`: The [Kubernetes Cluster State file]({{<baseurl>}}/rke/latest/en/installation/#kubernetes-cluster-state), this file contains the current state of the cluster including the RKE configuration and the certificates.
 
 > **Note:** The "rancher-cluster" parts of the two latter file names are dependent on how you name the RKE cluster configuration file.

--- a/content/rancher/v2.6/en/installation/resources/k8s-tutorials/ha-RKE/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/k8s-tutorials/ha-RKE/_index.md
@@ -95,14 +95,14 @@ This section describes how to set up your workspace so that you can interact wit
 
 Assuming you have installed `kubectl`, you need to place the `kubeconfig` file in a location where `kubectl` can reach it. The `kubeconfig` file contains the credentials necessary to access your cluster with `kubectl`.
 
-When you ran `rke up`, RKE should have created a `kubeconfig` file named `kube_config_rancher-cluster.yml`. This file has the credentials for `kubectl` and `helm`.
+When you ran `rke up`, RKE should have created a `kubeconfig` file named `kube_config_cluster.yml`. This file has the credentials for `kubectl` and `helm`.
 
 > **Note:** If you have used a different file name from `rancher-cluster.yml`, then the kube config file will be named `kube_config_<FILE_NAME>.yml`.
 
-Move this file to `$HOME/.kube/config`, or if you are working with multiple Kubernetes clusters, set the `KUBECONFIG` environmental variable to the path of `kube_config_rancher-cluster.yml`:
+Move this file to `$HOME/.kube/config`, or if you are working with multiple Kubernetes clusters, set the `KUBECONFIG` environmental variable to the path of `kube_config_cluster.yml`:
 
 ```
-export KUBECONFIG=$(pwd)/kube_config_rancher-cluster.yml
+export KUBECONFIG=$(pwd)/kube_config_cluster.yml
 ```
 
 Test your connectivity with `kubectl` and see if all your nodes are in `Ready` state:
@@ -153,7 +153,7 @@ This confirms that you have successfully installed a Kubernetes cluster that the
 Save a copy of the following files in a secure location:
 
 - `rancher-cluster.yml`: The RKE cluster configuration file.
-- `kube_config_rancher-cluster.yml`: The [Kubeconfig file]({{<baseurl>}}/rke/latest/en/kubeconfig/) for the cluster, this file contains credentials for full access to the cluster.
+- `kube_config_cluster.yml`: The [Kubeconfig file]({{<baseurl>}}/rke/latest/en/kubeconfig/) for the cluster, this file contains credentials for full access to the cluster.
 - `rancher-cluster.rkestate`: The [Kubernetes Cluster State file]({{<baseurl>}}/rke/latest/en/installation/#kubernetes-cluster-state), this file contains credentials for full access to the cluster.<br/><br/>_The Kubernetes Cluster State file is only created when using RKE v0.2.0 or higher._
 
 > **Note:** The "rancher-cluster" parts of the two latter file names are dependent on how you name the RKE cluster configuration file.

--- a/content/rancher/v2.6/en/overview/architecture/_index.md
+++ b/content/rancher/v2.6/en/overview/architecture/_index.md
@@ -75,7 +75,7 @@ The authentication proxy forwards all Kubernetes API calls to downstream cluster
 
 Rancher communicates with Kubernetes clusters using a [service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/), which provides an identity for processes that run in a pod.
 
-By default, Rancher generates a [kubeconfig file]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/cluster-access/kubectl/) that contains credentials for proxying through the Rancher server to connect to the Kubernetes API server on a downstream user cluster. The kubeconfig file (`kube_config_rancher-cluster.yml`) contains full access to the cluster.
+By default, Rancher generates a [kubeconfig file]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/cluster-access/kubectl/) that contains credentials for proxying through the Rancher server to connect to the Kubernetes API server on a downstream user cluster. The kubeconfig file (`kube_config_cluster.yml`) contains full access to the cluster.
 
 ### 2. Cluster Controllers and Cluster Agents
 
@@ -129,7 +129,7 @@ You will need to use a context defined in this kubeconfig file to access the clu
 The files mentioned below are needed to maintain, troubleshoot and upgrade your cluster:
 
 - `rancher-cluster.yml`: The RKE cluster configuration file.
-- `kube_config_rancher-cluster.yml`: The Kubeconfig file for the cluster, this file contains credentials for full access to the cluster. You can use this file to authenticate with a Rancher-launched Kubernetes cluster if Rancher goes down.
+- `kube_config_cluster.yml`: The Kubeconfig file for the cluster, this file contains credentials for full access to the cluster. You can use this file to authenticate with a Rancher-launched Kubernetes cluster if Rancher goes down.
 - `rancher-cluster.rkestate`: The Kubernetes cluster state file. This file contains credentials for full access to the cluster. Note: This state file is only created when using RKE v0.2.0 or higher.
 
 > **Note:** The "rancher-cluster" parts of the two latter file names are dependent on how you name the RKE cluster configuration file.

--- a/content/rancher/v2.6/en/troubleshooting/dns/_index.md
+++ b/content/rancher/v2.6/en/troubleshooting/dns/_index.md
@@ -5,7 +5,7 @@ weight: 103
 
 The commands/steps listed on this page can be used to check name resolution issues in your cluster.
 
-Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_rancher-cluster.yml` for Rancher HA) or are using the embedded kubectl via the UI.
+Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_cluster.yml` for Rancher HA) or are using the embedded kubectl via the UI.
 
 Before running the DNS checks, check the [default DNS provider]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/options/#default-dns-provider) for your cluster and make sure that [the overlay network is functioning correctly]({{<baseurl>}}/rancher/v2.6/en/troubleshooting/networking/#check-if-overlay-network-is-functioning-correctly) as this can also be the reason why DNS resolution (partly) fails.
 

--- a/content/rancher/v2.6/en/troubleshooting/kubernetes-resources/_index.md
+++ b/content/rancher/v2.6/en/troubleshooting/kubernetes-resources/_index.md
@@ -5,7 +5,7 @@ weight: 101
 
 The commands/steps listed on this page can be used to check the most important Kubernetes resources and apply to [Rancher Launched Kubernetes]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/) clusters.
 
-Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_rancher-cluster.yml` for Rancher HA) or are using the embedded kubectl via the UI.
+Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_cluster.yml` for Rancher HA) or are using the embedded kubectl via the UI.
 
 - [Nodes](#nodes)
   - [Get nodes](#get-nodes)

--- a/content/rancher/v2.6/en/troubleshooting/logging/_index.md
+++ b/content/rancher/v2.6/en/troubleshooting/logging/_index.md
@@ -16,7 +16,7 @@ The following log levels are used in Rancher:
 * Kubernetes install
  * Configure debug log level
 ```
-$ KUBECONFIG=./kube_config_rancher-cluster.yml
+$ KUBECONFIG=./kube_config_cluster.yml
 $ kubectl -n cattle-system get pods -l app=rancher --no-headers -o custom-columns=name:.metadata.name | while read rancherpod; do kubectl -n cattle-system exec $rancherpod -c rancher -- loglevel --set debug; done
 OK
 OK
@@ -26,7 +26,7 @@ $ kubectl -n cattle-system logs -l app=rancher -c rancher
 
  * Configure info log level
 ```
-$ KUBECONFIG=./kube_config_rancher-cluster.yml
+$ KUBECONFIG=./kube_config_cluster.yml
 $ kubectl -n cattle-system get pods -l app=rancher --no-headers -o custom-columns=name:.metadata.name | while read rancherpod; do kubectl -n cattle-system exec $rancherpod -c rancher -- loglevel --set info; done
 OK
 OK

--- a/content/rancher/v2.6/en/troubleshooting/networking/_index.md
+++ b/content/rancher/v2.6/en/troubleshooting/networking/_index.md
@@ -5,7 +5,7 @@ weight: 102
 
 The commands/steps listed on this page can be used to check networking related issues in your cluster.
 
-Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_rancher-cluster.yml` for Rancher HA) or are using the embedded kubectl via the UI.
+Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_cluster.yml` for Rancher HA) or are using the embedded kubectl via the UI.
 
 ### Double check if all the required ports are opened in your (host) firewall
 

--- a/content/rancher/v2.6/en/troubleshooting/rancherha/_index.md
+++ b/content/rancher/v2.6/en/troubleshooting/rancherha/_index.md
@@ -5,7 +5,7 @@ weight: 104
 
 The commands/steps listed on this page can be used to check your Rancher Kubernetes Installation.
 
-Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_rancher-cluster.yml`).
+Make sure you configured the correct kubeconfig (for example, `export KUBECONFIG=$PWD/kube_config_cluster.yml`).
 
 ### Check Rancher pods
 


### PR DESCRIPTION
### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
