### PR TITLE
Added more info for CD in 2.5, 2.6

### DIFF
--- a/content/rancher/v2.5/en/deploy-across-clusters/fleet/_index.md
+++ b/content/rancher/v2.5/en/deploy-across-clusters/fleet/_index.md
@@ -26,7 +26,24 @@ For information about how Fleet works, see [this page.](./architecture)
 
 # Accessing Fleet in the Rancher UI
 
-Fleet comes preinstalled in Rancher v2.5. To access it, go to the **Cluster Explorer** in the Rancher UI. In the top left dropdown menu, click **Cluster Explorer > Continuous Delivery.** On this page, you can edit Kubernetes resources and cluster groups managed by Fleet.
+Fleet comes preinstalled in Rancher v2.5. Users can leverage continuous delivery to deploy their applications to the Kubernetes clusters in the git repository without any manual operation by following **gitops** practice. For additional information on Continuous Delivery and other Fleet troubleshooting tips, refer [here](https://fleet.rancher.io/troubleshooting/).
+
+Follow the steps below to access Continuous Delivery in the Rancher UI:
+
+1. Click **Cluster Explorer** in the Rancher UI. 
+
+1. In the top left dropdown menu, click **Cluster Explorer > Continuous Delivery.**
+
+1. Select your namespace at the top of the menu, noting the following: 
+    - By default,`fleet-default` is selected which includes all downstream clusters that are registered through Rancher. 
+    - You may switch to `fleet-local`, which only contains the `local` cluster, or you may create your own workspace to which you may assign and move clusters. 
+    - You can then manage clusters by clicking on **Clusters** on the left navigation bar.
+
+1. Click on **Gitrepos** on the left navigation bar to deploy the gitrepo into your clusters in the current workspace. 
+
+1. Select your [git repository](https://fleet.rancher.io/gitrepo-add/) and [target clusters/cluster group](https://fleet.rancher.io/gitrepo-structure/). You can also create the cluster group in the UI by clicking on **Cluster Groups** from the left navigation bar.
+
+1. Once the gitrepo is deployed, you can monitor the application through the Rancher UI.
 
 # Windows Support
 

--- a/content/rancher/v2.6/en/deploy-across-clusters/fleet/_index.md
+++ b/content/rancher/v2.6/en/deploy-across-clusters/fleet/_index.md
@@ -22,7 +22,24 @@ For information about how Fleet works, see [this page.](./architecture)
 
 # Accessing Fleet in the Rancher UI
 
-Fleet comes preinstalled in Rancher. To access it, click **☰ > Continuous Delivery**.
+Fleet comes preinstalled in Rancher and is managed by the **Continous Delivery** option in the Rancher UI. For additional information on Continuous Delivery and other Fleet troubleshooting tips, refer [here](https://fleet.rancher.io/troubleshooting/).
+
+Users can leverage continuous delivery to deploy their applications to the Kubernetes clusters in the git repository without any manual operation by following **gitops** practice.
+
+Follow the steps below to access Continuous Delivery in the Rancher UI:
+
+1. Click **☰ > Continuous Delivery**.
+
+1. Select your namespace at the top of the menu, noting the following: 
+    - By default,`fleet-default` is selected which includes all downstream clusters that are registered through Rancher. 
+    - You may switch to `fleet-local`, which only contains the `local` cluster, or you may create your own workspace to which you may assign and move clusters. 
+    - You can then manage clusters by clicking on **Clusters** on the left navigation bar.
+
+1. Click on **Gitrepos** on the left navigation bar to deploy the gitrepo into your clusters in the current workspace. 
+
+1. Select your [git repository](https://fleet.rancher.io/gitrepo-add/) and [target clusters/cluster group](https://fleet.rancher.io/gitrepo-structure/). You can also create the cluster group in the UI by clicking on **Cluster Groups** from the left navigation bar.
+
+1. Once the gitrepo is deployed, you can monitor the application through the Rancher UI.
 
 # Windows Support
 


### PR DESCRIPTION
Closes #3057 

References: 
https://rancher.com/docs/rancher/v2.6/en/deploy-across-clusters/fleet/
https://rancher.com/docs/rancher/v2.5/en/deploy-across-clusters/fleet/
https://jira.suse.com/browse/SURE-3124?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel

- Added more on navigation and context behind CD. Added links for specifics back to Fleet docs, to include troubleshooting tips such as "what happens when you force update Fleet clusters".