### PR TITLE
Update quickstart docs

### DIFF
--- a/content/rancher/v2.5/en/quick-start-guide/deployment/amazon-aws-qs/_index.md
+++ b/content/rancher/v2.5/en/quick-start-guide/deployment/amazon-aws-qs/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Rancher AWS Quick Start Guide
-description: Read this step by step Rancher AWS guide to quickly deploy a Rancher Server with a single node cluster attached.
+description: Read this step by step Rancher AWS guide to quickly deploy a Rancher server with a single-node downstream Kubernetes cluster attached.
 weight: 100
 ---
 The following steps will quickly deploy a Rancher server on AWS in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
@@ -51,7 +51,7 @@ Suggestions include:
     ```
 
 8. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
-9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/aws`.
+9. ssh to the Rancher server using the `id_rsa` key generated in `quickstart/aws`.
 
 #### Result
 

--- a/content/rancher/v2.5/en/quick-start-guide/deployment/amazon-aws-qs/_index.md
+++ b/content/rancher/v2.5/en/quick-start-guide/deployment/amazon-aws-qs/_index.md
@@ -2,10 +2,8 @@
 title: Rancher AWS Quick Start Guide
 description: Read this step by step Rancher AWS guide to quickly deploy a Rancher Server with a single node cluster attached.
 weight: 100
-aliases:
-  - /rancher/v2.x/en/quick-start-guide/deployment/amazon-aws-qs/
 ---
-The following steps will quickly deploy a Rancher Server on AWS with a single node cluster attached.
+The following steps will quickly deploy a Rancher server on AWS in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
 
 ## Prerequisites
 
