### PR TITLE
Update install command for etcdctl

### DIFF
--- a/content/k3s/latest/en/advanced/_index.md
+++ b/content/k3s/latest/en/advanced/_index.md
@@ -126,8 +126,9 @@ etcdctl provides a CLI for etcd.
 If you would like to use etcdctl after installing K3s with embedded etcd, install etcdctl using the [official documentation.](https://etcd.io/docs/latest/install/) 
 
 ```
-$ VERSION="v3.5.0" curl -L https://github.com/etcd-io/etcd/releases/download/${VERSION}/etcd-${VERSION}-linux-amd64.tar.gz --output etcdctl-linux-amd64.tar.gz
-$ sudo tar -zxvf etcdctl-linux-amd64.tar.gz --strip-components=1 -C /usr/local/bin etcd-v3.5.0-linux-amd64/etcdctl
+$ VERSION="v3.5.0"
+$ curl -L https://github.com/etcd-io/etcd/releases/download/${VERSION}/etcd-${VERSION}-linux-amd64.tar.gz --output etcdctl-linux-amd64.tar.gz
+$ sudo tar -zxvf etcdctl-linux-amd64.tar.gz --strip-components=1 -C /usr/local/bin etcd-${VERSION}-linux-amd64/etcdctl
 ```
 
 Then start using etcdctl commands with the appropriate K3s flags:

--- a/content/k3s/latest/en/advanced/_index.md
+++ b/content/k3s/latest/en/advanced/_index.md
@@ -126,9 +126,8 @@ etcdctl provides a CLI for etcd.
 If you would like to use etcdctl after installing K3s with embedded etcd, install etcdctl using the [official documentation.](https://etcd.io/docs/latest/install/) 
 
 ```
-$ VERSION="v3.5.0"
-$ curl -L https://github.com/etcd-io/etcd/releases/download/${VERSION}/etcd-${VERSION}-linux-amd64.tar.gz --output etcdctl-${VERSION}-linux-amd64.tar.gz
-$ sudo tar -zxvf etcdctl-${VERSION}-linux-amd64.tar.gz -C /usr/local/bin
+$ VERSION="v3.5.0" curl -L https://github.com/etcd-io/etcd/releases/download/${VERSION}/etcd-${VERSION}-linux-amd64.tar.gz --output etcdctl-linux-amd64.tar.gz
+$ sudo tar -zxvf etcdctl-linux-amd64.tar.gz --strip-components=1 -C /usr/local/bin etcd-v3.5.0-linux-amd64/etcdctl
 ```
 
 Then start using etcdctl commands with the appropriate K3s flags:


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

The k3s info on how to install etcdctl (written by me) does not correctly move etcdctl into a user's PATH. This is now fixed.