### PR TITLE
Add networkpolicy for metrics-server in hardened k3s

### DIFF
--- a/content/k3s/latest/en/security/hardening_guide/_index.md
+++ b/content/k3s/latest/en/security/hardening_guide/_index.md
@@ -302,9 +302,23 @@ spec:
   - Ingress
 ```
 
-If you are using the default traefik ingress controller with k3s, it will also be blocked by default, so the following network policies must be added to allow traffic to both traefik pods and svclb pods in the kube-system namespace. For version 1.20 and below there is a different label `traefik` used than in 1.21 and above, so remove the one that is not associated with your Kubernetes version.
+A few of the packaged components may also need NetworkPolicies applied to allow them to work properly. For example, metrics-server will only work intermittently and the Traefik ingress controller will be blocked by default if not supplying the below policies. For Traefik in k3s version 1.20 and below there is a different `traefik` label used than in 1.21 and above, so remove the one in the below yaml that is not associated with your Kubernetes version.
 
 ```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-metrics-server
+  namespace: kube-system
+spec:
+  podSelector:
+    matchLabels:
+      k8s-app: metrics-server
+  ingress:
+  - {}
+  policyTypes:
+  - Ingress
+---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -319,7 +333,7 @@ spec:
   policyTypes:
   - Ingress
 ---
-# 1.20
+# Below is for 1.20 ONLY -- remove if on 1.21 or above
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -334,7 +348,7 @@ spec:
   policyTypes:
   - Ingress
 ---
-# 1.21
+# Below is for 1.21 and above ONLY -- remove if on 1.20 or below
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/content/k3s/latest/en/security/hardening_guide/_index.md
+++ b/content/k3s/latest/en/security/hardening_guide/_index.md
@@ -302,7 +302,7 @@ spec:
   - Ingress
 ```
 
-A few of the packaged components may also need NetworkPolicies applied to allow them to work properly. For example, metrics-server will only work intermittently and the Traefik ingress controller will be blocked by default if not supplying the below policies. For Traefik in k3s version 1.20 and below there is a different `traefik` label used than in 1.21 and above, so remove the one in the below yaml that is not associated with your Kubernetes version.
+The metrics-server and Traefik ingress controller will be blocked by default if network policies are not created to allow access. Traefik v1 as packaged in K3s version 1.20 and below uses different labels than Traefik v2; ensure that you only use the sample yaml below that is associated with the version of Traefik present on your cluster.
 
 ```yaml
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
Addresses https://github.com/k3s-io/k3s/issues/4496

### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
