### PR TITLE
Make branch name dynamic when using --set privateCA=true

### DIFF
--- a/content/rancher/v2.0-v2.4/en/installation/install-rancher-on-k8s/_index.md
+++ b/content/rancher/v2.0-v2.4/en/installation/install-rancher-on-k8s/_index.md
@@ -231,7 +231,7 @@ helm install rancher rancher-<CHART_REPO>/rancher \
 If you are using a Private CA signed certificate , add `--set privateCA=true` to the command:
 
 ```
-helm install rancher rancher-latest/rancher \
+helm install rancher rancher-<CHART_REPO>/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org \
   --set ingress.tls.source=secret \

--- a/content/rancher/v2.5/en/installation/install-rancher-on-k8s/_index.md
+++ b/content/rancher/v2.5/en/installation/install-rancher-on-k8s/_index.md
@@ -245,7 +245,7 @@ helm install rancher rancher-<CHART_REPO>/rancher \
 If you are using a Private CA signed certificate , add `--set privateCA=true` to the command:
 
 ```
-helm install rancher rancher-latest/rancher \
+helm install rancher rancher-<CHART_REPO>/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org \
   --set ingress.tls.source=secret \

--- a/content/rancher/v2.6/en/installation/install-rancher-on-k8s/_index.md
+++ b/content/rancher/v2.6/en/installation/install-rancher-on-k8s/_index.md
@@ -234,7 +234,7 @@ helm install rancher rancher-<CHART_REPO>/rancher \
 If you are using a Private CA signed certificate , add `--set privateCA=true` to the command:
 
 ```
-helm install rancher rancher-latest/rancher \
+helm install rancher rancher-<CHART_REPO>/rancher \
   --namespace cattle-system \
   --set hostname=rancher.my.org \
   --set bootstrapPassword=admin \


### PR DESCRIPTION
The branch name listed when installing with `--set privateCA=true` should match everything else.

### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
