### PR TITLE
Documented disabling nm-cloud-setup.service and nm-cloud-setup.timer in RKE and Rancher 2 Cluster Provisioning Docs

### DIFF
--- a/content/rancher/v2.5/en/cluster-provisioning/node-requirements/_index.md
+++ b/content/rancher/v2.5/en/cluster-provisioning/node-requirements/_index.md
@@ -32,6 +32,13 @@ For information on how to install Docker, refer to the official [Docker document
 
 Some distributions of Linux derived from RHEL, including Oracle Linux, may have default firewall rules that block communication with Helm. We recommend disabling firewalld. For Kubernetes 1.19, firewalld must be turned off.
 
+>**Note:** In RHEL 8.4, two extra services are included on the NetworkManager: `nm-cloud-setup.service` and `nm-cloud-setup.timer`. These services add a routing table that interferes with the CNI plugin's configuration. If these services are enabled, you must disable them using the command below, and then reboot the node to restore connectivity:
+>  
+>  ```
+   systemctl disable nm-cloud-setup.service nm-cloud-setup.timer
+   reboot
+   ```
+
 ### SUSE Linux Nodes
 
 SUSE Linux may have a firewall that blocks all ports by default. In that situation, follow [these steps]({{<baseurl>}}/rancher/v2.5/en/installation/requirements/ports/#opening-suse-linux-ports) to open the ports needed for adding a host to a custom cluster.

--- a/content/rancher/v2.6/en/cluster-provisioning/node-requirements/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/node-requirements/_index.md
@@ -30,6 +30,13 @@ For information on how to install Docker, refer to the official [Docker document
 
 Some distributions of Linux derived from RHEL, including Oracle Linux, may have default firewall rules that block communication with Helm. We recommend disabling firewalld. For Kubernetes 1.19, firewalld must be turned off.
 
+>**Note:** In RHEL 8.4, two extra services are included on the NetworkManager: `nm-cloud-setup.service` and `nm-cloud-setup.timer`. These services add a routing table that interferes with the CNI plugin's configuration. If these services are enabled, you must disable them using the command below, and then reboot the node to restore connectivity:
+>  
+>  ```
+   systemctl disable nm-cloud-setup.service nm-cloud-setup.timer
+   reboot
+   ```
+
 ### SUSE Linux Nodes
 
 SUSE Linux may have a firewall that blocks all ports by default. In that situation, follow [these steps]({{<baseurl>}}/rancher/v2.6/en/installation/requirements/ports/#opening-suse-linux-ports) to open the ports needed for adding a host to a custom cluster.

--- a/content/rke/latest/en/os/_index.md
+++ b/content/rke/latest/en/os/_index.md
@@ -148,6 +148,13 @@ https://kubic.opensuse.org/blog/2021-02-08-MicroOS-Kubic-Rancher-RKE/
 
 If using Red Hat Enterprise Linux, Oracle Linux or CentOS, you cannot use the `root` user as [SSH user]({{<baseurl>}}/rke/latest/en/config-options/nodes/#ssh-user) due to [Bugzilla 1527565](https://bugzilla.redhat.com/show_bug.cgi?id=1527565). Please follow the instructions below how to setup Docker correctly, based on the way you installed Docker on the node.
 
+>**Note:** In RHEL 8.4, two extra services are included on the NetworkManager: `nm-cloud-setup.service` and `nm-cloud-setup.timer`. These services add a routing table that interferes with the CNI plugin's configuration. If these services are enabled, you must disable them using the command below, and then reboot the node to restore connectivity:
+>  
+>  ```
+   systemctl disable nm-cloud-setup.service nm-cloud-setup.timer
+   reboot
+   ```
+
 #### Using upstream Docker
 If you are using upstream Docker, the package name is `docker-ce` or `docker-ee`. You can check the installed package by executing:
 


### PR DESCRIPTION
Closes #3700