@@ -21,25 +19,26 @@ The following steps will quickly deploy a Rancher Server on AWS with a single no
 
 1. Clone [Rancher Quickstart](https://github.com/rancher/quickstart) to a folder using `git clone https://github.com/rancher/quickstart`.
 
-1. Go into the AWS folder containing the terraform files by executing `cd quickstart/aws`.
+2. Go into the AWS folder containing the terraform files by executing `cd quickstart/aws`.
 
-1. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
+3. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
 
-1. Edit `terraform.tfvars` and customize the following variables:
-    - `aws_access_key` - Amazon AWS Access Key
+4. Edit `terraform.tfvars` and customize the following variables:
+    - `aws_access_key` - Amazon AWS Access Key 
     - `aws_secret_key` - Amazon AWS Secret Key
     - `rancher_server_admin_password` - Admin password for created Rancher server
 
-1. **Optional:** Modify optional variables within `terraform.tfvars`.
+5. **Optional:** Modify optional variables within `terraform.tfvars`.
 See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [AWS Quickstart Readme](https://github.com/rancher/quickstart/tree/master/aws) for more information.
 Suggestions include:
-    - `aws_region` - Amazon AWS region, choose the closest instead of the default
+    - `aws_region` - Amazon AWS region, choose the closest instead of the default (`us-east-1`)
     - `prefix` - Prefix for all created resources
     - `instance_type` - EC2 instance size used, minimum is `t3a.medium` but `t3a.large` or `t3a.xlarge` could be used if within budget
+    - `add_windows_node` - If true, an additional Windows worker node is added to the workload cluster
 
-1. Run `terraform init`.
+6. Run `terraform init`.
 
-1. To initiate the creation of the environment, run `terraform apply --auto-approve`. Then wait for output similar to the following:
+7. To initiate the creation of the environment, run `terraform apply --auto-approve`. Then wait for output similar to the following:
 
     ```
     Apply complete! Resources: 16 added, 0 changed, 0 destroyed.
@@ -51,11 +50,12 @@ Suggestions include:
     workload_node_ip = yy.yy.yy.yy
     ```
 
-1. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
+8. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
+9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/aws`.
 
 #### Result
 
-Two Kubernetes clusters are deployed into your AWS account, one running Rancher Server and the other ready for experimentation deployments. Please note that while this setup is a great way to explore Rancher functionality, a production setup should follow our high availability setup guidelines.
+Two Kubernetes clusters are deployed into your AWS account, one running Rancher Server and the other ready for experimentation deployments. Please note that while this setup is a great way to explore Rancher functionality, a production setup should follow our high availability setup guidelines. SSH keys for the VMs are auto-generated and stored in the module directory.
 
 ### What's Next?
 

--- a/content/rancher/v2.5/en/quick-start-guide/deployment/digital-ocean-qs/_index.md
+++ b/content/rancher/v2.5/en/quick-start-guide/deployment/digital-ocean-qs/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Rancher DigitalOcean Quick Start Guide
-description: Read this step by step Rancher DigitalOcean guide to quickly deploy a Rancher Server with a single node cluster attached.
+description: Read this step by step Rancher DigitalOcean guide to quickly deploy a Rancher server with a single-node downstream Kubernetes cluster attached.
 weight: 100
 ---
 The following steps will quickly deploy a Rancher server on DigitalOcean in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.

--- a/content/rancher/v2.5/en/quick-start-guide/deployment/digital-ocean-qs/_index.md
+++ b/content/rancher/v2.5/en/quick-start-guide/deployment/digital-ocean-qs/_index.md
@@ -2,10 +2,8 @@
 title: Rancher DigitalOcean Quick Start Guide
 description: Read this step by step Rancher DigitalOcean guide to quickly deploy a Rancher Server with a single node cluster attached.
 weight: 100
-aliases:
-  - /rancher/v2.x/en/quick-start-guide/deployment/digital-ocean-qs/
 ---
-The following steps will quickly deploy a Rancher Server on DigitalOcean with a single node cluster attached.
+The following steps will quickly deploy a Rancher server on DigitalOcean in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
 
 ## Prerequisites
 
@@ -21,25 +19,24 @@ The following steps will quickly deploy a Rancher Server on DigitalOcean with a 
 
 1. Clone [Rancher Quickstart](https://github.com/rancher/quickstart) to a folder using `git clone https://github.com/rancher/quickstart`.
 
-1. Go into the DigitalOcean folder containing the terraform files by executing `cd quickstart/do`.
+2. Go into the DigitalOcean folder containing the terraform files by executing `cd quickstart/do`.
 
-1. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
+3. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
 
-1. Edit `terraform.tfvars` and customize the following variables:
+4. Edit `terraform.tfvars` and customize the following variables:
     - `do_token` - DigitalOcean access key
     - `rancher_server_admin_password` - Admin password for created Rancher server
 
-1. **Optional:** Modify optional variables within `terraform.tfvars`.
+5. **Optional:** Modify optional variables within `terraform.tfvars`.
 See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [DO Quickstart Readme](https://github.com/rancher/quickstart/tree/master/do) for more information.
 Suggestions include:
-    - `do_region` - DigitalOcean region, choose the closest instead of the default
+    - `do_region` - DigitalOcean region, choose the closest instead of the default (`nyc1`)
     - `prefix` - Prefix for all created resources
     - `droplet_size` - Droplet size used, minimum is `s-2vcpu-4gb` but `s-4vcpu-8gb` could be used if within budget
-    - `ssh_key_file_name` - Use a specific SSH key instead of `~/.ssh/id_rsa` (public key is assumed to be `${ssh_key_file_name}.pub`)
 
-1. Run `terraform init`.
+6. Run `terraform init`.
 
-1. To initiate the creation of the environment, run `terraform apply --auto-approve`. Then wait for output similar to the following:
+7. To initiate the creation of the environment, run `terraform apply --auto-approve`. Then wait for output similar to the following:
 
     ```
     Apply complete! Resources: 15 added, 0 changed, 0 destroyed.
@@ -51,11 +48,12 @@ Suggestions include:
     workload_node_ip = yy.yy.yy.yy
     ```
 
-1. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
+8. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
+9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/do`.
 
 #### Result
 
-Two Kubernetes clusters are deployed into your DigitalOcean account, one running Rancher Server and the other ready for experimentation deployments.
+Two Kubernetes clusters are deployed into your DigitalOcean account, one running Rancher Server and the other ready for experimentation deployments. Please note that while this setup is a great way to explore Rancher functionality, a production setup should follow our high availability setup guidelines. SSH keys for the VMs are auto-generated and stored in the module directory.
 
 ### What's Next?
 

--- a/content/rancher/v2.5/en/quick-start-guide/deployment/google-gcp-qs/_index.md
+++ b/content/rancher/v2.5/en/quick-start-guide/deployment/google-gcp-qs/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Rancher GCP Quick Start Guide
-description: Read this step by step Rancher GCP guide to quickly deploy a Rancher Server with a single node cluster attached.
+description: Read this step by step Rancher GCP guide to quickly deploy a Rancher server with a single-node downstream Kubernetes cluster attached.
 weight: 100
 ---
 The following steps will quickly deploy a Rancher server on GCP in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.

--- a/content/rancher/v2.5/en/quick-start-guide/deployment/google-gcp-qs/_index.md
+++ b/content/rancher/v2.5/en/quick-start-guide/deployment/google-gcp-qs/_index.md
@@ -2,10 +2,8 @@
 title: Rancher GCP Quick Start Guide
 description: Read this step by step Rancher GCP guide to quickly deploy a Rancher Server with a single node cluster attached.
 weight: 100
-aliases:
-  - /rancher/v2.x/en/quick-start-guide/deployment/google-gcp-qs/
 ---
-The following steps will quickly deploy a Rancher server on GCP in a single-node RKE Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
+The following steps will quickly deploy a Rancher server on GCP in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
 
 ## Prerequisites
 
@@ -22,25 +20,25 @@ The following steps will quickly deploy a Rancher server on GCP in a single-node
 
 1. Clone [Rancher Quickstart](https://github.com/rancher/quickstart) to a folder using `git clone https://github.com/rancher/quickstart`.
 
-1. Go into the GCP folder containing the terraform files by executing `cd quickstart/gcp`.
+2. Go into the GCP folder containing the terraform files by executing `cd quickstart/gcp`.
 
-1. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
+3. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
 
-1. Edit `terraform.tfvars` and customize the following variables:
-    - `gcp_account_json` - GCP service account file path and file name
+4. Edit `terraform.tfvars` and customize the following variables:
+    - `gcp_account_json` - GCP service account file path and file name 
     - `rancher_server_admin_password` - Admin password for created Rancher server
 
-1. **Optional:** Modify optional variables within `terraform.tfvars`.
+5. **Optional:** Modify optional variables within `terraform.tfvars`.
 See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [GCP Quickstart Readme](https://github.com/rancher/quickstart/tree/master/gcp) for more information.
 Suggestions include:
-    - `gcp_region` - Google GCP region, choose the closest instead of the default
+    - `gcp_region` - Google GCP region, choose the closest instead of the default (`us-east4`)
+    - `gcp_zone` - Google GCP zone, choose the closest instead of the default (`us-east4-a`)
     - `prefix` - Prefix for all created resources
     - `machine_type` - Compute instance size used, minimum is `n1-standard-1` but `n1-standard-2` or `n1-standard-4` could be used if within budget
-    - `ssh_key_file_name` - Use a specific SSH key instead of `~/.ssh/id_rsa` (public key is assumed to be `${ssh_key_file_name}.pub`)
 
-1. Run `terraform init`.
+6. Run `terraform init`.
 
-1. To initiate the creation of the environment, run `terraform apply --auto-approve`. Then wait for output similar to the following:
+7. To initiate the creation of the environment, run `terraform apply --auto-approve`. Then wait for output similar to the following:
 
     ```
     Apply complete! Resources: 16 added, 0 changed, 0 destroyed.
@@ -52,11 +50,12 @@ Suggestions include:
     workload_node_ip = yy.yy.yy.yy
     ```
 
-1. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
+8. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
+9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/gcp`.
 
 #### Result
 
-Two Kubernetes clusters are deployed into your GCP account, one running Rancher Server and the other ready for experimentation deployments.
+Two Kubernetes clusters are deployed into your GCP account, one running Rancher Server and the other ready for experimentation deployments. Please note that while this setup is a great way to explore Rancher functionality, a production setup should follow our high availability setup guidelines. SSH keys for the VMs are auto-generated and stored in the module directory.
 
 ### What's Next?
 

--- a/content/rancher/v2.5/en/quick-start-guide/deployment/microsoft-azure-qs/_index.md
+++ b/content/rancher/v2.5/en/quick-start-guide/deployment/microsoft-azure-qs/_index.md
@@ -2,11 +2,9 @@
 title: Rancher Azure Quick Start Guide
 description: Read this step by step Rancher Azure guide to quickly deploy a Rancher Server with a single node cluster attached.
 weight: 100
-aliases:
-  - /rancher/v2.x/en/quick-start-guide/deployment/microsoft-azure-qs/
 ---
 
-The following steps will quickly deploy a Rancher server on Azure in a single-node RKE Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
+The following steps will quickly deploy a Rancher server on Azure in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
 
 ## Prerequisites
 
@@ -24,27 +22,29 @@ The following steps will quickly deploy a Rancher server on Azure in a single-no
 
 1. Clone [Rancher Quickstart](https://github.com/rancher/quickstart) to a folder using `git clone https://github.com/rancher/quickstart`.
 
-1. Go into the Azure folder containing the terraform files by executing `cd quickstart/azure`.
+2. Go into the Azure folder containing the terraform files by executing `cd quickstart/azure`.
 
-1. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
+3. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
 
-1. Edit `terraform.tfvars` and customize the following variables:
-    - `azure_subscription_id` - Microsoft Azure Subscription ID
+4. Edit `terraform.tfvars` and customize the following variables:
+    - `azure_subscription_id` - Microsoft Azure Subscription ID 
     - `azure_client_id` - Microsoft Azure Client ID
     - `azure_client_secret` - Microsoft Azure Client Secret
     - `azure_tenant_id` - Microsoft Azure Tenant ID
     - `rancher_server_admin_password` - Admin password for created Rancher server
 
-2. **Optional:** Modify optional variables within `terraform.tfvars`.
+5. **Optional:** Modify optional variables within `terraform.tfvars`.
 See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [Azure Quickstart Readme](https://github.com/rancher/quickstart/tree/master/azure) for more information.
 Suggestions include:
-    - `azure_location` - Microsoft Azure region, choose the closest instead of the default
+    - `azure_location` - Microsoft Azure region, choose the closest instead of the default (`East US`)
     - `prefix` - Prefix for all created resources
     - `instance_type` - Compute instance size used, minimum is `Standard_DS2_v2` but `Standard_DS2_v3` or `Standard_DS3_v2` could be used if within budget
+    - `add_windows_node` - If true, an additional Windows worker node is added to the workload cluster
+    - `windows_admin_password` - The admin password of the windows worker node
+    
+6. Run `terraform init`.
 
-1. Run `terraform init`.
-
-1. To initiate the creation of the environment, run `terraform apply --auto-approve`. Then wait for output similar to the following:
+7. To initiate the creation of the environment, run `terraform apply --auto-approve`. Then wait for output similar to the following:
 
     ```
     Apply complete! Resources: 16 added, 0 changed, 0 destroyed.
@@ -56,11 +56,12 @@ Suggestions include:
     workload_node_ip = yy.yy.yy.yy
     ```
 
-1. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
-2. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/azure`.
+8. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
+9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/azure`.
+
 #### Result
 
-Two Kubernetes clusters are deployed into your Azure account, one running Rancher Server and the other ready for experimentation deployments.
+Two Kubernetes clusters are deployed into your Azure account, one running Rancher Server and the other ready for experimentation deployments. Please note that while this setup is a great way to explore Rancher functionality, a production setup should follow our high availability setup guidelines. SSH keys for the VMs are auto-generated and stored in the module directory.
 
 ### What's Next?
 

--- a/content/rancher/v2.5/en/quick-start-guide/deployment/microsoft-azure-qs/_index.md
+++ b/content/rancher/v2.5/en/quick-start-guide/deployment/microsoft-azure-qs/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Rancher Azure Quick Start Guide
-description: Read this step by step Rancher Azure guide to quickly deploy a Rancher Server with a single node cluster attached.
+description: Read this step by step Rancher Azure guide to quickly deploy a Rancher server with a single-node downstream Kubernetes cluster attached.
 weight: 100
 ---
 

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/amazon-aws-qs/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/amazon-aws-qs/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Rancher AWS Quick Start Guide
-description: Read this step by step Rancher AWS guide to quickly deploy a Rancher Server with a single node cluster attached.
+description: Read this step by step Rancher AWS guide to quickly deploy a Rancher server with a single-node downstream Kubernetes cluster attached.
 weight: 100
 ---
 The following steps will quickly deploy a Rancher server on AWS in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/amazon-aws-qs/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/amazon-aws-qs/_index.md
@@ -3,7 +3,7 @@ title: Rancher AWS Quick Start Guide
 description: Read this step by step Rancher AWS guide to quickly deploy a Rancher Server with a single node cluster attached.
 weight: 100
 ---
-The following steps will quickly deploy a Rancher Server on AWS with a single node cluster attached.
+The following steps will quickly deploy a Rancher server on AWS in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
 
 ## Prerequisites
 
@@ -19,25 +19,26 @@ The following steps will quickly deploy a Rancher Server on AWS with a single no
 
 1. Clone [Rancher Quickstart](https://github.com/rancher/quickstart) to a folder using `git clone https://github.com/rancher/quickstart`.
 
-1. Go into the AWS folder containing the terraform files by executing `cd quickstart/aws`.
+2. Go into the AWS folder containing the terraform files by executing `cd quickstart/aws`.
 
-1. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
+3. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
 
-1. Edit `terraform.tfvars` and customize the following variables:
+4. Edit `terraform.tfvars` and customize the following variables:
     - `aws_access_key` - Amazon AWS Access Key 
     - `aws_secret_key` - Amazon AWS Secret Key
     - `rancher_server_admin_password` - Admin password for created Rancher server
 
-1. **Optional:** Modify optional variables within `terraform.tfvars`.
+5. **Optional:** Modify optional variables within `terraform.tfvars`.
 See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [AWS Quickstart Readme](https://github.com/rancher/quickstart/tree/master/aws) for more information.
 Suggestions include:
-    - `aws_region` - Amazon AWS region, choose the closest instead of the default
+    - `aws_region` - Amazon AWS region, choose the closest instead of the default (`us-east-1`)
     - `prefix` - Prefix for all created resources
     - `instance_type` - EC2 instance size used, minimum is `t3a.medium` but `t3a.large` or `t3a.xlarge` could be used if within budget
+    - `add_windows_node` - If true, an additional Windows worker node is added to the workload cluster
 
-1. Run `terraform init`.
+6. Run `terraform init`.
 
-1. To initiate the creation of the environment, run `terraform apply --auto-approve`. Then wait for output similar to the following:
+7. To initiate the creation of the environment, run `terraform apply --auto-approve`. Then wait for output similar to the following:
 
     ```
     Apply complete! Resources: 16 added, 0 changed, 0 destroyed.
@@ -45,15 +46,16 @@ Suggestions include:
     Outputs:
 
     rancher_node_ip = xx.xx.xx.xx
-    rancher_server_url = https://rancher.xx.xx.xx.xx.xip.io
+    rancher_server_url = https://rancher.xx.xx.xx.xx.sslip.io
     workload_node_ip = yy.yy.yy.yy
     ```
 
-1. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
+8. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
+9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/aws`.
 
 #### Result
 
-Two Kubernetes clusters are deployed into your AWS account, one running Rancher Server and the other ready for experimentation deployments. Please note that while this setup is a great way to explore Rancher functionality, a production setup should follow our high availability setup guidelines.
+Two Kubernetes clusters are deployed into your AWS account, one running Rancher Server and the other ready for experimentation deployments. Please note that while this setup is a great way to explore Rancher functionality, a production setup should follow our high availability setup guidelines. SSH keys for the VMs are auto-generated and stored in the module directory.
 
 ### What's Next?
 

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/digital-ocean-qs/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/digital-ocean-qs/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Rancher DigitalOcean Quick Start Guide
-description: Read this step by step Rancher DigitalOcean guide to quickly deploy a Rancher Server with a single node cluster attached.
+description: Read this step by step Rancher DigitalOcean guide to quickly deploy a Rancher server with a single-node downstream Kubernetes cluster attached.
 weight: 100
 ---
 The following steps will quickly deploy a Rancher server on DigitalOcean in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/digital-ocean-qs/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/digital-ocean-qs/_index.md
@@ -3,7 +3,7 @@ title: Rancher DigitalOcean Quick Start Guide
 description: Read this step by step Rancher DigitalOcean guide to quickly deploy a Rancher Server with a single node cluster attached.
 weight: 100
 ---
-The following steps will quickly deploy a Rancher Server on DigitalOcean with a single node cluster attached.
+The following steps will quickly deploy a Rancher server on DigitalOcean in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
 
 ## Prerequisites
 
@@ -19,25 +19,24 @@ The following steps will quickly deploy a Rancher Server on DigitalOcean with a 
 
 1. Clone [Rancher Quickstart](https://github.com/rancher/quickstart) to a folder using `git clone https://github.com/rancher/quickstart`.
 
-1. Go into the DigitalOcean folder containing the terraform files by executing `cd quickstart/do`.
+2. Go into the DigitalOcean folder containing the terraform files by executing `cd quickstart/do`.
 
-1. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
+3. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
 
-1. Edit `terraform.tfvars` and customize the following variables:
+4. Edit `terraform.tfvars` and customize the following variables:
     - `do_token` - DigitalOcean access key
     - `rancher_server_admin_password` - Admin password for created Rancher server
 
-1. **Optional:** Modify optional variables within `terraform.tfvars`.
+5. **Optional:** Modify optional variables within `terraform.tfvars`.
 See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [DO Quickstart Readme](https://github.com/rancher/quickstart/tree/master/do) for more information.
 Suggestions include:
-    - `do_region` - DigitalOcean region, choose the closest instead of the default
+    - `do_region` - DigitalOcean region, choose the closest instead of the default (`nyc1`)
     - `prefix` - Prefix for all created resources
     - `droplet_size` - Droplet size used, minimum is `s-2vcpu-4gb` but `s-4vcpu-8gb` could be used if within budget
-    - `ssh_key_file_name` - Use a specific SSH key instead of `~/.ssh/id_rsa` (public key is assumed to be `${ssh_key_file_name}.pub`)
 
-1. Run `terraform init`.
+6. Run `terraform init`.
 
-1. To initiate the creation of the environment, run `terraform apply --auto-approve`. Then wait for output similar to the following:
+7. To initiate the creation of the environment, run `terraform apply --auto-approve`. Then wait for output similar to the following:
 
     ```
     Apply complete! Resources: 15 added, 0 changed, 0 destroyed.
@@ -45,15 +44,16 @@ Suggestions include:
     Outputs:
 
     rancher_node_ip = xx.xx.xx.xx
-    rancher_server_url = https://rancher.xx.xx.xx.xx.xip.io
+    rancher_server_url = https://rancher.xx.xx.xx.xx.sslip.io
     workload_node_ip = yy.yy.yy.yy
     ```
 
-1. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
+8. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
+9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/do`.
 
 #### Result
 
-Two Kubernetes clusters are deployed into your DigitalOcean account, one running Rancher Server and the other ready for experimentation deployments.
+Two Kubernetes clusters are deployed into your DigitalOcean account, one running Rancher Server and the other ready for experimentation deployments. Please note that while this setup is a great way to explore Rancher functionality, a production setup should follow our high availability setup guidelines. SSH keys for the VMs are auto-generated and stored in the module directory.
 
 ### What's Next?
 

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/google-gcp-qs/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/google-gcp-qs/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Rancher GCP Quick Start Guide
-description: Read this step by step Rancher GCP guide to quickly deploy a Rancher Server with a single node cluster attached.
+description: Read this step by step Rancher GCP guide to quickly deploy a Rancher server with a single-node downstream Kubernetes cluster attached.
 weight: 100
 ---
 The following steps will quickly deploy a Rancher server on GCP in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/google-gcp-qs/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/google-gcp-qs/_index.md
@@ -3,7 +3,7 @@ title: Rancher GCP Quick Start Guide
 description: Read this step by step Rancher GCP guide to quickly deploy a Rancher Server with a single node cluster attached.
 weight: 100
 ---
-The following steps will quickly deploy a Rancher server on GCP in a single-node RKE Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
+The following steps will quickly deploy a Rancher server on GCP in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
 
 ## Prerequisites
 
@@ -20,25 +20,25 @@ The following steps will quickly deploy a Rancher server on GCP in a single-node
 
 1. Clone [Rancher Quickstart](https://github.com/rancher/quickstart) to a folder using `git clone https://github.com/rancher/quickstart`.
 
-1. Go into the GCP folder containing the terraform files by executing `cd quickstart/gcp`.
+2. Go into the GCP folder containing the terraform files by executing `cd quickstart/gcp`.
 
-1. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
+3. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
 
-1. Edit `terraform.tfvars` and customize the following variables:
+4. Edit `terraform.tfvars` and customize the following variables:
     - `gcp_account_json` - GCP service account file path and file name 
     - `rancher_server_admin_password` - Admin password for created Rancher server
 
-1. **Optional:** Modify optional variables within `terraform.tfvars`.
+5. **Optional:** Modify optional variables within `terraform.tfvars`.
 See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [GCP Quickstart Readme](https://github.com/rancher/quickstart/tree/master/gcp) for more information.
 Suggestions include:
-    - `gcp_region` - Google GCP region, choose the closest instead of the default
+    - `gcp_region` - Google GCP region, choose the closest instead of the default (`us-east4`)
+    - `gcp_zone` - Google GCP zone, choose the closest instead of the default (`us-east4-a`)
     - `prefix` - Prefix for all created resources
     - `machine_type` - Compute instance size used, minimum is `n1-standard-1` but `n1-standard-2` or `n1-standard-4` could be used if within budget
-    - `ssh_key_file_name` - Use a specific SSH key instead of `~/.ssh/id_rsa` (public key is assumed to be `${ssh_key_file_name}.pub`)
 
-1. Run `terraform init`.
+6. Run `terraform init`.
 
-1. To initiate the creation of the environment, run `terraform apply --auto-approve`. Then wait for output similar to the following:
+7. To initiate the creation of the environment, run `terraform apply --auto-approve`. Then wait for output similar to the following:
 
     ```
     Apply complete! Resources: 16 added, 0 changed, 0 destroyed.
@@ -46,15 +46,16 @@ Suggestions include:
     Outputs:
 
     rancher_node_ip = xx.xx.xx.xx
-    rancher_server_url = https://rancher.xx.xx.xx.xx.xip.io
+    rancher_server_url = https://rancher.xx.xx.xx.xx.sslip.io
     workload_node_ip = yy.yy.yy.yy
     ```
 
-1. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
+8. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
+9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/gcp`.
 
 #### Result
 
-Two Kubernetes clusters are deployed into your GCP account, one running Rancher Server and the other ready for experimentation deployments.
+Two Kubernetes clusters are deployed into your GCP account, one running Rancher Server and the other ready for experimentation deployments. Please note that while this setup is a great way to explore Rancher functionality, a production setup should follow our high availability setup guidelines. SSH keys for the VMs are auto-generated and stored in the module directory.
 
 ### What's Next?
 

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/hetzner-cloud-qs/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/hetzner-cloud-qs/_index.md
@@ -3,7 +3,7 @@ title: Rancher Hetzner Cloud Quick Start Guide
 description: Read this step by step Rancher Hetzner Cloud guide to quickly deploy a Rancher Server with a single node cluster attached.
 weight: 100
 ---
-The following steps will quickly deploy a Rancher Server on Hetzner Cloud with a single node cluster attached.
+The following steps will quickly deploy a Rancher server on Hetzner Cloud in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
 
 ## Prerequisites
 
@@ -19,24 +19,24 @@ The following steps will quickly deploy a Rancher Server on Hetzner Cloud with a
 
 1. Clone [Rancher Quickstart](https://github.com/rancher/quickstart) to a folder using `git clone https://github.com/rancher/quickstart`.
 
-1. Go into the Hetzner folder containing the terraform files by executing `cd quickstart/hcloud`.
+2. Go into the Hetzner folder containing the terraform files by executing `cd quickstart/hcloud`.
 
-1. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
+3. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
 
-1. Edit `terraform.tfvars` and customize the following variables:
+4. Edit `terraform.tfvars` and customize the following variables:
     - `hcloud_token` - Hetzner API access key
     - `rancher_server_admin_password` - Admin password for created Rancher server
 
-1. **Optional:** Modify optional variables within `terraform.tfvars`.
+5. **Optional:** Modify optional variables within `terraform.tfvars`.
 See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [Hetzner Quickstart Readme](https://github.com/rancher/quickstart/tree/master/hcloud) for more information.
 Suggestions include:
     - `prefix` - Prefix for all created resources
     - `instance_type` - Instance type, minimum required is `cx21`
-    - `ssh_key_file_name` - Use a specific SSH key instead of `~/.ssh/id_rsa` (public key is assumed to be `${ssh_key_file_name}.pub`)
+    - `hcloud_location` - Hetzner Cloud location, choose the closest instead of the default (`fsn1`)
 
-1. Run `terraform init`.
+6. Run `terraform init`.
 
-2. To initiate the creation of the environment, run `terraform apply --auto-approve`. Then wait for output similar to the following:
+7. To initiate the creation of the environment, run `terraform apply --auto-approve`. Then wait for output similar to the following:
 
     ```
     Apply complete! Resources: 15 added, 0 changed, 0 destroyed.
@@ -44,15 +44,16 @@ Suggestions include:
     Outputs:
 
     rancher_node_ip = xx.xx.xx.xx
-    rancher_server_url = https://rancher.xx.xx.xx.xx.xip.io
+    rancher_server_url = https://rancher.xx.xx.xx.xx.sslip.io
     workload_node_ip = yy.yy.yy.yy
     ```
 
-3. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
+8. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
+9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/hcloud`.
 
 #### Result
 
-Two Kubernetes clusters are deployed into your Hetzner account, one running Rancher Server and the other ready for experimentation deployments.
+Two Kubernetes clusters are deployed into your Hetzner account, one running Rancher Server and the other ready for experimentation deployments. Please note that while this setup is a great way to explore Rancher functionality, a production setup should follow our high availability setup guidelines. SSH keys for the VMs are auto-generated and stored in the module directory.
 
 ### What's Next?
 

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/hetzner-cloud-qs/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/hetzner-cloud-qs/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Rancher Hetzner Cloud Quick Start Guide
-description: Read this step by step Rancher Hetzner Cloud guide to quickly deploy a Rancher Server with a single node cluster attached.
+description: Read this step by step Rancher Hetzner Cloud guide to quickly deploy a Rancher server with a single-node downstream Kubernetes cluster attached.
 weight: 100
 ---
 The following steps will quickly deploy a Rancher server on Hetzner Cloud in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/microsoft-azure-qs/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/microsoft-azure-qs/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Rancher Azure Quick Start Guide
-description: Read this step by step Rancher Azure guide to quickly deploy a Rancher Server with a single node cluster attached.
+description: Read this step by step Rancher Azure guide to quickly deploy a Rancher server with a single-node downstream Kubernetes cluster attached.
 weight: 100
 ---
 

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/microsoft-azure-qs/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/microsoft-azure-qs/_index.md
@@ -4,7 +4,7 @@ description: Read this step by step Rancher Azure guide to quickly deploy a Ranc
 weight: 100
 ---
 
-The following steps will quickly deploy a Rancher server on Azure in a single-node RKE Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
+The following steps will quickly deploy a Rancher server on Azure in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
 
 ## Prerequisites
 
@@ -22,27 +22,29 @@ The following steps will quickly deploy a Rancher server on Azure in a single-no
 
 1. Clone [Rancher Quickstart](https://github.com/rancher/quickstart) to a folder using `git clone https://github.com/rancher/quickstart`.
 
-1. Go into the Azure folder containing the terraform files by executing `cd quickstart/azure`.
+2. Go into the Azure folder containing the terraform files by executing `cd quickstart/azure`.
 
-1. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
+3. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
 
-1. Edit `terraform.tfvars` and customize the following variables:
+4. Edit `terraform.tfvars` and customize the following variables:
     - `azure_subscription_id` - Microsoft Azure Subscription ID 
     - `azure_client_id` - Microsoft Azure Client ID
     - `azure_client_secret` - Microsoft Azure Client Secret
     - `azure_tenant_id` - Microsoft Azure Tenant ID
     - `rancher_server_admin_password` - Admin password for created Rancher server
 
-2. **Optional:** Modify optional variables within `terraform.tfvars`.
+5. **Optional:** Modify optional variables within `terraform.tfvars`.
 See the [Quickstart Readme](https://github.com/rancher/quickstart) and the [Azure Quickstart Readme](https://github.com/rancher/quickstart/tree/master/azure) for more information.
 Suggestions include:
-    - `azure_location` - Microsoft Azure region, choose the closest instead of the default
+    - `azure_location` - Microsoft Azure region, choose the closest instead of the default (`East US`)
     - `prefix` - Prefix for all created resources
     - `instance_type` - Compute instance size used, minimum is `Standard_DS2_v2` but `Standard_DS2_v3` or `Standard_DS3_v2` could be used if within budget
+    - `add_windows_node` - If true, an additional Windows worker node is added to the workload cluster
+    - `windows_admin_password` - The admin password of the windows worker node
+    
+6. Run `terraform init`.
 
-1. Run `terraform init`.
-
-1. To initiate the creation of the environment, run `terraform apply --auto-approve`. Then wait for output similar to the following:
+7. To initiate the creation of the environment, run `terraform apply --auto-approve`. Then wait for output similar to the following:
 
     ```
     Apply complete! Resources: 16 added, 0 changed, 0 destroyed.
@@ -50,15 +52,16 @@ Suggestions include:
     Outputs:
 
     rancher_node_ip = xx.xx.xx.xx
-    rancher_server_url = https://rancher.xx.xx.xx.xx.xip.io
+    rancher_server_url = https://rancher.xx.xx.xx.xx.sslip.io
     workload_node_ip = yy.yy.yy.yy
     ```
 
-1. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
-2. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/azure`.
+8. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
+9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/azure`.
+
 #### Result
 
-Two Kubernetes clusters are deployed into your Azure account, one running Rancher Server and the other ready for experimentation deployments.
+Two Kubernetes clusters are deployed into your Azure account, one running Rancher Server and the other ready for experimentation deployments. Please note that while this setup is a great way to explore Rancher functionality, a production setup should follow our high availability setup guidelines. SSH keys for the VMs are auto-generated and stored in the module directory.
 
 ### What's Next?
 


### PR DESCRIPTION
* SSH keys are auto-generated (https://github.com/rancher/quickstart/pull/86)
* Add documentation for missing variables
* Rancher is installed in a K3s cluster
* Align docs of different providers

Fixes https://github.com/rancher/quickstart/issues/192
