### PR TITLE
Add cert info/links for kubelet serving cert

### DIFF
--- a/content/rancher/v2.5/en/cluster-admin/certificate-rotation/_index.md
+++ b/content/rancher/v2.5/en/cluster-admin/certificate-rotation/_index.md
@@ -12,7 +12,8 @@ By default, Kubernetes clusters require certificates and Rancher launched Kubern
 Certificates can be rotated for the following services:
 
 - etcd
-- kubelet
+- kubelet (node certificate)
+- kubelet (serving certificate, if [enabled]({{<baseurl>}}/rke/latest/en/config-options/services/#kubelet-options))
 - kube-apiserver
 - kube-proxy
 - kube-scheduler

--- a/content/rancher/v2.6/en/cluster-admin/certificate-rotation/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/certificate-rotation/_index.md
@@ -10,7 +10,8 @@ By default, Kubernetes clusters require certificates and Rancher launched Kubern
 Certificates can be rotated for the following services:
 
 - etcd
-- kubelet
+- kubelet (node certificate)
+- kubelet (serving certificate, if [enabled]({{<baseurl>}}/rke/latest/en/config-options/services/#kubelet-options))
 - kube-apiserver
 - kube-proxy
 - kube-scheduler


### PR DESCRIPTION
Closes https://github.com/rancher/docs/issues/3332

### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
