### PR TITLE
Update k3s HA install to cover changes with the token

### DIFF
--- a/content/k3s/latest/en/installation/ha/_index.md
+++ b/content/k3s/latest/en/installation/ha/_index.md
@@ -63,7 +63,7 @@ Agent nodes need a URL to register against. This can be the IP or hostname of an
 
 This endpoint can also be used for accessing the Kubernetes API. So you can, for example, modify your [kubeconfig](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) file to point to it instead of a specific node. To avoid certificate errors in such a configuration, you should install the server with the `--tls-san YOUR_IP_OR_HOSTNAME_HERE` option. This option adds an additional hostname or IP as a Subject Alternative Name in the TLS cert, and it can be specified multiple times if you would like to access via both the IP and the hostname.
 
-### 4. Options: Join Additional Server Nodes
+### 4. Optional: Join Additional Server Nodes
 
 The same example command in Step 2 can be used to join additional server nodes, where the token from the first node needs to be used.
 

--- a/content/k3s/latest/en/installation/ha/_index.md
+++ b/content/k3s/latest/en/installation/ha/_index.md
@@ -33,12 +33,13 @@ You will first need to create an external datastore for the cluster. See the [Cl
 ### 2. Launch Server Nodes
 K3s requires two or more server nodes for this HA configuration. See the [Installation Requirements]({{<baseurl>}}/k3s/latest/en/installation/installation-requirements/) guide for minimum machine requirements.
 
-When running the `k3s server` command on these nodes, you must set the `datastore-endpoint` parameter so that K3s knows how to connect to the external datastore.
+When running the `k3s server` command on these nodes, you must set the `datastore-endpoint` parameter so that K3s knows how to connect to the external datastore. The `token` parameter can also be used to set a deterministic token when adding nodes, when empty this token will be generated automatically for further use.
 
-For example, a command like the following could be used to install the K3s server with a MySQL database as the external datastore:
+For example, a command like the following could be used to install the K3s server with a MySQL database as the external datastore and [set a token]({{<baseurl>}}/k3s/latest/en/installation/install-options/server-config/#cluster-options}}):
 
-```
+```bash
 curl -sfL https://get.k3s.io | sh -s - server \
+  --token=SECRET \
   --datastore-endpoint="mysql://username:password@tcp(hostname:3306)/database-name"
 ```
 
@@ -62,12 +63,31 @@ Agent nodes need a URL to register against. This can be the IP or hostname of an
 
 This endpoint can also be used for accessing the Kubernetes API. So you can, for example, modify your [kubeconfig](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) file to point to it instead of a specific node. To avoid certificate errors in such a configuration, you should install the server with the `--tls-san YOUR_IP_OR_HOSTNAME_HERE` option. This option adds an additional hostname or IP as a Subject Alternative Name in the TLS cert, and it can be specified multiple times if you would like to access via both the IP and the hostname.
 
-### 4. Optional: Join Agent Nodes
+### 4. Options: Join Additional Server Nodes
+
+The same example command in Step 2 can be used to join additional server nodes, where the token from the first node needs to be used.
+
+If the first server node was started without the `--token` CLI flag or `K3S_TOKEN` variable, the token value can be retrieved from any server already joined to the cluster:
+```bash
+cat /var/lib/rancher/k3s/server/token
+```
+
+Additional server nodes can then be added [using the token]({{<baseurl>}}/k3s/latest/en/installation/install-options/server-config/#cluster-options}}):
+
+```bash
+curl -sfL https://get.k3s.io | sh -s - server \
+  --token=SECRET \
+  --datastore-endpoint="mysql://username:password@tcp(hostname:3306)/database-name"
+```
+
+> **Note:** Ensure that you retain a copy of this token as it is required when restoring from backup and adding nodes. Previously, K3s did not enforce the use of a token when using external SQL datastores.
+
+### 5. Optional: Join Agent Nodes
 
 Because K3s server nodes are schedulable by default, the minimum number of nodes for an HA K3s server cluster is two server nodes and zero agent nodes. To add nodes designated to run your apps and services, join agent nodes to your cluster.
 
 Joining agent nodes in an HA cluster is the same as joining agent nodes in a single server cluster. You just need to specify the URL the agent should register to and the token it should use.
 
-```
+```bash
 K3S_TOKEN=SECRET k3s agent --server https://fixed-registration-address:6443
 ```

--- a/content/k3s/latest/en/installation/ha/_index.md
+++ b/content/k3s/latest/en/installation/ha/_index.md
@@ -33,7 +33,7 @@ You will first need to create an external datastore for the cluster. See the [Cl
 ### 2. Launch Server Nodes
 K3s requires two or more server nodes for this HA configuration. See the [Installation Requirements]({{<baseurl>}}/k3s/latest/en/installation/installation-requirements/) guide for minimum machine requirements.
 
-When running the `k3s server` command on these nodes, you must set the `datastore-endpoint` parameter so that K3s knows how to connect to the external datastore. The `token` parameter can also be used to set a deterministic token when adding nodes, when empty this token will be generated automatically for further use.
+When running the `k3s server` command on these nodes, you must set the `datastore-endpoint` parameter so that K3s knows how to connect to the external datastore. The `token` parameter can also be used to set a deterministic token when adding nodes. When empty, this token will be generated automatically for further use.
 
 For example, a command like the following could be used to install the K3s server with a MySQL database as the external datastore and [set a token]({{<baseurl>}}/k3s/latest/en/installation/install-options/server-config/#cluster-options}}):
 


### PR DESCRIPTION
In recent k3s versions, [the token must](https://github.com/k3s-io/k3s/releases/tag/v1.19.13%2Bk3s1) be used to join additional server nodes, updated to add suggests reflecting more prominent use of the token.

As additional server nodes are needed in an HA install, added a dedicated step for adding the additional nodes to avoid confusion.
