### PR TITLE
Added section for Helm chart dependencies in Fleet for 2.5, 2.6

### DIFF
--- a/content/rancher/v2.5/en/deploy-across-clusters/fleet/_index.md
+++ b/content/rancher/v2.5/en/deploy-across-clusters/fleet/_index.md
@@ -16,6 +16,7 @@ Fleet is a separate project from Rancher, and can be installed on any Kubernetes
 - [Windows Support](#windows-support)
 - [GitHub Repository](#github-repository)
 - [Using Fleet Behind a Proxy](#using-fleet-behind-a-proxy)
+- [Fleet Helm Chart Dependencies](#fleet-helm-chart-dependencies)
 - [Troubleshooting](#troubleshooting)
 - [Documentation](#documentation)
 
@@ -44,6 +45,12 @@ The Fleet Helm charts are available [here.](https://github.com/rancher/fleet/rel
 _Available as of v2.5.8_
 
 For details on using Fleet behind a proxy, see [this page.](./proxy)
+
+# Fleet Helm Chart Dependencies
+
+In order for the Helm chart dependencies in Fleet to deploy successfully, you must run a manual command (as listed below) to let Fleet know where to retrieve them. If you do not do this and proceed to clone your repository and run `helm install`, your installation will fail because the dependencies will be missing.
+
+The Helm chart in the git repository must include its dependencies in the charts subdirectory. You must either manually run `helm dependencies update` OR run `helm dependencies build` locally, then commit the complete charts directory to your git repository.
 
 # Troubleshooting
 ---

--- a/content/rancher/v2.5/en/deploy-across-clusters/fleet/_index.md
+++ b/content/rancher/v2.5/en/deploy-across-clusters/fleet/_index.md
@@ -16,7 +16,7 @@ Fleet is a separate project from Rancher, and can be installed on any Kubernetes
 - [Windows Support](#windows-support)
 - [GitHub Repository](#github-repository)
 - [Using Fleet Behind a Proxy](#using-fleet-behind-a-proxy)
-- [Fleet Helm Chart Dependencies](#fleet-helm-chart-dependencies)
+- [Helm Chart Dependencies](#helm-chart-dependencies)
 - [Troubleshooting](#troubleshooting)
 - [Documentation](#documentation)
 
@@ -46,11 +46,11 @@ _Available as of v2.5.8_
 
 For details on using Fleet behind a proxy, see [this page.](./proxy)
 
-# Fleet Helm Chart Dependencies
+# Helm Chart Dependencies
 
-In order for the Helm chart dependencies in Fleet to deploy successfully, you must run a manual command (as listed below) to let Fleet know where to retrieve them. If you do not do this and proceed to clone your repository and run `helm install`, your installation will fail because the dependencies will be missing.
+In order for Helm charts with dependencies to deploy successfully, you must run a manual command (as listed below), as it is up to the user to fulfill the dependency list. If you do not do this and proceed to clone your repository and run `helm install`, your installation will fail because the dependencies will be missing.
 
-The Helm chart in the git repository must include its dependencies in the charts subdirectory. You must either manually run `helm dependencies update` OR run `helm dependencies build` locally, then commit the complete charts directory to your git repository.
+The Helm chart in the git repository must include its dependencies in the charts subdirectory. You must either manually run `helm dependencies update $chart` OR run `helm dependencies build $chart` locally, then commit the complete charts directory to your git repository. Note that you will update your commands with the applicable parameters.
 
 # Troubleshooting
 ---

--- a/content/rancher/v2.6/en/deploy-across-clusters/fleet/_index.md
+++ b/content/rancher/v2.6/en/deploy-across-clusters/fleet/_index.md
@@ -12,6 +12,7 @@ Fleet is a separate project from Rancher, and can be installed on any Kubernetes
 - [Windows Support](#windows-support)
 - [GitHub Repository](#github-repository)
 - [Using Fleet Behind a Proxy](#using-fleet-behind-a-proxy)
+- [Fleet Helm Chart Dependencies](#fleet-helm-chart-dependencies)
 - [Troubleshooting](#troubleshooting)
 - [Documentation](#documentation)
 
@@ -36,6 +37,12 @@ The Fleet Helm charts are available [here.](https://github.com/rancher/fleet/rel
 # Using Fleet Behind a Proxy
 
 For details on using Fleet behind a proxy, see [this page.](./proxy)
+
+# Fleet Helm Chart Dependencies
+
+In order for the Helm chart dependencies in Fleet to deploy successfully, you must run a manual command (as listed below) to let Fleet know where to retrieve them. If you do not do this and proceed to clone your repository and run `helm install`, your installation will fail because the dependencies will be missing.
+
+The Helm chart in the git repository must include its dependencies in the charts subdirectory. You must either manually run `helm dependencies update` OR run `helm dependencies build` locally, then commit the complete charts directory to your git repository.
 
 # Troubleshooting
 

--- a/content/rancher/v2.6/en/deploy-across-clusters/fleet/_index.md
+++ b/content/rancher/v2.6/en/deploy-across-clusters/fleet/_index.md
@@ -12,7 +12,7 @@ Fleet is a separate project from Rancher, and can be installed on any Kubernetes
 - [Windows Support](#windows-support)
 - [GitHub Repository](#github-repository)
 - [Using Fleet Behind a Proxy](#using-fleet-behind-a-proxy)
-- [Fleet Helm Chart Dependencies](#fleet-helm-chart-dependencies)
+- [Helm Chart Dependencies](#helm-chart-dependencies)
 - [Troubleshooting](#troubleshooting)
 - [Documentation](#documentation)
 
@@ -38,11 +38,11 @@ The Fleet Helm charts are available [here.](https://github.com/rancher/fleet/rel
 
 For details on using Fleet behind a proxy, see [this page.](./proxy)
 
-# Fleet Helm Chart Dependencies
+# Helm Chart Dependencies
 
-In order for the Helm chart dependencies in Fleet to deploy successfully, you must run a manual command (as listed below) to let Fleet know where to retrieve them. If you do not do this and proceed to clone your repository and run `helm install`, your installation will fail because the dependencies will be missing.
+In order for Helm charts with dependencies to deploy successfully, you must run a manual command (as listed below), as it is up to the user to fulfill the dependency list. If you do not do this and proceed to clone your repository and run `helm install`, your installation will fail because the dependencies will be missing.
 
-The Helm chart in the git repository must include its dependencies in the charts subdirectory. You must either manually run `helm dependencies update` OR run `helm dependencies build` locally, then commit the complete charts directory to your git repository.
+The Helm chart in the git repository must include its dependencies in the charts subdirectory. You must either manually run `helm dependencies update $chart` OR run `helm dependencies build $chart` locally, then commit the complete charts directory to your git repository. Note that you will update your commands with the applicable parameters.
 
 # Troubleshooting
 


### PR DESCRIPTION
Closes #3705; related https://github.com/rancher/fleet/issues/250.