### PR TITLE
Update image list with awk and sed

### DIFF
--- a/content/rancher/v2.5/en/installation/other-installation-methods/air-gap/populate-private-registry/_index.md
+++ b/content/rancher/v2.5/en/installation/other-installation-methods/air-gap/populate-private-registry/_index.md
@@ -66,7 +66,7 @@ In a Kubernetes Install, if you elect to use the Rancher default self-signed TLS
     helm repo add jetstack https://charts.jetstack.io
     helm repo update
     helm fetch jetstack/cert-manager --version v1.5.1
-    helm template ./cert-manager-<version>.tgz | awk '$1 ~ /image:/ {print $2}' | sed s/\"//g' >> ./rancher-images.txt
+    helm template ./cert-manager-<version>.tgz | awk '$1 ~ /image:/ {print $2}' | sed s/\"//g >> ./rancher-images.txt
     ```
 
 2.  Sort and unique the images list to remove any overlap between the sources:

--- a/content/rancher/v2.5/en/installation/other-installation-methods/air-gap/populate-private-registry/_index.md
+++ b/content/rancher/v2.5/en/installation/other-installation-methods/air-gap/populate-private-registry/_index.md
@@ -66,7 +66,7 @@ In a Kubernetes Install, if you elect to use the Rancher default self-signed TLS
     helm repo add jetstack https://charts.jetstack.io
     helm repo update
     helm fetch jetstack/cert-manager --version v1.5.1
-    helm template ./cert-manager-<version>.tgz | grep -oP '(?<=image: ").*(?=")' >> ./rancher-images.txt
+    helm template ./cert-manager-<version>.tgz | awk '$1 ~ /image:/ {print $2}' | sed s/\"//g' >> ./rancher-images.txt
     ```
 
 2.  Sort and unique the images list to remove any overlap between the sources:
@@ -237,7 +237,7 @@ The workstation must have Docker 18.02+ in order to support manifests, which are
    helm repo add jetstack https://charts.jetstack.io
    helm repo update
    helm fetch jetstack/cert-manager --version v0.12.0
-   helm template ./cert-manager-<version>.tgz | grep -oP '(?<=image: ").*(?=")' >> ./rancher-images.txt
+   helm template ./cert-manager-<version>.tgz | | awk '$1 ~ /image:/ {print $2}' | sed s/\"//g >> ./rancher-images.txt
    ```
 
 2. Sort and unique the images list to remove any overlap between the sources:

--- a/content/rancher/v2.6/en/installation/other-installation-methods/air-gap/populate-private-registry/_index.md
+++ b/content/rancher/v2.6/en/installation/other-installation-methods/air-gap/populate-private-registry/_index.md
@@ -59,7 +59,7 @@ In a Kubernetes Install, if you elect to use the Rancher default self-signed TLS
     helm repo add jetstack https://charts.jetstack.io
     helm repo update
     helm fetch jetstack/cert-manager --version v1.5.1
-    helm template ./cert-manager-<version>.tgz | grep -oP '(?<=image: ").*(?=")' >> ./rancher-images.txt
+    helm template ./cert-manager-<version>.tgz | awk '$1 ~ /image:/ {print $2}' | sed s/\"//g >> ./rancher-images.txt
     ```
 
 2.  Sort and unique the images list to remove any overlap between the sources:
@@ -230,7 +230,7 @@ The workstation must have Docker 18.02+ in order to support manifests, which are
    helm repo add jetstack https://charts.jetstack.io
    helm repo update
    helm fetch jetstack/cert-manager --version v0.12.0
-   helm template ./cert-manager-<version>.tgz | grep -oP '(?<=image: ").*(?=")' >> ./rancher-images.txt
+   helm template ./cert-manager-<version>.tgz | awk '$1 ~ /image:/ {print $2}' | sed s/\"//g >> ./rancher-images.txt
    ```
 
 2. Sort and unique the images list to remove any overlap between the sources:


### PR DESCRIPTION
Proposing this change to allow the cert-manager images to be extracted without GNU grep (no `-P` flag), for example using default tools on MacOS
