### PR TITLE
fix(thoubleshooting-dns): remove duplicated kubectl get

### DIFF
--- a/content/rancher/v2.0-v2.4/en/troubleshooting/dns/_index.md
+++ b/content/rancher/v2.0-v2.4/en/troubleshooting/dns/_index.md
@@ -158,7 +158,7 @@ kubectl run -i --restart=Never --rm test-${RANDOM} --image=ubuntu --overrides='{
 Enabling query logging can be done by enabling the [log plugin](https://coredns.io/plugins/log/) in the Corefile configuration in the configmap `coredns`. You can do so by using `kubectl -n kube-system edit configmap coredns` or use the command below to replace the configuration in place:
 
 ```
-kubectl get configmap -n kube-system coredns -o json |  kubectl get configmap -n kube-system coredns -o json | sed -e 's_loadbalance_log\\n    loadbalance_g' | kubectl apply -f -
+kubectl get configmap -n kube-system coredns -o json | sed -e 's_loadbalance_log\\n    loadbalance_g' | kubectl apply -f -
 ```
 
 All queries will now be logged and can be checked using the command in [Check CoreDNS logging](#check-coredns-logging).

--- a/content/rancher/v2.5/en/troubleshooting/dns/_index.md
+++ b/content/rancher/v2.5/en/troubleshooting/dns/_index.md
@@ -160,7 +160,7 @@ kubectl run -i --restart=Never --rm test-${RANDOM} --image=ubuntu --overrides='{
 Enabling query logging can be done by enabling the [log plugin](https://coredns.io/plugins/log/) in the Corefile configuration in the configmap `coredns`. You can do so by using `kubectl -n kube-system edit configmap coredns` or use the command below to replace the configuration in place:
 
 ```
-kubectl get configmap -n kube-system coredns -o json |  kubectl get configmap -n kube-system coredns -o json | sed -e 's_loadbalance_log\\n    loadbalance_g' | kubectl apply -f -
+kubectl get configmap -n kube-system coredns -o json | sed -e 's_loadbalance_log\\n    loadbalance_g' | kubectl apply -f -
 ```
 
 All queries will now be logged and can be checked using the command in [Check CoreDNS logging](#check-coredns-logging).

--- a/content/rancher/v2.6/en/troubleshooting/dns/_index.md
+++ b/content/rancher/v2.6/en/troubleshooting/dns/_index.md
@@ -158,7 +158,7 @@ kubectl run -i --restart=Never --rm test-${RANDOM} --image=ubuntu --overrides='{
 Enabling query logging can be done by enabling the [log plugin](https://coredns.io/plugins/log/) in the Corefile configuration in the configmap `coredns`. You can do so by using `kubectl -n kube-system edit configmap coredns` or use the command below to replace the configuration in place:
 
 ```
-kubectl get configmap -n kube-system coredns -o json |  kubectl get configmap -n kube-system coredns -o json | sed -e 's_loadbalance_log\\n    loadbalance_g' | kubectl apply -f -
+kubectl get configmap -n kube-system coredns -o json | sed -e 's_loadbalance_log\\n    loadbalance_g' | kubectl apply -f -
 ```
 
 All queries will now be logged and can be checked using the command in [Check CoreDNS logging](#check-coredns-logging).


### PR DESCRIPTION
### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
