### PR TITLE
Updated monitoringV2 architecture docs

### DIFF
--- a/content/rancher/v2.5/en/monitoring-alerting/how-monitoring-works/_index.md
+++ b/content/rancher/v2.5/en/monitoring-alerting/how-monitoring-works/_index.md
@@ -13,7 +13,7 @@ weight: 1
 
 _**The following steps describe how data flows through the Monitoring V2 application:**_
 
-**1.** **ServiceMonitors and PodMonitors** declaratively specify targets, such as Services and Pods, that need to be monitored.
+**1. ServiceMonitors and PodMonitors** declaratively specify targets, such as Services and Pods, that need to be monitored.
 
 - Targets are scraped on a recurring schedule based on the configured Prometheus scrape interval, and the metrics that are scraped are stored into the Prometheus Time Series Database (TSDB).
 - In order to perform the scrape, ServiceMonitors and PodMonitors are defined with label selectors that determine which Services or Pods should be scraped and endpoints that determine how the scrape should happen on the given target, e.g., scrape/metrics in TCP 10252, proxying through IP addr x.x.x.x.
@@ -37,12 +37,12 @@ _**The following steps describe how data flows through the Monitoring V2 applica
 
     For more information, see [Scraping and Exposing Metrics](#5-scraping-and-exposing-metrics).
 
-**2.** **PrometheusRules** allow users to define rules for what metrics or time series database queries should result in alerts being fired. Rules are evaluated on an interval.
+**2. PrometheusRules** allow users to define rules for what metrics or time series database queries should result in alerts being fired. Rules are evaluated on an interval.
 
 - **Recording rules** create a new time series based on existing series that have been collected. They are frequently used to precompute complex queries.
 - **Alerting rules** run a particular query and fire an alert from Prometheus if the query evaluates to a non-zero value.
 
-**3.** **Prometheus Operator** observes ServiceMonitors, PodMonitors, and PrometheusRules being created. When the Prometheus configuration resources are created, Prometheus Operator calls the Prometheus API to sync the new configuration.
+**3. Prometheus Operator** observes ServiceMonitors, PodMonitors, and PrometheusRules being created. When the Prometheus configuration resources are created, Prometheus Operator calls the Prometheus API to sync the new configuration.
 
 **4.** Once Prometheus determines that an alert needs to be fired, alerts are forwarded to **Alertmanager**.
 
@@ -123,7 +123,7 @@ By editing custom YAML in the Alertmanager or Receiver configuration, you can al
 
 # 4. Monitoring V2 Specific Components
 
-Prometheus Operator introduces a set of [Custom Resource Definitions](https://github.com/prometheus-operator/prometheus-operator#customresourcedefinitions) that allow users to deploy and manage Prometheus and Alertmanager instances by creating and modifying those custom resources on a cluster. 
+Prometheus Operator introduces a set of [Custom Resource Definitions](https://github.com/prometheus-operator/prometheus-operator#customresourcedefinitions) that allow users to deploy and manage Prometheus and Alertmanager instances by creating and modifying those custom resources on a cluster.
 
 Prometheus Operator will automatically update your Prometheus configuration based on the live state of the resources and configuration options that are edited in the Rancher UI.
 
@@ -137,15 +137,15 @@ The resources that get deployed onto your cluster to support this solution can b
 
 Monitoring V2 deploys three default exporters that provide additional metrics for Prometheus to store:
 
-1. `node-exporter`: exposes hardware and OS metrics for Linux hosts. For more information on `node-exporter`, refer to the [upstream documentation.](https://prometheus.io/docs/guides/node-exporter/)
+1. `node-exporter`: exposes hardware and OS metrics for Linux hosts. For more information on `node-exporter`, refer to the [upstream documentation](https://prometheus.io/docs/guides/node-exporter/).
 
-1. `windows-exporter`: exposes hardware and OS metrics for Windows hosts (only deployed on Windows clusters).
+1. `windows-exporter`: exposes hardware and OS metrics for Windows hosts (only deployed on Windows clusters). For more information on `windows-exporter`, refer to the [upstream documentation](https://github.com/prometheus-community/windows_exporter).
 
-1. [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics): expose additional metrics that track the state of resources contained in the Kubernetes API (e.g. pods, workloads, etc.).
+1. `kube-state-metrics`: expose additional metrics that track the state of resources contained in the Kubernetes API (e.g., pods, workloads, etc.). For more information on `kube-state-metrics`, refer to the [upstream documentation](https://github.com/kubernetes/kube-state-metrics/tree/master/docs).
 
 ServiceMonitors and PodMonitors will scrape these exporters, as defined [here](#defining-what-metrics-are-scraped). Prometheus stores these metrics, and you can query the results via either Prometheus's UI or Grafana.
 
-See [architecture](#1-architecture-overview) section for more information on recording rules, alerting rules, and Alertmanager.
+See the [architecture](#1-architecture-overview) section for more information on recording rules, alerting rules, and Alertmanager.
 
 ### Components Exposed in the Rancher UI
 
@@ -155,7 +155,7 @@ When the monitoring application is installed, you will be able to edit the follo
 |--------------|------------------------|---------------------------|
 | ServiceMonitor | Custom resource | Sets up Kubernetes Services to scrape custom metrics from. Automatically updates the scrape configuration in the Prometheus custom resource. |
 | PodMonitor | Custom resource | Sets up Kubernetes Pods to scrape custom metrics from. Automatically updates the scrape configuration in the Prometheus custom resource. |
-| Receiver | Configuration block (part of Alertmanager) | Modifies information on where to send an alert (e.g. Slack, PagerDuty, etc.) and any necessary information to send the alert (e.g. TLS certs, proxy URLs, etc.). Automatically updates the Alertmanager custom resource. |
+| Receiver | Configuration block (part of Alertmanager) | Modifies information on where to send an alert (e.g., Slack, PagerDuty, etc.) and any necessary information to send the alert (e.g., TLS certs, proxy URLs, etc.). Automatically updates the Alertmanager custom resource. |
 | Route | Configuration block (part of Alertmanager) | Modifies the routing tree that is used to filter, label, and group alerts based on labels and send them to the appropriate Receiver. Automatically updates the Alertmanager custom resource. |
 | PrometheusRule | Custom resource | Defines additional queries that need to trigger alerts or define materialized views of existing series that are within Prometheus's TSDB.  Automatically updates the Prometheus custom resource. |
 
@@ -202,7 +202,7 @@ The following Kubernetes components are directly scraped by Prometheus:
 - coreDns/kubeDns
 - kube-api-server
 
-\* You can optionally use hardenedKubelet.enabled to use a PushProx, but that is not the default.
+\* You can optionally use `hardenedKubelet.enabled` to use a PushProx, but that is not the default.
 
 ** For RKE and RKE2 clusters, ingress-nginx is deployed by default and treated as an internal Kubernetes component.
 

--- a/content/rancher/v2.5/en/monitoring-alerting/how-monitoring-works/_index.md
+++ b/content/rancher/v2.5/en/monitoring-alerting/how-monitoring-works/_index.md
@@ -11,52 +11,64 @@ weight: 1
 
 # 1. Architecture Overview
 
-This diagram shows how data flows through the Monitoring V2 application:
+_**The following steps describe how data flows through the Monitoring V2 application:**_
 
-{{% row %}}
-{{% column %}}
+**1.** **ServiceMonitors and PodMonitors** declaratively specify targets, such as Services and Pods, that need to be monitored.
 
-![How data flows through the monitoring application]({{<baseurl>}}/img/rancher/monitoring-v2-architecture-overview.svg)
+- Targets are scraped on a recurring schedule based on the configured Prometheus scrape interval, and the metrics that are scraped are stored into the Prometheus Time Series Database (TSDB).
+- In order to perform the scrape, ServiceMonitors and PodMonitors are defined with label selectors that determine which Services or Pods should be scraped and endpoints that determine how the scrape should happen on the given target, e.g., scrape/metrics in TCP 10252, proxying through IP addr x.x.x.x.
+- Out of the box, Monitoring V2 comes with certain pre-configured exporters that are deployed based on the type of Kubernetes cluster that it is deployed on.
+    - Certain internal Kubernetes components are scraped via a proxy deployed as part of Monitoring V2 called **PushProx**. The Kubernetes components that expose metrics to Prometheus through PushProx are the following: `kube-controller-manager`, `kube-scheduler`, `etcd`, and `kube-proxy`.
+    - For each PushProx exporter, we deploy one PushProx client onto all target nodes. For example, a PushProx client is deployed onto all controlplane nodes for kube-controller-manager, all etcd nodes for kube-etcd, and all nodes for kubelet. 
+    
+    - We deploy exactly one PushProx proxy per exporter. The process for exporting metrics is as follows:
 
-{{% /column %}}
-{{% column %}}
+        1. The PushProx Client establishes an outbound connection with the PushProx Proxy.
+        1. The client then polls the proxy for scrape requests that have come into the proxy.
+        1. When the proxy receives a scrape request from Prometheus, the client sees it as a result of the poll.
+        1. The client scrapes the internal component.
+        1. The internal component responds by pushing metrics back to the proxy.
+    
+    </br>
 
+    <figcaption>Process for Exporting Metrics with PushProx:</figcaption>
 
-1. Rules define what Prometheus metrics or time series database queries should result in alerts being fired.
-2. ServiceMonitors and PodMonitors declaratively specify how services and pods should be monitored. They use labels to scrape metrics from pods.
-3. Prometheus Operator observes ServiceMonitors, PodMonitors and PrometheusRules being created.
-4. When the Prometheus configuration resources are created, Prometheus Operator calls the Prometheus API to sync the new configuration.
-5. Recording Rules are not directly used for alerting. They create new time series of precomputed queries. These new time series data can then be queried to generate alerts.
-6. Prometheus scrapes all targets in the scrape configuration on a recurring schedule based on the scrape interval, storing the results in its time series database.Depending on the Kubernetes master component and Kubernetes distribution, the metrics from a certain Kubernetes component could be directly exposed to Prometheus, proxied through PushProx, or not available. For details, see Scraping and Exposing Metrics.
-7. Prometheus evaluates the alerting rules against the time series database. It fires alerts to Alertmanager whenever an alerting rule evaluates to a positive number.
-8. Alertmanager uses routes to group, label and filter the fired alerts to translate them into useful notifications.
-9. Alertmanager uses the  Receiver configuration to send notifications to Slack, PagerDuty, SMS, or other types of receivers.
+    ![Process for Exporting Metrics with PushProx]({{<baseurl>}}/img/rancher/pushprox-process.svg)
 
-{{% /column %}}
-{{% /row %}}
+    For more information, see [Scraping and Exposing Metrics](#5-scraping-and-exposing-metrics).
 
+**2.** **PrometheusRules** allow users to define rules for what metrics or time series database queries should result in alerts being fired. Rules are evaluated on an interval.
 
+- **Recording rules** create a new time series based on existing series that have been collected. They are frequently used to precompute complex queries.
+- **Alerting rules** run a particular query and fire an alert from Prometheus if the query evaluates to a non-zero value.
+
+**3.** **Prometheus Operator** observes ServiceMonitors, PodMonitors, and PrometheusRules being created. When the Prometheus configuration resources are created, Prometheus Operator calls the Prometheus API to sync the new configuration.
+
+**4.** Once Prometheus determines that an alert needs to be fired, alerts are forwarded to **Alertmanager**.
+
+- Alerts contain labels that come from the PromQL query itself and additional labels and annotations that can be provided as part of specifying the initial PrometheusRule.
+- Before receiving any alerts, Alertmanager will use the **routes** and **receivers** specified in its configuration to form a routing tree on which all incoming alerts are evaluated. Each node of the routing tree can specify additional grouping, labeling, and filtering that needs to happen based on the labels attached to the Prometheus alert. A node on the routing tree (usually a leaf node) can also specify that an alert that reaches it needs to be sent out to a configured Receiver, e.g., Slack, PagerDuty, SMS, etc. Note that Alertmanager will send an alert first to **alertingDriver**, then alertingDriver will send or forward alert to the proper destination.
+- Routes and receivers are also stored in the Kubernetes API via the Alertmanager Secret. When the Secret is updated, Alertmanager is also updated automatically. Note that routing occurs via labels only (not via annotations, etc.).
+
+<figcaption>How data flows through the monitoring application:</figcaption>
 
 
 # 2. How Prometheus Works
 
-### 2.1. Storing Time Series Data
+### Storing Time Series Data
 
 After collecting metrics from exporters, Prometheus stores the time series in a local on-disk time series database. Prometheus optionally integrates with remote systems, but `rancher-monitoring` uses local storage for the time series database.
 
-The database can then be queried using PromQL, the query language for Prometheus. Grafana dashboards use PromQL queries to generate data visualizations.
+Once stored, users can query this TSDB using PromQL, the query language for Prometheus.
 
-### 2.2. Querying the Time Series Database
+PromQL queries can be visualized in one of two ways:
 
-The PromQL query language is the primary tool to query Prometheus for time series data.
+1. By supplying the query in Prometheus's Graph UI, which will show a simple graphical view of the data.
+1. By creating a Grafana Dashboard that contains the PromQL query and additional formatting directives that label axes, add units, change colors, use alternative visualizations, etc.
 
-In Grafana, you can right-click a CPU utilization and click Inspect. This opens a panel that shows the [raw query results.](https://grafana.com/docs/grafana/latest/panels/inspect-panel/#inspect-raw-query-results)The raw results demonstrate how each dashboard is powered by PromQL queries.
+### Defining Rules for Prometheus
 
-### 2.3. Defining Rules for when Alerts Should be Fired
-
-Rules define the conditions for Prometheus to fire alerts. When PrometheusRule custom resources are created or updated, the Prometheus Operator observes the change and calls the Prometheus API to synchronize the rule configuration with the Alerting Rules and Recording Rules in Prometheus.
-
-When you define a Rule (which is declared within a RuleGroup in a PrometheusRule resource), the [spec of the Rule itself](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#rule) contains labels that are used by Alertmanager to figure out which Route should receive this Alert. For example, an Alert with the label `team: front-end` will be sent to all Routes that match on that label.
+Rules define queries that Prometheus needs to execute on a regular `evaluationInterval` to perform certain actions, such as firing an alert (alerting rules) or precomputing a query based on others existing in its TSDB (recording rules). These rules are encoded in PrometheusRules custom resources. When PrometheusRule custom resources are created or updated, the Prometheus Operator observes the change and calls the Prometheus API to synchronize the set of rules that Prometheus is currently evaluating on a regular interval.
 
 A PrometheusRule allows you to define one or more RuleGroups. Each RuleGroup consists of a set of Rule objects that can each represent either an alerting or a recording rule with the following fields:
 
@@ -65,7 +77,9 @@ A PrometheusRule allows you to define one or more RuleGroups. Each RuleGroup con
 - Labels that should be attached to the alert or record that identify it (e.g. cluster name or severity)
 - Annotations that encode any additional important pieces of information that need to be displayed on the notification for an alert (e.g. summary, description, message, runbook URL, etc.). This field is not required for recording rules.
 
-### 2.4. Firing Alerts
+On evaluating a [rule](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#rule), Prometheus will execute the provided PromQL query, add additional provided labels (or annotations - only for alerting rules), and execute the appropriate action for the rule. For example, an Alerting Rule that adds `team: front-end` as a label to the provided PromQL query will append that label to the fired alert, which will allow Alertmanager to forward the alert to the correct Receiver.
+
+### Alerting and Recording Rules
 
 Prometheus doesn't maintain the state of whether alerts are active. It fires alerts repetitively at every evaluation interval, relying on Alertmanager to group and filter the alerts into meaningful notifications.
 
@@ -90,14 +104,18 @@ The Alertmanager handles alerts sent by client applications such as the Promethe
 - Silencing and inhibition of alerts
 - Tracking alerts that fire over time
 - Sending out the status of whether an alert is currently firing, or if it is resolved
+
+### Alerts Forwarded by alertingDrivers
+
+When alertingDrivers are installed, this creates a `Service` that can be used as the receiver's URL for Teams or SMS, based on the alertingDriver's configuration. The URL in the Receiver points to the alertingDrivers; so the Alertmanager sends alert first to alertingDriver, then alertingDriver forwards or sends alert to the proper destination.
     
-### 3.1. Routing Alerts to Receivers
+### Routing Alerts to Receivers
 
 Alertmanager coordinates where alerts are sent. It allows you to group alerts based on labels and fire them based on whether certain labels are matched. One top-level route accepts all alerts. From there, Alertmanager continues routing alerts to receivers based on whether they match the conditions of the next route.
 
-While the Rancher UI forms only allow editing a routing tree that is two levels deep, you can configure more deeply nested routing structures by editing the Alertmanager custom resource YAML.
+While the Rancher UI forms only allow editing a routing tree that is two levels deep, you can configure more deeply nested routing structures by editing the Alertmanager Secret.
 
-### 3.2. Configuring Multiple Receivers
+### Configuring Multiple Receivers
 
 By editing the forms in the Rancher UI, you can set up a Receiver resource with all the information Alertmanager needs to send alerts to your notification system.
 
@@ -105,124 +123,93 @@ By editing custom YAML in the Alertmanager or Receiver configuration, you can al
 
 # 4. Monitoring V2 Specific Components
 
-Prometheus Operator introduces a set of [Custom Resource Definitions](https://github.com/prometheus-operator/prometheus-operator#customresourcedefinitions) that allow users to deploy and manage Prometheus and Alertmanager instances by creating and modifying those custom resources on a cluster.
+Prometheus Operator introduces a set of [Custom Resource Definitions](https://github.com/prometheus-operator/prometheus-operator#customresourcedefinitions) that allow users to deploy and manage Prometheus and Alertmanager instances by creating and modifying those custom resources on a cluster. 
 
 Prometheus Operator will automatically update your Prometheus configuration based on the live state of the resources and configuration options that are edited in the Rancher UI.
 
-### 4.1. Resources Deployed by Default
+### Resources Deployed by Default
 
 By default, a set of resources curated by the [kube-prometheus](https://github.com/prometheus-operator/kube-prometheus) project are deployed onto your cluster as part of installing the Rancher Monitoring Application to set up a basic Monitoring/Alerting stack.
 
 The resources that get deployed onto your cluster to support this solution can be found in the [`rancher-monitoring`](https://github.com/rancher/charts/tree/main/charts/rancher-monitoring) Helm chart, which closely tracks the upstream [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) Helm chart maintained by the Prometheus community with certain changes tracked in the [CHANGELOG.md](https://github.com/rancher/charts/blob/main/charts/rancher-monitoring/CHANGELOG.md).
 
-There are also certain special types of ConfigMaps and Secrets such as those corresponding to Grafana Dashboards, Grafana Datasources, and Alertmanager Configs that will automatically update your Prometheus configuration via sidecar proxies that observe the live state of those resources within your cluster.
+### Default Exporters
 
-### 4.2. PushProx
+Monitoring V2 deploys three default exporters that provide additional metrics for Prometheus to store:
 
-PushProx enhances the security of the monitoring application, allowing it to be installed on hardened Kubernetes clusters.
+1. `node-exporter`: exposes hardware and OS metrics for Linux hosts. For more information on `node-exporter`, refer to the [upstream documentation.](https://prometheus.io/docs/guides/node-exporter/)
 
-To expose Kubernetes metrics, PushProxes use a client proxy model to expose specific ports within default Kubernetes components. Node exporters expose metrics to PushProx through an outbound connection.
+1. `windows-exporter`: exposes hardware and OS metrics for Windows hosts (only deployed on Windows clusters).
 
-The proxy allows `rancher-monitoring` to scrape metrics from processes on the hostNetwork, such as the `kube-api-server`, without opening up node ports to inbound connections.
+1. [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics): expose additional metrics that track the state of resources contained in the Kubernetes API (e.g. pods, workloads, etc.).
 
-PushProx is a DaemonSet that listens for clients that seek to register. Once registered, it proxies scrape requests through the established connection. Then the client executes the request to etcd.
+ServiceMonitors and PodMonitors will scrape these exporters, as defined [here](#defining-what-metrics-are-scraped). Prometheus stores these metrics, and you can query the results via either Prometheus's UI or Grafana.
 
-All of the default ServiceMonitors, such as `rancher-monitoring-kube-controller-manager`, are configured to hit the metrics endpoint of the client using this proxy.
+See [architecture](#1-architecture-overview) section for more information on recording rules, alerting rules, and Alertmanager.
 
-For more details about how PushProx works, refer to [Scraping Metrics with PushProx.](#5-5-scraping-metrics-with-pushprox)
-
-
-### 4.3. Default Exporters
-
-`rancher-monitoring` deploys two exporters to expose metrics to prometheus: `node-exporter` and `windows-exporter`. Both are deployed as DaemonSets.
-
-`node-exporter` exports container, pod and node metrics for CPU and memory from each Linux node. `windows-exporter` does the same, but for Windows nodes.
-
-For more information on `node-exporter`, refer to the [upstream documentation.](https://prometheus.io/docs/guides/node-exporter/)
-
-[kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) is also useful because it exports metrics for Kubernetes components.
-
-### 4.4. Components Exposed in the Rancher UI
+### Components Exposed in the Rancher UI
 
 When the monitoring application is installed, you will be able to edit the following components in the Rancher UI:
 
 | Component | Type of Component | Purpose and Common Use Cases for Editing |
 |--------------|------------------------|---------------------------|
-| ServiceMonitor | Custom resource | Set up targets to scrape custom metrics from. Automatically updates the scrape configuration in the Prometheus custom resource. |
-| PodMonitor | Custom resource | Set up targets to scrape custom metrics from. Automatically updates the scrape configuration in the Prometheus custom resource. |
-| Receiver | Configuration block (part of Alertmanager) | Set up a notification system to receive alerts. Automatically updates the Alertmanager custom resource. |
-| Route | Configuration block (part of Alertmanager) | Add identifying information to make alerts more meaningful and direct them to individual teams. Automatically updates the Alertmanager custom resource. |
-| PrometheusRule | Custom resource | For more advanced use cases, you may want to define what Prometheus metrics or time series database queries should result in alerts being fired.  Automatically updates the Prometheus custom resource. |
-| Alertmanager | Custom resource | Edit this custom resource only if you need more advanced configuration options beyond what the Rancher UI exposes in the Routes and Receivers sections. For example, you might want to edit this resource to add a routing tree with more than two levels. |
-| Prometheus | Custom resource | Edit this custom resource only if you need more advanced configuration beyond what can be configured using  ServiceMonitors, PodMonitors, or [Rancher monitoring Helm chart options.](../configuration/helm-chart-options) |
+| ServiceMonitor | Custom resource | Sets up Kubernetes Services to scrape custom metrics from. Automatically updates the scrape configuration in the Prometheus custom resource. |
+| PodMonitor | Custom resource | Sets up Kubernetes Pods to scrape custom metrics from. Automatically updates the scrape configuration in the Prometheus custom resource. |
+| Receiver | Configuration block (part of Alertmanager) | Modifies information on where to send an alert (e.g. Slack, PagerDuty, etc.) and any necessary information to send the alert (e.g. TLS certs, proxy URLs, etc.). Automatically updates the Alertmanager custom resource. |
+| Route | Configuration block (part of Alertmanager) | Modifies the routing tree that is used to filter, label, and group alerts based on labels and send them to the appropriate Receiver. Automatically updates the Alertmanager custom resource. |
+| PrometheusRule | Custom resource | Defines additional queries that need to trigger alerts or define materialized views of existing series that are within Prometheus's TSDB.  Automatically updates the Prometheus custom resource. |
+
+### How PushProx Works
+
+PushProx allows Prometheus to scrape metrics across a network boundary, which prevents users from having to expose metrics ports for internal Kubernetes components on each node in a Kubernetes cluster.
+
+Since the metrics for Kubernetes components are generally exposed on the host network of nodes in the cluster, PushProx deploys a DaemonSet of clients that sit on the hostNetwork of each node and make an outbound connection to a single proxy that is sitting on the Kubernetes API. Prometheus can then be configured to proxy scrape requests through the proxy to each client, which allows it to scrape metrics from the internal Kubernetes components without requiring any inbound node ports to be open.
+
+For more details about how PushProx works, refer to [Scraping Metrics with PushProx](#scraping-metrics-with-pushprox).
 
 # 5. Scraping and Exposing Metrics
 
-### 5.1. Defining what Metrics are Scraped
+### Defining what Metrics are Scraped
 
-ServiceMonitors define targets that are intended for Prometheus to scrape. The [Prometheus custom resource tells](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/design.md#prometheus) Prometheus which ServiceMonitors it should use to find out where to scrape metrics from.
+ServiceMonitors and PodMonitors define targets that are intended for Prometheus to scrape. The [Prometheus custom resource](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/design.md#prometheus) tells Prometheus which ServiceMonitors or PodMonitors it should use to find out where to scrape metrics from.
 
-The Prometheus Operator observes the ServiceMonitors. When it observes that ServiceMonitors are created or updated, it calls the Prometheus API to update the scrape configuration in the Prometheus custom resource and keep it in sync with the scrape configuration in the ServiceMonitors. This scrape configuration tells Prometheus which endpoints to scrape metrics from and how it will label the metrics from those endpoints.
+The Prometheus Operator observes the ServiceMonitors and PodMonitors. When it observes that they are created or updated, it calls the Prometheus API to update the scrape configuration in the Prometheus custom resource and keep it in sync with the scrape configuration in the ServiceMonitors or PodMonitors. This scrape configuration tells Prometheus which endpoints to scrape metrics from and how it will label the metrics from those endpoints.
 
 Prometheus scrapes all of the metrics defined in its scrape configuration at every `scrape_interval`, which is one minute by default.
 
 The scrape configuration can be viewed as part of the Prometheus custom resource that is exposed in the Rancher UI.
 
-### 5.2. How the Prometheus Operator Sets up Metrics Scraping
+### How the Prometheus Operator Sets up Metrics Scraping
 
 The Prometheus Deployment or StatefulSet scrapes metrics, and the configuration of Prometheus is controlled by the Prometheus custom resources. The Prometheus Operator watches for Prometheus and Alertmanager resources, and when they are created, the Prometheus Operator creates a Deployment or StatefulSet for Prometheus or Alertmanager with the user-defined configuration.
 
-<figcaption>How the Prometheus Operator Sets up Metrics Scraping</figcaption>
+When the Prometheus Operator observes ServiceMonitors, PodMonitors, and PrometheusRules being created, it knows that the scrape configuration needs to be updated in Prometheus. It updates Prometheus by first updating the configuration and rules files in the volumes of Prometheus's Deployment or StatefulSet. Then it calls the Prometheus API to sync the new configuration, resulting in the Prometheus Deployment or StatefulSet to be modified in place.
 
-![How the Prometheus Operator sets up metrics scraping]({{<baseurl>}}/img/rancher/set-up-scraping.svg)
-
-When the Prometheus Operator observes ServiceMonitors, PodMonitors and PrometheusRules being created, it knows that the scrape configuration needs to be updated in Prometheus. It updates Prometheus by first updating the configuration and rules files in the volumes of Prometheus's Deployment or StatefulSet. Then it calls the Prometheus API to sync the new configuration, resulting in the Prometheus Deployment or StatefulSet to be modified in place.
-
-![How the Prometheus Operator Updates Scrape Configuration]({{<baseurl>}}/img/rancher/update-scrape-config.svg)
-
-### 5.3. How Kubernetes Component Metrics are Exposed
+### How Kubernetes Component Metrics are Exposed
 
 Prometheus scrapes metrics from deployments known as [exporters,](https://prometheus.io/docs/instrumenting/exporters/) which export the time series data in a format that Prometheus can ingest. In Prometheus, time series consist of streams of timestamped values belonging to the same metric and the same set of labeled dimensions.
 
-To allow monitoring to be installed on hardened Kubernetes clusters, `rancher-monitoring` application proxies the communication between Prometheus and the exporter through PushProx for some Kubernetes master components.
+### Scraping Metrics with PushProx
 
-### 5.4. Scraping Metrics without PushProx
+Certain internal Kubernetes components are scraped via a proxy deployed as part of Monitoring V2 called PushProx. For detailed information on PushProx, refer [here](#pushprox) and to the above [architecture](#1-architecture-overview) section.
 
-The Kubernetes components that directly expose metrics to Prometheus are the following:
+### Scraping Metrics
 
-- kubelet
-- ingress-nginx*
+The following Kubernetes components are directly scraped by Prometheus:
+
+- kubelet*
+- ingress-nginx**
 - coreDns/kubeDns
 - kube-api-server
 
-\* For RKE and RKE2 clusters, ingress-nginx is deployed by default and treated as an internal Kubernetes component.
+\* You can optionally use hardenedKubelet.enabled to use a PushProx, but that is not the default.
 
-### 5.5. Scraping Metrics with PushProx
+** For RKE and RKE2 clusters, ingress-nginx is deployed by default and treated as an internal Kubernetes component.
 
-The purpose of this architecture is to allow us to scrape internal Kubernetes components without exposing those ports to inbound requests. As a result, Prometheus can scrape metrics across a network boundary.
 
-The Kubernetes components that expose metrics to Prometheus through PushProx are the following:
+### Scraping Metrics Based on Kubernetes Distribution
 
-- kube-controller-manager
-- kube-scheduler
-- etcd
-- kube-proxy
-
-For each PushProx exporter, we deploy one PushProx client onto all target nodes. For example, a PushProx client is deployed onto all controlplane nodes for kube-controller-manager, all etcd nodes for kube-etcd, and all nodes for kubelet. We deploy exactly one PushProx proxy per exporter.
-
-The process for exporting metrics is as follows:
-
-1. The PushProx Client establishes an outbound connection with the PushProx Proxy.
-2. The client then polls the proxy for scrape requests that have come into the proxy.
-3. When the proxy receives a scrape request from Prometheus, the client sees it as a result of the poll.
-4. The client scrapes the internal component.
-5. The internal component responds by pushing metrics back to the proxy.
-
-<figcaption>Process for Exporting Metrics with PushProx</figcaption>
-
-![Process for Exporting Metrics with PushProx]({{<baseurl>}}/img/rancher/pushprox-process.svg)
-
-Metrics are scraped differently based on the Kubernetes distribution. For help with terminology, see Terminology(#terminology). For details, see the table below:
+Metrics are scraped differently based on the Kubernetes distribution. For help with terminology, refer [here](#terminology). For details, see the table below:
 
 <figcaption>How Metrics are Exposed to Prometheus</figcaption>
 
@@ -239,7 +226,7 @@ Metrics are scraped differently based on the Kubernetes distribution. For help w
 
 \* For RKE and RKE2 clusters, ingress-nginx is deployed by default and treated as an internal Kubernetes component.
 
-### 5.6. Terminology
+### Terminology
 
 - **kube-scheduler:** The internal Kubernetes component that uses information in the pod spec to decide on which node to run a pod.
 - **kube-controller-manager:** The internal Kubernetes component that is responsible for node management (detecting if a node fails), pod replication and endpoint creation.

--- a/content/rancher/v2.6/en/monitoring-alerting/how-monitoring-works/_index.md
+++ b/content/rancher/v2.6/en/monitoring-alerting/how-monitoring-works/_index.md
@@ -13,7 +13,7 @@ weight: 1
 
 _**The following steps describe how data flows through the Monitoring V2 application:**_
 
-**1.** **ServiceMonitors and PodMonitors** declaratively specify targets, such as Services and Pods, that need to be monitored.
+**1. ServiceMonitors and PodMonitors** declaratively specify targets, such as Services and Pods, that need to be monitored.
 
 - Targets are scraped on a recurring schedule based on the configured Prometheus scrape interval, and the metrics that are scraped are stored into the Prometheus Time Series Database (TSDB).
 - In order to perform the scrape, ServiceMonitors and PodMonitors are defined with label selectors that determine which Services or Pods should be scraped and endpoints that determine how the scrape should happen on the given target, e.g., scrape/metrics in TCP 10252, proxying through IP addr x.x.x.x.
@@ -38,12 +38,12 @@ _**The following steps describe how data flows through the Monitoring V2 applica
 
     For more information, see [Scraping and Exposing Metrics](#5-scraping-and-exposing-metrics).
 
-**2.** **PrometheusRules** allow users to define rules for what metrics or time series database queries should result in alerts being fired. Rules are evaluated on an interval.
+**2. PrometheusRules** allow users to define rules for what metrics or time series database queries should result in alerts being fired. Rules are evaluated on an interval.
 
 - **Recording rules** create a new time series based on existing series that have been collected. They are frequently used to precompute complex queries.
 - **Alerting rules** run a particular query and fire an alert from Prometheus if the query evaluates to a non-zero value.
 
-**3.** **Prometheus Operator** observes ServiceMonitors, PodMonitors, and PrometheusRules being created. When the Prometheus configuration resources are created, Prometheus Operator calls the Prometheus API to sync the new configuration.
+**3. Prometheus Operator** observes ServiceMonitors, PodMonitors, and PrometheusRules being created. When the Prometheus configuration resources are created, Prometheus Operator calls the Prometheus API to sync the new configuration.
 
 **4.** Once Prometheus determines that an alert needs to be fired, alerts are forwarded to **Alertmanager**.
 
@@ -124,7 +124,7 @@ By editing custom YAML in the Alertmanager or Receiver configuration, you can al
 
 # 4. Monitoring V2 Specific Components
 
-Prometheus Operator introduces a set of [Custom Resource Definitions](https://github.com/prometheus-operator/prometheus-operator#customresourcedefinitions) that allow users to deploy and manage Prometheus and Alertmanager instances by creating and modifying those custom resources on a cluster. 
+Prometheus Operator introduces a set of [Custom Resource Definitions](https://github.com/prometheus-operator/prometheus-operator#customresourcedefinitions) that allow users to deploy and manage Prometheus and Alertmanager instances by creating and modifying those custom resources on a cluster.
 
 Prometheus Operator will automatically update your Prometheus configuration based on the live state of the resources and configuration options that are edited in the Rancher UI.
 
@@ -138,15 +138,15 @@ The resources that get deployed onto your cluster to support this solution can b
 
 Monitoring V2 deploys three default exporters that provide additional metrics for Prometheus to store:
 
-1. `node-exporter`: exposes hardware and OS metrics for Linux hosts. For more information on `node-exporter`, refer to the [upstream documentation.](https://prometheus.io/docs/guides/node-exporter/)
+1. `node-exporter`: exposes hardware and OS metrics for Linux hosts. For more information on `node-exporter`, refer to the [upstream documentation](https://prometheus.io/docs/guides/node-exporter/).
 
-1. `windows-exporter`: exposes hardware and OS metrics for Windows hosts (only deployed on Windows clusters).
+1. `windows-exporter`: exposes hardware and OS metrics for Windows hosts (only deployed on Windows clusters). For more information on `windows-exporter`, refer to the [upstream documentation](https://github.com/prometheus-community/windows_exporter).
 
-1. [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics): expose additional metrics that track the state of resources contained in the Kubernetes API (e.g. pods, workloads, etc.).
+1. `kube-state-metrics`: expose additional metrics that track the state of resources contained in the Kubernetes API (e.g., pods, workloads, etc.). For more information on `kube-state-metrics`, refer to the [upstream documentation](https://github.com/kubernetes/kube-state-metrics/tree/master/docs).
 
 ServiceMonitors and PodMonitors will scrape these exporters, as defined [here](#defining-what-metrics-are-scraped). Prometheus stores these metrics, and you can query the results via either Prometheus's UI or Grafana.
 
-See [architecture](#1-architecture-overview) section for more information on recording rules, alerting rules, and Alertmanager.
+See the [architecture](#1-architecture-overview) section for more information on recording rules, alerting rules, and Alertmanager.
 
 ### Components Exposed in the Rancher UI
 
@@ -156,7 +156,7 @@ When the monitoring application is installed, you will be able to edit the follo
 |--------------|------------------------|---------------------------|
 | ServiceMonitor | Custom resource | Sets up Kubernetes Services to scrape custom metrics from. Automatically updates the scrape configuration in the Prometheus custom resource. |
 | PodMonitor | Custom resource | Sets up Kubernetes Pods to scrape custom metrics from. Automatically updates the scrape configuration in the Prometheus custom resource. |
-| Receiver | Configuration block (part of Alertmanager) | Modifies information on where to send an alert (e.g. Slack, PagerDuty, etc.) and any necessary information to send the alert (e.g. TLS certs, proxy URLs, etc.). Automatically updates the Alertmanager custom resource. |
+| Receiver | Configuration block (part of Alertmanager) | Modifies information on where to send an alert (e.g., Slack, PagerDuty, etc.) and any necessary information to send the alert (e.g., TLS certs, proxy URLs, etc.). Automatically updates the Alertmanager custom resource. |
 | Route | Configuration block (part of Alertmanager) | Modifies the routing tree that is used to filter, label, and group alerts based on labels and send them to the appropriate Receiver. Automatically updates the Alertmanager custom resource. |
 | PrometheusRule | Custom resource | Defines additional queries that need to trigger alerts or define materialized views of existing series that are within Prometheus's TSDB.  Automatically updates the Prometheus custom resource. |
 
@@ -203,7 +203,7 @@ The following Kubernetes components are directly scraped by Prometheus:
 - coreDns/kubeDns
 - kube-api-server
 
-\* You can optionally use hardenedKubelet.enabled to use a PushProx, but that is not the default.
+\* You can optionally use `hardenedKubelet.enabled` to use a PushProx, but that is not the default.
 
 ** For RKE and RKE2 clusters, ingress-nginx is deployed by default and treated as an internal Kubernetes component.
 

--- a/content/rancher/v2.6/en/monitoring-alerting/how-monitoring-works/_index.md
+++ b/content/rancher/v2.6/en/monitoring-alerting/how-monitoring-works/_index.md
@@ -8,56 +8,68 @@ weight: 1
 3. [How Alertmanager Works](#3-how-alertmanager-works)
 4. [Monitoring V2 Specific Components](#4-monitoring-v2-specific-components)
 5. [Scraping and Exposing Metrics](#5-scraping-and-exposing-metrics)
-6. [Monitoring on RKE2 Clusters](#6-monitoring-on-rke2-clusters)
 
 # 1. Architecture Overview
 
-This diagram shows how data flows through the Monitoring V2 application:
+_**The following steps describe how data flows through the Monitoring V2 application:**_
 
-{{% row %}}
-{{% column %}}
+**1.** **ServiceMonitors and PodMonitors** declaratively specify targets, such as Services and Pods, that need to be monitored.
 
-![How data flows through the monitoring application]({{<baseurl>}}/img/rancher/monitoring-v2-architecture-overview.svg)
+- Targets are scraped on a recurring schedule based on the configured Prometheus scrape interval, and the metrics that are scraped are stored into the Prometheus Time Series Database (TSDB).
+- In order to perform the scrape, ServiceMonitors and PodMonitors are defined with label selectors that determine which Services or Pods should be scraped and endpoints that determine how the scrape should happen on the given target, e.g., scrape/metrics in TCP 10252, proxying through IP addr x.x.x.x.
+- Out of the box, Monitoring V2 comes with certain pre-configured exporters that are deployed based on the type of Kubernetes cluster that it is deployed on.
+    - Certain internal Kubernetes components are scraped via a proxy deployed as part of Monitoring V2 called **PushProx**. The Kubernetes components that expose metrics to Prometheus through PushProx are the following:
+    `kube-controller-manager`, `kube-scheduler`, `etcd`, and `kube-proxy`.
+    - For each PushProx exporter, we deploy one PushProx client onto all target nodes. For example, a PushProx client is deployed onto all controlplane nodes for kube-controller-manager, all etcd nodes for kube-etcd, and all nodes for kubelet. 
+    
+    - We deploy exactly one PushProx proxy per exporter. The process for exporting metrics is as follows:
 
-{{% /column %}}
-{{% column %}}
+        1. The PushProx Client establishes an outbound connection with the PushProx Proxy.
+        1. The client then polls the proxy for scrape requests that have come into the proxy.
+        1. When the proxy receives a scrape request from Prometheus, the client sees it as a result of the poll.
+        1. The client scrapes the internal component.
+        1. The internal component responds by pushing metrics back to the proxy.
+    
+    </br>
 
+    <figcaption>Process for Exporting Metrics with PushProx:</figcaption>
 
-1. Rules define what Prometheus metrics or time series database queries should result in alerts being fired.
-2. ServiceMonitors and PodMonitors declaratively specify how services and pods should be monitored. They use labels to scrape metrics from pods.
-3. Prometheus Operator observes ServiceMonitors, PodMonitors and PrometheusRules being created.
-4. When the Prometheus configuration resources are created, Prometheus Operator calls the Prometheus API to sync the new configuration.
-5. Recording Rules are not directly used for alerting. They create new time series of precomputed queries. These new time series data can then be queried to generate alerts.
-6. Prometheus scrapes all targets in the scrape configuration on a recurring schedule based on the scrape interval, storing the results in its time series database.Depending on the Kubernetes master component and Kubernetes distribution, the metrics from a certain Kubernetes component could be directly exposed to Prometheus, proxied through PushProx, or not available. For details, see Scraping and Exposing Metrics.
-7. Prometheus evaluates the alerting rules against the time series database. It fires alerts to Alertmanager whenever an alerting rule evaluates to a positive number.
-8. Alertmanager uses routes to group, label and filter the fired alerts to translate them into useful notifications.
-9. Alertmanager uses the  Receiver configuration to send notifications to Slack, PagerDuty, SMS, or other types of receivers.
+    ![Process for Exporting Metrics with PushProx]({{<baseurl>}}/img/rancher/pushprox-process.svg)
 
-{{% /column %}}
-{{% /row %}}
+    For more information, see [Scraping and Exposing Metrics](#5-scraping-and-exposing-metrics).
 
+**2.** **PrometheusRules** allow users to define rules for what metrics or time series database queries should result in alerts being fired. Rules are evaluated on an interval.
 
+- **Recording rules** create a new time series based on existing series that have been collected. They are frequently used to precompute complex queries.
+- **Alerting rules** run a particular query and fire an alert from Prometheus if the query evaluates to a non-zero value.
+
+**3.** **Prometheus Operator** observes ServiceMonitors, PodMonitors, and PrometheusRules being created. When the Prometheus configuration resources are created, Prometheus Operator calls the Prometheus API to sync the new configuration.
+
+**4.** Once Prometheus determines that an alert needs to be fired, alerts are forwarded to **Alertmanager**.
+
+- Alerts contain labels that come from the PromQL query itself and additional labels and annotations that can be provided as part of specifying the initial PrometheusRule.
+- Before receiving any alerts, Alertmanager will use the **routes** and **receivers** specified in its configuration to form a routing tree on which all incoming alerts are evaluated. Each node of the routing tree can specify additional grouping, labeling, and filtering that needs to happen based on the labels attached to the Prometheus alert. A node on the routing tree (usually a leaf node) can also specify that an alert that reaches it needs to be sent out to a configured Receiver, e.g., Slack, PagerDuty, SMS, etc. Note that Alertmanager will send an alert first to **alertingDriver**, then alertingDriver will send or forward alert to the proper destination.
+- Routes and receivers are also stored in the Kubernetes API via the Alertmanager Secret. When the Secret is updated, Alertmanager is also updated automatically. Note that routing occurs via labels only (not via annotations, etc.).
+
+<figcaption>How data flows through the monitoring application:</figcaption>
 
 
 # 2. How Prometheus Works
 
-### 2.1. Storing Time Series Data
+### Storing Time Series Data
 
 After collecting metrics from exporters, Prometheus stores the time series in a local on-disk time series database. Prometheus optionally integrates with remote systems, but `rancher-monitoring` uses local storage for the time series database.
 
-The database can then be queried using PromQL, the query language for Prometheus. Grafana dashboards use PromQL queries to generate data visualizations.
+Once stored, users can query this TSDB using PromQL, the query language for Prometheus.
 
-### 2.2. Querying the Time Series Database
+PromQL queries can be visualized in one of two ways:
 
-The PromQL query language is the primary tool to query Prometheus for time series data.
+1. By supplying the query in Prometheus's Graph UI, which will show a simple graphical view of the data.
+1. By creating a Grafana Dashboard that contains the PromQL query and additional formatting directives that label axes, add units, change colors, use alternative visualizations, etc.
 
-In Grafana, you can right-click a CPU utilization and click Inspect. This opens a panel that shows the [raw query results.](https://grafana.com/docs/grafana/latest/panels/inspect-panel/#inspect-raw-query-results)The raw results demonstrate how each dashboard is powered by PromQL queries.
+### Defining Rules for Prometheus
 
-### 2.3. Defining Rules for when Alerts Should be Fired
-
-Rules define the conditions for Prometheus to fire alerts. When PrometheusRule custom resources are created or updated, the Prometheus Operator observes the change and calls the Prometheus API to synchronize the rule configuration with the Alerting Rules and Recording Rules in Prometheus.
-
-When you define a Rule (which is declared within a RuleGroup in a PrometheusRule resource), the [spec of the Rule itself](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#rule) contains labels that are used by Alertmanager to figure out which Route should receive this Alert. For example, an Alert with the label `team: front-end` will be sent to all Routes that match on that label.
+Rules define queries that Prometheus needs to execute on a regular `evaluationInterval` to perform certain actions, such as firing an alert (alerting rules) or precomputing a query based on others existing in its TSDB (recording rules). These rules are encoded in PrometheusRules custom resources. When PrometheusRule custom resources are created or updated, the Prometheus Operator observes the change and calls the Prometheus API to synchronize the set of rules that Prometheus is currently evaluating on a regular interval.
 
 A PrometheusRule allows you to define one or more RuleGroups. Each RuleGroup consists of a set of Rule objects that can each represent either an alerting or a recording rule with the following fields:
 
@@ -66,7 +78,9 @@ A PrometheusRule allows you to define one or more RuleGroups. Each RuleGroup con
 - Labels that should be attached to the alert or record that identify it (e.g. cluster name or severity)
 - Annotations that encode any additional important pieces of information that need to be displayed on the notification for an alert (e.g. summary, description, message, runbook URL, etc.). This field is not required for recording rules.
 
-### 2.4. Firing Alerts
+On evaluating a [rule](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#rule), Prometheus will execute the provided PromQL query, add additional provided labels (or annotations - only for alerting rules), and execute the appropriate action for the rule. For example, an Alerting Rule that adds `team: front-end` as a label to the provided PromQL query will append that label to the fired alert, which will allow Alertmanager to forward the alert to the correct Receiver.
+
+### Alerting and Recording Rules
 
 Prometheus doesn't maintain the state of whether alerts are active. It fires alerts repetitively at every evaluation interval, relying on Alertmanager to group and filter the alerts into meaningful notifications.
 
@@ -91,14 +105,18 @@ The Alertmanager handles alerts sent by client applications such as the Promethe
 - Silencing and inhibition of alerts
 - Tracking alerts that fire over time
 - Sending out the status of whether an alert is currently firing, or if it is resolved
+
+### Alerts Forwarded by alertingDrivers
+
+When alertingDrivers are installed, this creates a `Service` that can be used as the receiver's URL for Teams or SMS, based on the alertingDriver's configuration. The URL in the Receiver points to the alertingDrivers; so the Alertmanager sends alert first to alertingDriver, then alertingDriver forwards or sends alert to the proper destination.
     
-### 3.1. Routing Alerts to Receivers
+### Routing Alerts to Receivers
 
 Alertmanager coordinates where alerts are sent. It allows you to group alerts based on labels and fire them based on whether certain labels are matched. One top-level route accepts all alerts. From there, Alertmanager continues routing alerts to receivers based on whether they match the conditions of the next route.
 
-While the Rancher UI forms only allow editing a routing tree that is two levels deep, you can configure more deeply nested routing structures by editing the Alertmanager custom resource YAML.
+While the Rancher UI forms only allow editing a routing tree that is two levels deep, you can configure more deeply nested routing structures by editing the Alertmanager Secret.
 
-### 3.2. Configuring Multiple Receivers
+### Configuring Multiple Receivers
 
 By editing the forms in the Rancher UI, you can set up a Receiver resource with all the information Alertmanager needs to send alerts to your notification system.
 
@@ -106,124 +124,93 @@ By editing custom YAML in the Alertmanager or Receiver configuration, you can al
 
 # 4. Monitoring V2 Specific Components
 
-Prometheus Operator introduces a set of [Custom Resource Definitions](https://github.com/prometheus-operator/prometheus-operator#customresourcedefinitions) that allow users to deploy and manage Prometheus and Alertmanager instances by creating and modifying those custom resources on a cluster.
+Prometheus Operator introduces a set of [Custom Resource Definitions](https://github.com/prometheus-operator/prometheus-operator#customresourcedefinitions) that allow users to deploy and manage Prometheus and Alertmanager instances by creating and modifying those custom resources on a cluster. 
 
 Prometheus Operator will automatically update your Prometheus configuration based on the live state of the resources and configuration options that are edited in the Rancher UI.
 
-### 4.1. Resources Deployed by Default
+### Resources Deployed by Default
 
 By default, a set of resources curated by the [kube-prometheus](https://github.com/prometheus-operator/kube-prometheus) project are deployed onto your cluster as part of installing the Rancher Monitoring Application to set up a basic Monitoring/Alerting stack.
 
 The resources that get deployed onto your cluster to support this solution can be found in the [`rancher-monitoring`](https://github.com/rancher/charts/tree/main/charts/rancher-monitoring) Helm chart, which closely tracks the upstream [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) Helm chart maintained by the Prometheus community with certain changes tracked in the [CHANGELOG.md](https://github.com/rancher/charts/blob/main/charts/rancher-monitoring/CHANGELOG.md).
 
-There are also certain special types of ConfigMaps and Secrets such as those corresponding to Grafana Dashboards, Grafana Datasources, and Alertmanager Configs that will automatically update your Prometheus configuration via sidecar proxies that observe the live state of those resources within your cluster.
+### Default Exporters
 
-### 4.2. PushProx
+Monitoring V2 deploys three default exporters that provide additional metrics for Prometheus to store:
 
-PushProx enhances the security of the monitoring application, allowing it to be installed on hardened Kubernetes clusters.
+1. `node-exporter`: exposes hardware and OS metrics for Linux hosts. For more information on `node-exporter`, refer to the [upstream documentation.](https://prometheus.io/docs/guides/node-exporter/)
 
-To expose Kubernetes metrics, PushProxes use a client proxy model to expose specific ports within default Kubernetes components. Node exporters expose metrics to PushProx through an outbound connection.
+1. `windows-exporter`: exposes hardware and OS metrics for Windows hosts (only deployed on Windows clusters).
 
-The proxy allows `rancher-monitoring` to scrape metrics from processes on the hostNetwork, such as the `kube-api-server`, without opening up node ports to inbound connections.
+1. [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics): expose additional metrics that track the state of resources contained in the Kubernetes API (e.g. pods, workloads, etc.).
 
-PushProx is a DaemonSet that listens for clients that seek to register. Once registered, it proxies scrape requests through the established connection. Then the client executes the request to etcd.
+ServiceMonitors and PodMonitors will scrape these exporters, as defined [here](#defining-what-metrics-are-scraped). Prometheus stores these metrics, and you can query the results via either Prometheus's UI or Grafana.
 
-All of the default ServiceMonitors, such as `rancher-monitoring-kube-controller-manager`, are configured to hit the metrics endpoint of the client using this proxy.
+See [architecture](#1-architecture-overview) section for more information on recording rules, alerting rules, and Alertmanager.
 
-For more details about how PushProx works, refer to [Scraping Metrics with PushProx.](#5-5-scraping-metrics-with-pushprox)
-
-
-### 4.3. Default Exporters
-
-`rancher-monitoring` deploys two exporters to expose metrics to prometheus: `node-exporter` and `windows-exporter`. Both are deployed as DaemonSets.
-
-`node-exporter` exports container, pod and node metrics for CPU and memory from each Linux node. `windows-exporter` does the same, but for Windows nodes.
-
-For more information on `node-exporter`, refer to the [upstream documentation.](https://prometheus.io/docs/guides/node-exporter/)
-
-[kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) is also useful because it exports metrics for Kubernetes components.
-
-# 4.4. Components Exposed in the Rancher UI
+### Components Exposed in the Rancher UI
 
 When the monitoring application is installed, you will be able to edit the following components in the Rancher UI:
 
 | Component | Type of Component | Purpose and Common Use Cases for Editing |
 |--------------|------------------------|---------------------------|
-| ServiceMonitor | Custom resource | Set up targets to scrape custom metrics from. Automatically updates the scrape configuration in the Prometheus custom resource. |
-| PodMonitor | Custom resource | Set up targets to scrape custom metrics from. Automatically updates the scrape configuration in the Prometheus custom resource. |
-| Receiver | Configuration block (part of Alertmanager) | Set up a notification system to receive alerts. Automatically updates the Alertmanager custom resource. |
-| Route | Configuration block (part of Alertmanager) | Add identifying information to make alerts more meaningful and direct them to individual teams. Automatically updates the Alertmanager custom resource. |
-| PrometheusRule | Custom resource | For more advanced use cases, you may want to define what Prometheus metrics or time series database queries should result in alerts being fired.  Automatically updates the Prometheus custom resource. |
-| Alertmanager | Custom resource | Edit this custom resource only if you need more advanced configuration options beyond what the Rancher UI exposes in the Routes and Receivers sections. For example, you might want to edit this resource to add a routing tree with more than two levels. |
-| Prometheus | Custom resource | Edit this custom resource only if you need more advanced configuration beyond what can be configured using  ServiceMonitors, PodMonitors, or [Rancher monitoring Helm chart options.](../configuration/helm-chart-options) |
+| ServiceMonitor | Custom resource | Sets up Kubernetes Services to scrape custom metrics from. Automatically updates the scrape configuration in the Prometheus custom resource. |
+| PodMonitor | Custom resource | Sets up Kubernetes Pods to scrape custom metrics from. Automatically updates the scrape configuration in the Prometheus custom resource. |
+| Receiver | Configuration block (part of Alertmanager) | Modifies information on where to send an alert (e.g. Slack, PagerDuty, etc.) and any necessary information to send the alert (e.g. TLS certs, proxy URLs, etc.). Automatically updates the Alertmanager custom resource. |
+| Route | Configuration block (part of Alertmanager) | Modifies the routing tree that is used to filter, label, and group alerts based on labels and send them to the appropriate Receiver. Automatically updates the Alertmanager custom resource. |
+| PrometheusRule | Custom resource | Defines additional queries that need to trigger alerts or define materialized views of existing series that are within Prometheus's TSDB.  Automatically updates the Prometheus custom resource. |
+
+### How PushProx Works
+
+PushProx allows Prometheus to scrape metrics across a network boundary, which prevents users from having to expose metrics ports for internal Kubernetes components on each node in a Kubernetes cluster.
+
+Since the metrics for Kubernetes components are generally exposed on the host network of nodes in the cluster, PushProx deploys a DaemonSet of clients that sit on the hostNetwork of each node and make an outbound connection to a single proxy that is sitting on the Kubernetes API. Prometheus can then be configured to proxy scrape requests through the proxy to each client, which allows it to scrape metrics from the internal Kubernetes components without requiring any inbound node ports to be open.
+
+For more details about how PushProx works, refer to [Scraping Metrics with PushProx](#scraping-metrics-with-pushprox).
 
 # 5. Scraping and Exposing Metrics
 
-### 5.1. Defining what Metrics are Scraped
+### Defining what Metrics are Scraped
 
-ServiceMonitors define targets that are intended for Prometheus to scrape. The [Prometheus custom resource tells](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/design.md#prometheus) Prometheus which ServiceMonitors it should use to find out where to scrape metrics from.
+ServiceMonitors and PodMonitors define targets that are intended for Prometheus to scrape. The [Prometheus custom resource](https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/design.md#prometheus) tells Prometheus which ServiceMonitors or PodMonitors it should use to find out where to scrape metrics from.
 
-The Prometheus Operator observes the ServiceMonitors. When it observes that ServiceMonitors are created or updated, it calls the Prometheus API to update the scrape configuration in the Prometheus custom resource and keep it in sync with the scrape configuration in the ServiceMonitors. This scrape configuration tells Prometheus which endpoints to scrape metrics from and how it will label the metrics from those endpoints.
+The Prometheus Operator observes the ServiceMonitors and PodMonitors. When it observes that they are created or updated, it calls the Prometheus API to update the scrape configuration in the Prometheus custom resource and keep it in sync with the scrape configuration in the ServiceMonitors or PodMonitors. This scrape configuration tells Prometheus which endpoints to scrape metrics from and how it will label the metrics from those endpoints.
 
 Prometheus scrapes all of the metrics defined in its scrape configuration at every `scrape_interval`, which is one minute by default.
 
 The scrape configuration can be viewed as part of the Prometheus custom resource that is exposed in the Rancher UI.
 
-### 5.2. How the Prometheus Operator Sets up Metrics Scraping
+### How the Prometheus Operator Sets up Metrics Scraping
 
 The Prometheus Deployment or StatefulSet scrapes metrics, and the configuration of Prometheus is controlled by the Prometheus custom resources. The Prometheus Operator watches for Prometheus and Alertmanager resources, and when they are created, the Prometheus Operator creates a Deployment or StatefulSet for Prometheus or Alertmanager with the user-defined configuration.
 
-<figcaption>How the Prometheus Operator Sets up Metrics Scraping</figcaption>
+When the Prometheus Operator observes ServiceMonitors, PodMonitors, and PrometheusRules being created, it knows that the scrape configuration needs to be updated in Prometheus. It updates Prometheus by first updating the configuration and rules files in the volumes of Prometheus's Deployment or StatefulSet. Then it calls the Prometheus API to sync the new configuration, resulting in the Prometheus Deployment or StatefulSet to be modified in place.
 
-![How the Prometheus Operator sets up metrics scraping]({{<baseurl>}}/img/rancher/set-up-scraping.svg)
-
-When the Prometheus Operator observes ServiceMonitors, PodMonitors and PrometheusRules being created, it knows that the scrape configuration needs to be updated in Prometheus. It updates Prometheus by first updating the configuration and rules files in the volumes of Prometheus's Deployment or StatefulSet. Then it calls the Prometheus API to sync the new configuration, resulting in the Prometheus Deployment or StatefulSet to be modified in place.
-
-![How the Prometheus Operator Updates Scrape Configuration]({{<baseurl>}}/img/rancher/update-scrape-config.svg)
-
-### 5.3. How Kubernetes Component Metrics are Exposed
+### How Kubernetes Component Metrics are Exposed
 
 Prometheus scrapes metrics from deployments known as [exporters,](https://prometheus.io/docs/instrumenting/exporters/) which export the time series data in a format that Prometheus can ingest. In Prometheus, time series consist of streams of timestamped values belonging to the same metric and the same set of labeled dimensions.
 
-To allow monitoring to be installed on hardened Kubernetes clusters, `rancher-monitoring` application proxies the communication between Prometheus and the exporter through PushProx for some Kubernetes master components.
+### Scraping Metrics with PushProx
 
-### 5.4. Scraping Metrics without PushProx
+Certain internal Kubernetes components are scraped via a proxy deployed as part of Monitoring V2 called PushProx. For detailed information on PushProx, refer [here](#pushprox) and to the above [architecture](#1-architecture-overview) section.
 
-The Kubernetes components that directly expose metrics to Prometheus are the following:
+### Scraping Metrics
 
-- kubelet
-- ingress-nginx*
+The following Kubernetes components are directly scraped by Prometheus:
+
+- kubelet*
+- ingress-nginx**
 - coreDns/kubeDns
 - kube-api-server
 
-\* For RKE and RKE2 clusters, ingress-nginx is deployed by default and treated as an internal Kubernetes component.
+\* You can optionally use hardenedKubelet.enabled to use a PushProx, but that is not the default.
 
-### 5.5. Scraping Metrics with PushProx
+** For RKE and RKE2 clusters, ingress-nginx is deployed by default and treated as an internal Kubernetes component.
 
-The purpose of this architecture is to allow us to scrape internal Kubernetes components without exposing those ports to inbound requests. As a result, Prometheus can scrape metrics across a network boundary.
 
-The Kubernetes components that expose metrics to Prometheus through PushProx are the following:
+### Scraping Metrics Based on Kubernetes Distribution
 
-- kube-controller-manager
-- kube-scheduler
-- etcd
-- kube-proxy
-
-For each PushProx exporter, we deploy one PushProx client onto all target nodes. For example, a PushProx client is deployed onto all controlplane nodes for kube-controller-manager, all etcd nodes for kube-etcd, and all nodes for kubelet. We deploy exactly one PushProx proxy per exporter.
-
-The process for exporting metrics is as follows:
-
-1. The PushProx Client establishes an outbound connection with the PushProx Proxy.
-2. The client then polls the proxy for scrape requests that have come into the proxy.
-3. When the proxy receives a scrape request from Prometheus, the client sees it as a result of the poll.
-4. The client scrapes the internal component.
-5. The internal component responds by pushing metrics back to the proxy.
-
-<figcaption>Process for Exporting Metrics with PushProx</figcaption>
-
-![Process for Exporting Metrics with PushProx]({{<baseurl>}}/img/rancher/pushprox-process.svg)
-
-Metrics are scraped differently based on the Kubernetes distribution. For help with terminology, see Terminology(#terminology). For details, see the table below:
+Metrics are scraped differently based on the Kubernetes distribution. For help with terminology, refer [here](#terminology). For details, see the table below:
 
 <figcaption>How Metrics are Exposed to Prometheus</figcaption>
 
@@ -240,7 +227,7 @@ Metrics are scraped differently based on the Kubernetes distribution. For help w
 
 \* For RKE and RKE2 clusters, ingress-nginx is deployed by default and treated as an internal Kubernetes component.
 
-### 5.6. Terminology
+### Terminology
 
 - **kube-scheduler:** The internal Kubernetes component that uses information in the pod spec to decide on which node to run a pod.
 - **kube-controller-manager:** The internal Kubernetes component that is responsible for node management (detecting if a node fails), pod replication and endpoint creation.
@@ -250,13 +237,3 @@ Metrics are scraped differently based on the Kubernetes distribution. For help w
 - **ingress-nginx:** An Ingress controller for Kubernetes using NGINX as a reverse proxy and load balancer.
 - **coreDns/kubeDns:** The internal Kubernetes component responsible for DNS.
 - **kube-api-server:** The main internal Kubernetes component that is responsible for exposing APIs for the other master components.
-
-# 6. Monitoring on RKE2 Clusters
-
-Rancher v2.6 introduced the ability to provision new Kubernetes clusters with [RKE2,](https://docs.rke2.io/) which is Rancher's fully conformant Kubernetes distribution that focuses on security and compliance within the U.S. Federal Government sector. To allow Monitoring V2 to be installed on RKE2 Kubernetes clusters, the `rkeIngressNginx` and `rke2IngressNginx` sub-charts were introduced to scrape metrics from the `ingress-nginx` Deployment/DaemonSet in RKE and RKE2 clusters respectively.
-
-The PushProx pod needs to run on the same nodes as the `ingress-nginx` pod.
-
-When the RKE2 cluster's Kubernetes version is <= 1.20,  the workload type of `ingress-nginx` is a Deployment. The `pushprox-ingress-nginx-client` is deployed as a Deployment, and the Rancher UI sets the Helm chart value `rke2IngressNginx.deployment.enabled=true`.
-
-For Kubernetes >= 1.21, the workload type of `ingress-nginx` is a DaemonSet. The `pushprox-ingress-nginx-client` is deployed as a DaemonSet, which is the default behavior.

--- a/content/rancher/v2.6/en/monitoring-alerting/how-monitoring-works/_index.md
+++ b/content/rancher/v2.6/en/monitoring-alerting/how-monitoring-works/_index.md
@@ -11,44 +11,57 @@ weight: 1
 
 # 1. Architecture Overview
 
-_**The following steps describe how data flows through the Monitoring V2 application:**_
+_**The following sections describe how data flows through the Monitoring V2 application:**_
 
-**1. ServiceMonitors and PodMonitors** declaratively specify targets, such as Services and Pods, that need to be monitored.
+### Prometheus Operator
+
+Prometheus Operator observes ServiceMonitors, PodMonitors, and PrometheusRules being created. When the Prometheus configuration resources are created, Prometheus Operator calls the Prometheus API to sync the new configuration. As the diagram at the end of this section shows, the Prometheus Operator acts as the intermediary between Prometheus and Kubernetes, calling the Prometheus API to synchronize Prometheus with the monitoring-related resources in Kubernetes.
+
+### ServiceMonitors and PodMonitors
+
+ServiceMonitors and PodMonitors declaratively specify targets, such as Services and Pods, that need to be monitored.
 
 - Targets are scraped on a recurring schedule based on the configured Prometheus scrape interval, and the metrics that are scraped are stored into the Prometheus Time Series Database (TSDB).
+
 - In order to perform the scrape, ServiceMonitors and PodMonitors are defined with label selectors that determine which Services or Pods should be scraped and endpoints that determine how the scrape should happen on the given target, e.g., scrape/metrics in TCP 10252, proxying through IP addr x.x.x.x.
-- Out of the box, Monitoring V2 comes with certain pre-configured exporters that are deployed based on the type of Kubernetes cluster that it is deployed on.
-    - Certain internal Kubernetes components are scraped via a proxy deployed as part of Monitoring V2 called **PushProx**. The Kubernetes components that expose metrics to Prometheus through PushProx are the following:
-    `kube-controller-manager`, `kube-scheduler`, `etcd`, and `kube-proxy`.
-    - For each PushProx exporter, we deploy one PushProx client onto all target nodes. For example, a PushProx client is deployed onto all controlplane nodes for kube-controller-manager, all etcd nodes for kube-etcd, and all nodes for kubelet. 
+
+- Out of the box, Monitoring V2 comes with certain pre-configured exporters that are deployed based on the type of Kubernetes cluster that it is deployed on. For more information, see [Scraping and Exposing Metrics](#5-scraping-and-exposing-metrics).
+
+### How PushProx Works
+
+- Certain internal Kubernetes components are scraped via a proxy deployed as part of Monitoring V2 called **PushProx**. The Kubernetes components that expose metrics to Prometheus through PushProx are the following:
+`kube-controller-manager`, `kube-scheduler`, `etcd`, and `kube-proxy`.
+
+- For each PushProx exporter, we deploy one PushProx client onto all target nodes. For example, a PushProx client is deployed onto all controlplane nodes for kube-controller-manager, all etcd nodes for kube-etcd, and all nodes for kubelet. 
     
-    - We deploy exactly one PushProx proxy per exporter. The process for exporting metrics is as follows:
+- We deploy exactly one PushProx proxy per exporter. The process for exporting metrics is as follows:
 
-        1. The PushProx Client establishes an outbound connection with the PushProx Proxy.
-        1. The client then polls the proxy for scrape requests that have come into the proxy.
-        1. When the proxy receives a scrape request from Prometheus, the client sees it as a result of the poll.
-        1. The client scrapes the internal component.
-        1. The internal component responds by pushing metrics back to the proxy.
+1. The PushProx Client establishes an outbound connection with the PushProx Proxy.    
+1. The client then polls the proxy for scrape requests that have come into the proxy.
+1. When the proxy receives a scrape request from Prometheus, the client sees it as a result of the poll.
+1. The client scrapes the internal component.
+1. The internal component responds by pushing metrics back to the proxy.
     
-    </br>
 
-    <figcaption>Process for Exporting Metrics with PushProx:</figcaption>
+<figcaption><br>Process for Exporting Metrics with PushProx:</br></figcaption>
 
-    ![Process for Exporting Metrics with PushProx]({{<baseurl>}}/img/rancher/pushprox-process.svg)
+![Process for Exporting Metrics with PushProx]({{<baseurl>}}/img/rancher/pushprox-process.svg)
 
-    For more information, see [Scraping and Exposing Metrics](#5-scraping-and-exposing-metrics).
+### PrometheusRules
 
-**2. PrometheusRules** allow users to define rules for what metrics or time series database queries should result in alerts being fired. Rules are evaluated on an interval.
+PrometheusRules allow users to define rules for what metrics or time series database queries should result in alerts being fired. Rules are evaluated on an interval.
 
 - **Recording rules** create a new time series based on existing series that have been collected. They are frequently used to precompute complex queries.
 - **Alerting rules** run a particular query and fire an alert from Prometheus if the query evaluates to a non-zero value.
 
-**3. Prometheus Operator** observes ServiceMonitors, PodMonitors, and PrometheusRules being created. When the Prometheus configuration resources are created, Prometheus Operator calls the Prometheus API to sync the new configuration.
+### Alert Routing
 
-**4.** Once Prometheus determines that an alert needs to be fired, alerts are forwarded to **Alertmanager**.
+Once Prometheus determines that an alert needs to be fired, alerts are forwarded to **Alertmanager**.
 
 - Alerts contain labels that come from the PromQL query itself and additional labels and annotations that can be provided as part of specifying the initial PrometheusRule.
+
 - Before receiving any alerts, Alertmanager will use the **routes** and **receivers** specified in its configuration to form a routing tree on which all incoming alerts are evaluated. Each node of the routing tree can specify additional grouping, labeling, and filtering that needs to happen based on the labels attached to the Prometheus alert. A node on the routing tree (usually a leaf node) can also specify that an alert that reaches it needs to be sent out to a configured Receiver, e.g., Slack, PagerDuty, SMS, etc. Note that Alertmanager will send an alert first to **alertingDriver**, then alertingDriver will send or forward alert to the proper destination.
+
 - Routes and receivers are also stored in the Kubernetes API via the Alertmanager Secret. When the Secret is updated, Alertmanager is also updated automatically. Note that routing occurs via labels only (not via annotations, etc.).
 
 <figcaption>How data flows through the monitoring application:</figcaption>
@@ -95,6 +108,7 @@ Alerting rules are more commonly used. Whenever an alerting rule evaluates to a 
 The Rule file adds labels and annotations to alerts before firing them, depending on the use case:
 
 - Labels indicate information that identifies the alert and could affect the routing of the alert. For example, if when sending an alert about a certain container, the container ID could be used as a label.
+
 - Annotations denote information that doesn't affect where an alert is routed, for example, a runbook or an error message.
 
 # 3. How Alertmanager Works
@@ -102,8 +116,11 @@ The Rule file adds labels and annotations to alerts before firing them, dependin
 The Alertmanager handles alerts sent by client applications such as the Prometheus server. It takes care of the following tasks:
 
 - Deduplicating, grouping, and routing alerts to the correct receiver integration such as email, PagerDuty, or OpsGenie
+
 - Silencing and inhibition of alerts
+
 - Tracking alerts that fire over time
+
 - Sending out the status of whether an alert is currently firing, or if it is resolved
 
 ### Alerts Forwarded by alertingDrivers
@@ -160,13 +177,13 @@ When the monitoring application is installed, you will be able to edit the follo
 | Route | Configuration block (part of Alertmanager) | Modifies the routing tree that is used to filter, label, and group alerts based on labels and send them to the appropriate Receiver. Automatically updates the Alertmanager custom resource. |
 | PrometheusRule | Custom resource | Defines additional queries that need to trigger alerts or define materialized views of existing series that are within Prometheus's TSDB.  Automatically updates the Prometheus custom resource. |
 
-### How PushProx Works
+### PushProx
 
 PushProx allows Prometheus to scrape metrics across a network boundary, which prevents users from having to expose metrics ports for internal Kubernetes components on each node in a Kubernetes cluster.
 
 Since the metrics for Kubernetes components are generally exposed on the host network of nodes in the cluster, PushProx deploys a DaemonSet of clients that sit on the hostNetwork of each node and make an outbound connection to a single proxy that is sitting on the Kubernetes API. Prometheus can then be configured to proxy scrape requests through the proxy to each client, which allows it to scrape metrics from the internal Kubernetes components without requiring any inbound node ports to be open.
 
-For more details about how PushProx works, refer to [Scraping Metrics with PushProx](#scraping-metrics-with-pushprox).
+Refer to [Scraping Metrics with PushProx](#scraping-metrics-with-pushprox) for more.
 
 # 5. Scraping and Exposing Metrics
 
@@ -192,7 +209,7 @@ Prometheus scrapes metrics from deployments known as [exporters,](https://promet
 
 ### Scraping Metrics with PushProx
 
-Certain internal Kubernetes components are scraped via a proxy deployed as part of Monitoring V2 called PushProx. For detailed information on PushProx, refer [here](#pushprox) and to the above [architecture](#1-architecture-overview) section.
+Certain internal Kubernetes components are scraped via a proxy deployed as part of Monitoring V2 called PushProx. For detailed information on PushProx, refer [here](#how-pushprox-works) and to the above [architecture](#1-architecture-overview) section.
 
 ### Scraping Metrics
 


### PR DESCRIPTION
Closes #3688 (to be reviewed for 2.6.5 implementation)

References:
https://confluence.suse.com/display/EN/Monitoring+V2+Architecture+-+Draft
https://rancher.com/docs/rancher/v2.5/en/monitoring-alerting/how-monitoring-works/
https://rancher.com/docs/rancher/v2.6/en/monitoring-alerting/how-monitoring-works/

Note: Attaching revised diagram to also be reviewed that will go at the end of section 1, Architecture Overview.

![monitoring-V2-architecture-overview](https://user-images.githubusercontent.com/87146683/148434824-3919f889-d9cf-4111-a65d-e3f0435ff694.png)