### PR TITLE
Update vagrant quickstart IP

### DIFF
--- a/content/rancher/v2.5/en/quick-start-guide/deployment/quickstart-vagrant/_index.md
+++ b/content/rancher/v2.5/en/quick-start-guide/deployment/quickstart-vagrant/_index.md
@@ -32,7 +32,7 @@ The following steps quickly deploy a Rancher Server with a single node cluster a
 
 4. To initiate the creation of the environment run, `vagrant up --provider=virtualbox`.
 
-5. Once provisioning finishes, go to `https://172.22.101.101` in the browser. The default user/password is `admin/admin`.
+5. Once provisioning finishes, go to `https://192.168.56.101` in the browser. The default user/password is `admin/admin`.
 
 **Result:** Rancher Server and your Kubernetes cluster is installed on VirtualBox.
 

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/quickstart-vagrant/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/quickstart-vagrant/_index.md
@@ -30,7 +30,7 @@ The following steps quickly deploy a Rancher Server with a single node cluster a
 
 4. To initiate the creation of the environment run, `vagrant up --provider=virtualbox`.
 
-5. Once provisioning finishes, go to `https://172.22.101.101` in the browser. The default user/password is `admin/admin`.
+5. Once provisioning finishes, go to `https://192.168.56.101` in the browser. The default user/password is `admin/admin`.
 
 **Result:** Rancher Server and your Kubernetes cluster is installed on VirtualBox.
 


### PR DESCRIPTION
The IPs were changed in https://github.com/rancher/quickstart/pull/191 to support the latest VirtualBox version on Mac