### PR TITLE
[K3s] Updated link to Github repo for klipper-lb

### DIFF
--- a/content/k3s/latest/en/networking/_index.md
+++ b/content/k3s/latest/en/networking/_index.md
@@ -42,7 +42,7 @@ To migrate from an older Traefik v1 instance please refer to the [Traefik docume
 
 # Service Load Balancer
 
-Any service load balancer (LB) can be leveraged in your Kubernetes cluster. K3s provides a load balancer known as [Klipper Load Balancer](https://github.com/rancher/klipper-lb) that uses available host ports.
+Any service load balancer (LB) can be leveraged in your Kubernetes cluster. K3s provides a load balancer known as [Klipper Load Balancer](https://github.com/k3s-io/klipper-lb) that uses available host ports.
 
 Upstream Kubernetes allows a Service of type LoadBalancer to be created, but doesn't include the implementation of the LB. Some LB services require a cloud provider such as Amazon EC2 or Microsoft Azure. By contrast, the K3s service LB makes it possible to use an LB service without a cloud provider.
 


### PR DESCRIPTION
The klipper-lb repo was moved from github.com/rancher to github.com/k3s-io, updating the link on the networking page to reflect this.

> NOTE: this repository has been recently (2020-11-18) moved out of the github.com/rancher org to github.com/k3s-io supporting the acceptance of K3s as a CNCF sandbox project.
