### PR TITLE
[K3s] Duplicate Warning HA K3s about not enabling secrets later

### DIFF
--- a/content/k3s/latest/en/security/secrets_encryption/_index.md
+++ b/content/k3s/latest/en/security/secrets_encryption/_index.md
@@ -87,6 +87,8 @@ The steps are the same for both embedded DB and external DB clusters.
 
 To rotate secrets encryption keys on HA setups:
 
+>**Note:** Starting K3s without encryption and enabling it at a later time is currently *not* supported.
+
 >**Note:** While not required, it is recommended that you pick one server node from which to run the `secrets-encrypt` commands.
 
 - Start up all three K3s servers with the `--secrets-encryption` flag. For brevity, the servers will be referred to as S1, S2, S3.

--- a/content/k3s/latest/en/security/secrets_encryption/_index.md
+++ b/content/k3s/latest/en/security/secrets_encryption/_index.md
@@ -87,9 +87,11 @@ The steps are the same for both embedded DB and external DB clusters.
 
 To rotate secrets encryption keys on HA setups:
 
->**Note:** Starting K3s without encryption and enabling it at a later time is currently *not* supported.
-
->**Note:** While not required, it is recommended that you pick one server node from which to run the `secrets-encrypt` commands.
+>**Notes:** 
+>
+> - Starting K3s without encryption and enabling it at a later time is currently *not* supported.
+>
+> - While not required, it is recommended that you pick one server node from which to run the `secrets-encrypt` commands.
 
 - Start up all three K3s servers with the `--secrets-encryption` flag. For brevity, the servers will be referred to as S1, S2, S3.
 


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

A user of K3s attempted to enable secrets-encryption on a HA setup after starting K3s. This is not supported and the docs warn as much... but only in the Single Node section. This PR duplicates the warning to the HA section.