### PR TITLE
Document command to get RKE2 server logs

### DIFF
--- a/content/rancher/v2.6/en/troubleshooting/kubernetes-components/controlplane/_index.md
+++ b/content/rancher/v2.6/en/troubleshooting/kubernetes-components/controlplane/_index.md
@@ -38,3 +38,11 @@ docker logs kube-apiserver
 docker logs kube-controller-manager
 docker logs kube-scheduler
 ```
+
+# RKE2 Server Logging
+
+If Rancher provisions an RKE2 cluster that can't communicate with Rancher, you can run this command on a server node in the downstream cluster to get the RKE2 server logs:
+
+```
+journalctl -u rke2-server -f
+```


### PR DESCRIPTION
Caleb Warren showed me this command which made it clear why an RKE2 cluster was provisioning. It turned out that the private registry was missing some images, but there was no descriptive error message about that. So this command could help someone whose cluster gets stuck provisioning.

I looked for a relevant troubleshooting section in the cluster provisioning docs, but it didn't fit with what was there already, so I put it under troubleshooting Kubernetes components. I'm open to moving it if there's a better place to put it.