### PR TITLE
Add newly available etcd-arg

### DIFF
--- a/content/k3s/latest/en/installation/install-options/server-config/_index.md
+++ b/content/k3s/latest/en/installation/install-options/server-config/_index.md
@@ -152,6 +152,7 @@ the agent options are there because the server has the agent process embedded wi
 
 | Flag |  Description |
 |------|--------------|
+| `--etcd-arg` value | Customized flag for etcd process |
 | `--kube-apiserver-arg` value | Customized flag for kube-apiserver process |
 | `--kube-scheduler-arg` value | Customized flag for kube-scheduler process |
 | `--kube-controller-manager-arg` value  | Customized flag for kube-controller-manager process    |
@@ -234,6 +235,7 @@ OPTIONS:
    --token-file value                         (cluster) File containing the cluster-secret/token [$K3S_TOKEN_FILE]
    --write-kubeconfig value, -o value         (client) Write kubeconfig for admin client to this file [$K3S_KUBECONFIG_OUTPUT]
    --write-kubeconfig-mode value              (client) Write kubeconfig with this mode [$K3S_KUBECONFIG_MODE]
+   --etcd-arg value                           (flags) Customized flag for etcd process
    --kube-apiserver-arg value                 (flags) Customized flag for kube-apiserver process
    --kube-scheduler-arg value                 (flags) Customized flag for kube-scheduler process
    --kube-controller-manager-arg value        (flags) Customized flag for kube-controller-manager process


### PR DESCRIPTION
Adds the newly available environment variable in k3s to our official docs.

### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
