### PR TITLE
Update Node version to 16 LTS

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,4 +1,4 @@
-FROM node:8-alpine
+FROM node:16-alpine
 
 RUN apk update && apk add py-pygments bash git asciidoc gcompat && rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
Update Node version from 8 to 16 LTS, which is the current active LTS with [EOL in 2024-04-30](https://nodejs.org/en/about/releases/).

Signed-off-by: Guilherme Macedo <guilherme.macedo@suse.com>