### PR TITLE
Add the API URL to the doc until this gets fixed in the dashboard.

### DIFF
--- a/content/rancher/v2.6/en/api/_index.md
+++ b/content/rancher/v2.6/en/api/_index.md
@@ -5,7 +5,7 @@ weight: 24
 
 ## How to use the API
 
-The API has its own user interface accessible from a web browser.  This is an easy way to see resources, perform actions, and see the equivalent cURL or HTTP request & response.  To access it, click on your user avatar in the upper right corner. Under **API & Keys**, you can find the URL endpoint as well as create [API keys]({{<baseurl>}}/rancher/v2.6/en/user-settings/api-keys/).
+The API has its own user interface accessible from a web browser.  This is an easy way to see resources, perform actions, and see the equivalent cURL or HTTP request & response.  To access it, click on your user avatar in the upper right corner. Under **API & Keys**, you can find the URL endpoint (`https://<rancher_fqdn>/v3`) as well as create [API keys]({{<baseurl>}}/rancher/v2.6/en/user-settings/api-keys/).
 
 ## Authentication
 


### PR DESCRIPTION
Rancher 2.6 dashboard is not showing the API endpoint URL.
Add the API URL to the doc until this gets fixed in the dashboard.


