### PR TITLE
Added rancher.cattle-system to no-proxy list in 2.5 with explanation

### DIFF
--- a/content/rancher/v2.5/en/installation/other-installation-methods/behind-proxy/install-rancher/_index.md
+++ b/content/rancher/v2.5/en/installation/other-installation-methods/behind-proxy/install-rancher/_index.md
@@ -62,7 +62,7 @@ kubectl create namespace cattle-system
 
 And install Rancher with Helm. Rancher also needs a proxy configuration so that it can communicate with external application catalogs or retrieve Kubernetes version update metadata. 
 
-Note that `rancher.cattle-system` must be added to the noProxy list (as shown below) so that Rancher can communicate directly with Kubernetes service DNS using service discovery.
+Note that `rancher.cattle-system` must be added to the noProxy list (as shown below) so that Fleet can communicate directly to Rancher with Kubernetes service DNS using service discovery.
 
 ```
 helm upgrade --install rancher rancher-latest/rancher \

--- a/content/rancher/v2.5/en/installation/other-installation-methods/behind-proxy/install-rancher/_index.md
+++ b/content/rancher/v2.5/en/installation/other-installation-methods/behind-proxy/install-rancher/_index.md
@@ -60,14 +60,16 @@ Create a namespace:
 kubectl create namespace cattle-system
 ```
 
-And install Rancher with Helm. Rancher also needs a proxy configuration so that it can communicate with external application catalogs or retrieve Kubernetes version update metadata:
+And install Rancher with Helm. Rancher also needs a proxy configuration so that it can communicate with external application catalogs or retrieve Kubernetes version update metadata. 
+
+Note that `rancher.cattle-system` must be added to the noProxy list (as shown below) so that Rancher can communicate directly with Kubernetes service DNS using service discovery.
 
 ```
 helm upgrade --install rancher rancher-latest/rancher \
    --namespace cattle-system \
    --set hostname=rancher.example.com \
    --set proxy=http://${proxy_host}
-   --set noProxy=127.0.0.0/8\\,10.0.0.0/8\\,cattle-system.svc\\,172.16.0.0/12\\,192.168.0.0/16\\,.svc\\,.cluster.local
+   --set noProxy=127.0.0.0/8\\,10.0.0.0/8\\,cattle-system.svc\\,172.16.0.0/12\\,192.168.0.0/16\\,.svc\\,.cluster.local,rancher.cattle-system
 ```
 
 After waiting for the deployment to finish:


### PR DESCRIPTION
See https://github.com/rancher/fleet/issues/142

Reference: https://rancher.com/docs/rancher/v2.5/en/installation/other-installation-methods/behind-proxy/install-rancher/#install-rancher