### PR TITLE
Removed outdated TOC links in 2.5, 2.6

### DIFF
--- a/content/rancher/v2.5/en/cluster-provisioning/_index.md
+++ b/content/rancher/v2.5/en/cluster-provisioning/_index.md
@@ -25,7 +25,6 @@ This section covers the following topics:
   - [Launching Kubernetes and Provisioning Nodes in an Infrastructure Provider](#launching-kubernetes-and-provisioning-nodes-in-an-infrastructure-provider)
   - [Launching Kubernetes on Existing Custom Nodes](#launching-kubernetes-on-existing-custom-nodes)
 - [Registering Existing Clusters](#registering-existing-clusters)
-- [Importing Existing Clusters](#importing-existing-clusters)
 
   <!-- /TOC -->
 

--- a/content/rancher/v2.6/en/cluster-provisioning/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/_index.md
@@ -20,7 +20,6 @@ This section covers the following topics:
   - [Launching Kubernetes and Provisioning Nodes in an Infrastructure Provider](#launching-kubernetes-and-provisioning-nodes-in-an-infrastructure-provider)
   - [Launching Kubernetes on Existing Custom Nodes](#launching-kubernetes-on-existing-custom-nodes)
 - [Registering Existing Clusters](#registering-existing-clusters)
-- [Importing Existing Clusters](#importing-existing-clusters)
 
   <!-- /TOC -->
 


### PR DESCRIPTION
Removed TOC links that are no longer valid for removed sections:

https://rancher.com/docs/rancher/v2.5/en/cluster-provisioning/#importing-existing-clusters
https://rancher.com/docs/rancher/v2.6/en/cluster-provisioning/#importing-existing-clusters