### PR TITLE
correct key lengths

### DIFF
--- a/content/rke/latest/en/config-options/secrets-encryption/_index.md
+++ b/content/rke/latest/en/config-options/secrets-encryption/_index.md
@@ -126,7 +126,7 @@ With custom encryption configuration, RKE allows the user to provide their own c
 
 The following describes the steps required to configure custom encryption with a user provided 32-byte random key.
 
-Step 1: Generate a 32 byte random key and base64 encode it. If you're on Linux or macOS, run the following command:
+Step 1: Generate a 32-byte random key and base64 encode it. If you're on Linux or macOS, run the following command:
 
 ```
 head -c 32 /dev/urandom | base64

--- a/content/rke/latest/en/config-options/secrets-encryption/_index.md
+++ b/content/rke/latest/en/config-options/secrets-encryption/_index.md
@@ -56,7 +56,7 @@ services:
 ```
 Once enabled, RKE will perform the following [actions](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#encrypting-your-data) to enable at-rest data encryption:
 
-- Generate a new random 32-bit encryption key
+- Generate a new random 32-byte encryption key
 - Generate an encryption provider configuration file using the new key The default [provider](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#providers) used is `aescbc`
 - Deploy the provider configuration file to all nodes with `controlplane` role
 - Update the `kube-apiserver` container arguments to point to the provider configuration file.
@@ -105,7 +105,7 @@ OPTIONS:
 ```
 This command will perform the following actions:
 
-- Generate a new random 32-bit encryption key
+- Generate a new random 32-byte encryption key
 - Generate a new provider configuration with the new key as the first provider and the second key as the second provider. When the secrets are rewritten, the first key will be used to encrypt the data on the write operation, while the second key (the old key) will be used to decrypt the stored data during the the read operation
 - Deploy the new provider configuration to all `controlplane` nodes and restart the `kube-apiserver`
 - Rewrite all secrets. This process will re-encrypt all the secrets with the new key.


### PR DESCRIPTION
I'm no cryptographer, but 32 //bits// for encryption/decryption keys for AES sound dangerously small. Later on in this same document, 32 //bytes// are mentioned. Is that the intended size?

### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
