### PR TITLE
Add missing steps for recovering from cert expiration

### DIFF
--- a/content/rancher/v2.6/en/troubleshooting/expired-webhook-certificates/_index.md
+++ b/content/rancher/v2.6/en/troubleshooting/expired-webhook-certificates/_index.md
@@ -10,6 +10,7 @@ Rancher will advise the community once there is a permanent solution in place fo
 ##### 1. Users with cluster access, run the following commands:
 ```
 kubectl delete secret -n cattle-system cattle-webhook-tls
+kubectl delete mutatingwebhookconfigurations.admissionregistration.k8s.io rancher.cattle.io
 kubectl delete pod -n cattle-system -l app=rancher-webhook
 ```
 
@@ -17,6 +18,8 @@ kubectl delete pod -n cattle-system -l app=rancher-webhook
 
 1. Delete the `cattle-webhook-tls` secret in the `cattle-system` namespace in the local cluster.
 
-1. Delete the `rancher-webhook` pod in the `cattle-system` namespace in the local cluster.
+2. Delete the `rancher.cattle.io` mutating webhook
+
+3. Delete the `rancher-webhook` pod in the `cattle-system` namespace in the local cluster.
 
 **Note:** The webhook certificate expiration issue is not specific to `cattle-webhook-tls` as listed in the examples. You will fill in your expired certificate secret accordingly.

--- a/content/rancher/v2.6/en/troubleshooting/expired-webhook-certificates/_index.md
+++ b/content/rancher/v2.6/en/troubleshooting/expired-webhook-certificates/_index.md
@@ -10,7 +10,7 @@ Rancher will advise the community once there is a permanent solution in place fo
 ##### 1. Users with cluster access, run the following commands:
 ```
 kubectl delete secret -n cattle-system cattle-webhook-tls
-kubectl delete mutatingwebhookconfigurations.admissionregistration.k8s.io rancher.cattle.io
+kubectl delete mutatingwebhookconfigurations.admissionregistration.k8s.io --ignore-not-found=true rancher.cattle.io
 kubectl delete pod -n cattle-system -l app=rancher-webhook
 ```
 


### PR DESCRIPTION
Add instructions for deleting the mutating webhook, If this is not done, the rancher-webhook pod will not be able to recreate the certificate.

rancher-webhook will recreate the mutating webhook on startup :+1: 

### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
