### PR TITLE
Documented workarounds for Rancher backup-operator Fleet issues in 2.5, 2.6

### DIFF
--- a/content/rancher/v2.5/en/backups/_index.md
+++ b/content/rancher/v2.5/en/backups/_index.md
@@ -63,6 +63,8 @@ The Backup and Restore custom resources can be created in the Rancher UI, or by 
 
 The `rancher-backup` operator can be installed from the Rancher UI, or with the Helm CLI. In both cases, the `rancher-backup` Helm chart is installed on the Kubernetes cluster running the Rancher server. It is a cluster-admin only feature and available only for the **local** cluster.  (*If you do not see `rancher-backup` in the Rancher UI, you may have selected the wrong cluster.*)
 
+>**NOTE:** There are two known issues in Fleet that occur after performing a restoration using the backup-restore-operator: Fleet agents are inoperable and clientSecretName and helmSecretName are not included in Fleet gitrepos. Refer [here]({{<baseurl>}}rancher/v2.5/en/deploy-across-clusters/fleet/#troubleshooting) for workarounds.
+
 ### Installing rancher-backup with the Rancher UI
 
 1. In the Rancher UI's Cluster Manager, choose the cluster named **local**

--- a/content/rancher/v2.5/en/backups/back-up-rancher/_index.md
+++ b/content/rancher/v2.5/en/backups/back-up-rancher/_index.md
@@ -28,6 +28,8 @@ Backups are created as .tar.gz files. These files can be pushed to S3 or Minio, 
 1. Click **Rancher Backups.**
 1. Configure the default storage location. For help, refer to the [storage configuration section.](../configuration/storage-config)
 
+>**NOTE:** There is a [known Fleet issue](https://github.com/rancher/backup-restore-operator/issues/164) in Rancher v2.5 that occurs after performing a restoration using the backup-restore-operator. Fleet agents in both the local and downstream Rancher clusters are unable to connect. A temporary workaround may be found [here]({{<baseurl>}}rancher/v2.5/en/deploy-across-clusters/fleet/#troubleshooting).
+
 ### 2. Perform a Backup
 
 To perform a backup, a custom resource of type Backup must be created.

--- a/content/rancher/v2.5/en/backups/back-up-rancher/_index.md
+++ b/content/rancher/v2.5/en/backups/back-up-rancher/_index.md
@@ -28,7 +28,7 @@ Backups are created as .tar.gz files. These files can be pushed to S3 or Minio, 
 1. Click **Rancher Backups.**
 1. Configure the default storage location. For help, refer to the [storage configuration section.](../configuration/storage-config)
 
->**NOTE:** There is a [known Fleet issue](https://github.com/rancher/backup-restore-operator/issues/164) in Rancher v2.5 that occurs after performing a restoration using the backup-restore-operator. Fleet agents in both the local and downstream Rancher clusters are unable to connect. A temporary workaround may be found [here]({{<baseurl>}}rancher/v2.5/en/deploy-across-clusters/fleet/#troubleshooting).
+>**NOTE:** There are two known issues in Fleet that occur after performing a restoration using the backup-restore-operator: Fleet agents are inoperable and clientSecretName and helmSecretName are not included in Fleet gitrepos. Refer [here]({{<baseurl>}}rancher/v2.5/en/deploy-across-clusters/fleet/#troubleshooting) for workarounds.
 
 ### 2. Perform a Backup
 

--- a/content/rancher/v2.5/en/deploy-across-clusters/fleet/_index.md
+++ b/content/rancher/v2.5/en/deploy-across-clusters/fleet/_index.md
@@ -52,7 +52,7 @@ For details on using Fleet behind a proxy, see [this page.](./proxy)
 * **Temporary Workaround:** </br>
         1. Find the two service account tokens listed in the fleet-controller and the fleet-controller-bootstrap service accounts. These are under the fleet-system namespace of the local cluster. </br>
         2. Remove the non-existent token secret. Doing so allows for only one entry to be present for the service account token secret that actually exists. </br> 
-        3. Delete the fleet-controller Pod in the fleet-system Namespace to reschedule. </br>
+        3. Delete the fleet-controller Pod in the fleet-system namespace to reschedule. </br>
         4. After the service account token issue is resolved, you can force redeployment of the fleet-agents. In the Rancher UI, go to **☰ > Cluster Management**, click on **Clusters** page, then click **Force Update**. </br> 
         5. If the fleet-agent bundles remain in a `Modified` state after Step 4, update the field `spec.forceSyncGeneration` for the fleet-agent bundle to force re-creation.
 

--- a/content/rancher/v2.5/en/deploy-across-clusters/fleet/_index.md
+++ b/content/rancher/v2.5/en/deploy-across-clusters/fleet/_index.md
@@ -16,6 +16,7 @@ Fleet is a separate project from Rancher, and can be installed on any Kubernetes
 - [Windows Support](#windows-support)
 - [GitHub Repository](#github-repository)
 - [Using Fleet Behind a Proxy](#using-fleet-behind-a-proxy)
+- [Troubleshooting](#troubleshooting)
 - [Documentation](#documentation)
 
 # Architecture
@@ -43,6 +44,16 @@ The Fleet Helm charts are available [here.](https://github.com/rancher/fleet/rel
 _Available as of v2.5.8_
 
 For details on using Fleet behind a proxy, see [this page.](./proxy)
+
+# Troubleshooting
+
+- **Known Issue:** Fleet in Rancher v2.5 becomes inoperable after a restore using the [backup-restore operator](({{<baseurl>}}rancher/v2.5/en/backups/back-up-rancher/#install-the-rancher-backup-operator)). We will update the community once a permanent solution is in place.
+- **Temporary Workaround:** </br> 
+        1. Find the two service account tokens listed in the fleet-controller and the fleet-controller-bootstrap service accounts. These are under the fleet-system Namespace of the local cluster. </br>
+        2. Remove the non-existent token secret. Doing so allows for only one entry to be present for the service account token secret that actually exists. </br> 
+        3. Delete the fleet-controller Pod in the fleet-system Namespace to reschedule. </br>
+        4. After the service account token issue is resolved, you can force redeployment of the fleet-agents. In the Rancher UI, go to **☰ > Cluster Management**, click on **Clusters** page, then click **Force Update**. </br> 
+        5. If the fleet-agent bundles remain in a `Modified` state after Step 4, use the command `spec.forceSyncGeneration` for fleet-agent bundle to force re-creation.
 
 # Documentation
 

--- a/content/rancher/v2.5/en/deploy-across-clusters/fleet/_index.md
+++ b/content/rancher/v2.5/en/deploy-across-clusters/fleet/_index.md
@@ -47,14 +47,18 @@ For details on using Fleet behind a proxy, see [this page.](./proxy)
 
 # Troubleshooting
 
-- **Known Issue:** Fleet in Rancher v2.5 becomes inoperable after a restore using the [backup-restore operator](({{<baseurl>}}rancher/v2.5/en/backups/back-up-rancher/#install-the-rancher-backup-operator)). We will update the community once a permanent solution is in place.
-- **Temporary Workaround:** </br> 
-        1. Find the two service account tokens listed in the fleet-controller and the fleet-controller-bootstrap service accounts. These are under the fleet-system Namespace of the local cluster. </br>
-        2. Remove the non-existent token secret. Doing so allows for only one entry to be present for the service account token secret that actually exists. </br> 
-        3. Delete the fleet-controller Pod in the fleet-system Namespace to reschedule. </br>
-        4. After the service account token issue is resolved, you can force redeployment of the fleet-agents. In the Rancher UI, go to **☰ > Cluster Management**, click on **Clusters** page, then click **Force Update**. </br> 
-        5. If the fleet-agent bundles remain in a `Modified` state after Step 4, use the command `spec.forceSyncGeneration` for fleet-agent bundle to force re-creation.
+**Known Issue:** 
 
+Fleet in Rancher v2.5 becomes inoperable after a restore using the [backup-restore operator]({{<baseurl>}}rancher/v2.5/en/backups/back-up-rancher/#1-install-the-rancher-backup-operator). We will update the community once a permanent solution is in place. 
+
+**Temporary Workaround**:
+
+1. Find the two service account tokens listed in the fleet-controller and the fleet-controller-bootstrap service accounts. These are under the fleet-system Namespace of the local cluster. </br>
+2. Remove the non-existent token secret. Doing so allows for only one entry to be present for the service account token secret that actually exists. </br> 
+3. Delete the fleet-controller Pod in the fleet-system Namespace to reschedule. </br>
+4. After the service account token issue is resolved, you can force redeployment of the fleet-agents. In the Rancher UI, go to **☰ > Cluster Management**, click on **Clusters** page, then click **Force Update**. </br> 
+5. If the fleet-agent bundles remain in a `Modified` state after Step 4, use the command `spec.forceSyncGeneration` for fleet-agent bundle to force re-creation.
+      
 # Documentation
 
 The Fleet documentation is at [https://fleet.rancher.io/.](https://fleet.rancher.io/)

--- a/content/rancher/v2.5/en/deploy-across-clusters/fleet/_index.md
+++ b/content/rancher/v2.5/en/deploy-across-clusters/fleet/_index.md
@@ -54,7 +54,7 @@ For details on using Fleet behind a proxy, see [this page.](./proxy)
         2. Remove the non-existent token secret. Doing so allows for only one entry to be present for the service account token secret that actually exists. </br> 
         3. Delete the fleet-controller Pod in the fleet-system Namespace to reschedule. </br>
         4. After the service account token issue is resolved, you can force redeployment of the fleet-agents. In the Rancher UI, go to **☰ > Cluster Management**, click on **Clusters** page, then click **Force Update**. </br> 
-        5. If the fleet-agent bundles remain in a `Modified` state after Step 4, use the command `spec.forceSyncGeneration` for the fleet-agent bundle to force re-creation.
+        5. If the fleet-agent bundles remain in a `Modified` state after Step 4, update the field `spec.forceSyncGeneration` for the fleet-agent bundle to force re-creation.
 
 ---
 * **Known Issue:** clientSecretName and helmSecretName secrets for Fleet gitrepos are not included in the backup nor restore created by the [backup-restore-operator]({{<baseurl>}}rancher/v2.5/en/backups/back-up-rancher/#1-install-the-rancher-backup-operator). We will update the community once a permanent solution is in place. 

--- a/content/rancher/v2.5/en/deploy-across-clusters/fleet/_index.md
+++ b/content/rancher/v2.5/en/deploy-across-clusters/fleet/_index.md
@@ -50,7 +50,7 @@ For details on using Fleet behind a proxy, see [this page.](./proxy)
 * **Known Issue:** Fleet becomes inoperable after a restore using the [backup-restore-operator]({{<baseurl>}}rancher/v2.5/en/backups/back-up-rancher/#1-install-the-rancher-backup-operator). We will update the community once a permanent solution is in place. 
 
 * **Temporary Workaround:** </br>
-        1. Find the two service account tokens listed in the fleet-controller and the fleet-controller-bootstrap service accounts. These are under the fleet-system Namespace of the local cluster. </br>
+        1. Find the two service account tokens listed in the fleet-controller and the fleet-controller-bootstrap service accounts. These are under the fleet-system namespace of the local cluster. </br>
         2. Remove the non-existent token secret. Doing so allows for only one entry to be present for the service account token secret that actually exists. </br> 
         3. Delete the fleet-controller Pod in the fleet-system Namespace to reschedule. </br>
         4. After the service account token issue is resolved, you can force redeployment of the fleet-agents. In the Rancher UI, go to **☰ > Cluster Management**, click on **Clusters** page, then click **Force Update**. </br> 

--- a/content/rancher/v2.5/en/deploy-across-clusters/fleet/_index.md
+++ b/content/rancher/v2.5/en/deploy-across-clusters/fleet/_index.md
@@ -46,18 +46,23 @@ _Available as of v2.5.8_
 For details on using Fleet behind a proxy, see [this page.](./proxy)
 
 # Troubleshooting
+---
+* **Known Issue:** Fleet becomes inoperable after a restore using the [backup-restore-operator]({{<baseurl>}}rancher/v2.5/en/backups/back-up-rancher/#1-install-the-rancher-backup-operator). We will update the community once a permanent solution is in place. 
 
-**Known Issue:** 
+* **Temporary Workaround:** </br>
+        1. Find the two service account tokens listed in the fleet-controller and the fleet-controller-bootstrap service accounts. These are under the fleet-system Namespace of the local cluster. </br>
+        2. Remove the non-existent token secret. Doing so allows for only one entry to be present for the service account token secret that actually exists. </br> 
+        3. Delete the fleet-controller Pod in the fleet-system Namespace to reschedule. </br>
+        4. After the service account token issue is resolved, you can force redeployment of the fleet-agents. In the Rancher UI, go to **☰ > Cluster Management**, click on **Clusters** page, then click **Force Update**. </br> 
+        5. If the fleet-agent bundles remain in a `Modified` state after Step 4, use the command `spec.forceSyncGeneration` for the fleet-agent bundle to force re-creation.
 
-Fleet in Rancher v2.5 becomes inoperable after a restore using the [backup-restore operator]({{<baseurl>}}rancher/v2.5/en/backups/back-up-rancher/#1-install-the-rancher-backup-operator). We will update the community once a permanent solution is in place. 
+---
+* **Known Issue:** clientSecretName and helmSecretName secrets for Fleet gitrepos are not included in the backup nor restore created by the [backup-restore-operator]({{<baseurl>}}rancher/v2.5/en/backups/back-up-rancher/#1-install-the-rancher-backup-operator). We will update the community once a permanent solution is in place. 
 
-**Temporary Workaround**:
+* **Temporary Workaround:** </br>
+By default, user-defined secrets are not backed up in Fleet. It is necessary to recreate secrets if performing a disaster recovery restore or migration of Rancher into a fresh cluster. To modify resourceSet to include extra resources you want to backup, refer to docs [here](https://github.com/rancher/backup-restore-operator#user-flow).
 
-1. Find the two service account tokens listed in the fleet-controller and the fleet-controller-bootstrap service accounts. These are under the fleet-system Namespace of the local cluster. </br>
-2. Remove the non-existent token secret. Doing so allows for only one entry to be present for the service account token secret that actually exists. </br> 
-3. Delete the fleet-controller Pod in the fleet-system Namespace to reschedule. </br>
-4. After the service account token issue is resolved, you can force redeployment of the fleet-agents. In the Rancher UI, go to **☰ > Cluster Management**, click on **Clusters** page, then click **Force Update**. </br> 
-5. If the fleet-agent bundles remain in a `Modified` state after Step 4, use the command `spec.forceSyncGeneration` for fleet-agent bundle to force re-creation.
+---
       
 # Documentation
 

--- a/content/rancher/v2.6/en/backups/_index.md
+++ b/content/rancher/v2.6/en/backups/_index.md
@@ -47,6 +47,8 @@ The Backup and Restore custom resources can be created in the Rancher UI, or by 
 
 The `rancher-backup` operator can be installed from the Rancher UI, or with the Helm CLI. In both cases, the `rancher-backup` Helm chart is installed on the Kubernetes cluster running the Rancher server. It is a cluster-admin only feature and available only for the **local** cluster.  (*If you do not see `rancher-backup` in the Rancher UI, you may have selected the wrong cluster.*)
 
+>**NOTE:** There is a known issue in Fleet that occurs after performing a restoration using the backup-restore-operator: Secrets used for clientSecretName and helmSecretName are not included in Fleet gitrepos. Refer [here]({{<baseurl>}}rancher/v2.6/en/deploy-across-clusters/fleet/#troubleshooting) for a workaround.
+
 ### Installing rancher-backup with the Rancher UI
 
 1. In the upper left corner, click **☰ > Cluster Management**.

--- a/content/rancher/v2.6/en/backups/back-up-rancher/_index.md
+++ b/content/rancher/v2.6/en/backups/back-up-rancher/_index.md
@@ -25,6 +25,8 @@ Backups are created as .tar.gz files. These files can be pushed to S3 or Minio, 
 1. Configure the default storage location. For help, refer to the [storage configuration section.](../configuration/storage-config)
 1. Click **Install**.
 
+>**NOTE:** There is a known issue in Fleet that occurs after performing a restoration using the backup-restore-operator: Secrets used for clientSecretName and helmSecretName are not included in Fleet gitrepos. Refer [here]({{<baseurl>}}rancher/v2.6/en/deploy-across-clusters/fleet/#troubleshooting) for a workaround.
+
 ### 2. Perform a Backup
 
 To perform a backup, a custom resource of type Backup must be created.

--- a/content/rancher/v2.6/en/deploy-across-clusters/fleet/_index.md
+++ b/content/rancher/v2.6/en/deploy-across-clusters/fleet/_index.md
@@ -12,6 +12,7 @@ Fleet is a separate project from Rancher, and can be installed on any Kubernetes
 - [Windows Support](#windows-support)
 - [GitHub Repository](#github-repository)
 - [Using Fleet Behind a Proxy](#using-fleet-behind-a-proxy)
+- [Troubleshooting](#troubleshooting)
 - [Documentation](#documentation)
 
 # Architecture
@@ -35,6 +36,16 @@ The Fleet Helm charts are available [here.](https://github.com/rancher/fleet/rel
 # Using Fleet Behind a Proxy
 
 For details on using Fleet behind a proxy, see [this page.](./proxy)
+
+# Troubleshooting
+
+---
+* **Known Issue:** clientSecretName and helmSecretName secrets for Fleet gitrepos are not included in the backup nor restore created by the [backup-restore-operator]({{<baseurl>}}rancher/v2.6/en/backups/back-up-rancher/#1-install-the-rancher-backups-operator). We will update the community once a permanent solution is in place. 
+
+* **Temporary Workaround:** </br>
+By default, user-defined secrets are not backed up in Fleet. It is necessary to recreate secrets if performing a disaster recovery restore or migration of Rancher into a fresh cluster. To modify resourceSet to include extra resources you want to backup, refer to docs [here](https://github.com/rancher/backup-restore-operator#user-flow).
+
+---
 
 # Documentation
 


### PR DESCRIPTION
Closes #3665 

Created small troubleshooting sections for Fleet in Rancher; added pointers in backup-restore-operator sections in 2.5, 2.6 that point to new workarounds in troubleshooting. 
