### PR TITLE
Added note to clarify that iSCSI volume example YAML is for RKE clusters only

### DIFF
--- a/content/rancher/v2.5/en/cluster-admin/volumes-and-storage/iscsi-volumes/_index.md
+++ b/content/rancher/v2.5/en/cluster-admin/volumes-and-storage/iscsi-volumes/_index.md
@@ -19,9 +19,12 @@ If you encounter this issue, you can work around it by installing the initiator 
 
 After installing the initiator tool on your nodes, edit the YAML for your cluster, editing the kubelet configuration to mount the iSCSI binary and configuration, as shown in the sample below.
 
->**Note:**
+>**Notes:**
+>  
+>- Before updating your Kubernetes YAML to mount the iSCSI binary and configuration, make sure either the `open-iscsi` (deb) or `iscsi-initiator-utils` (yum) package is installed on your cluster nodes. If this package isn't installed _before_ the bind mounts are created in your Kubernetes YAML, Docker will automatically create the directories and files on each node and will not allow the package install to succeed.</br>
+></br>
 >
->Before updating your Kubernetes YAML to mount the iSCSI binary and configuration, make sure either the `open-iscsi` (deb) or `iscsi-initiator-utils` (yum) package is installed on your cluster nodes. If this package isn't installed _before_ the bind mounts are created in your Kubernetes YAML, Docker will automatically create the directories and files on each node and will not allow the package install to succeed.
+>- The example YAML below does not apply to K3s. Since the K3s kubelet does not run in a container, adding extra binds is not necessary. However, all iSCSI tools must still be installed on your K3s nodes.
 
 ```
 services:

--- a/content/rancher/v2.5/en/cluster-admin/volumes-and-storage/iscsi-volumes/_index.md
+++ b/content/rancher/v2.5/en/cluster-admin/volumes-and-storage/iscsi-volumes/_index.md
@@ -24,7 +24,7 @@ After installing the initiator tool on your nodes, edit the YAML for your cluste
 >- Before updating your Kubernetes YAML to mount the iSCSI binary and configuration, make sure either the `open-iscsi` (deb) or `iscsi-initiator-utils` (yum) package is installed on your cluster nodes. If this package isn't installed _before_ the bind mounts are created in your Kubernetes YAML, Docker will automatically create the directories and files on each node and will not allow the package install to succeed.</br>
 ></br>
 >
->- The example YAML below does not apply to K3s. Since the K3s kubelet does not run in a container, adding extra binds is not necessary. However, all iSCSI tools must still be installed on your K3s nodes.
+>- The example YAML below does not apply to K3s, but only to RKE clusters. Since the K3s kubelet does not run in a container, adding extra binds is not necessary. However, all iSCSI tools must still be installed on your K3s nodes.
 
 ```
 services:

--- a/content/rancher/v2.6/en/cluster-admin/volumes-and-storage/iscsi-volumes/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/volumes-and-storage/iscsi-volumes/_index.md
@@ -17,9 +17,12 @@ If you encounter this issue, you can work around it by installing the initiator 
 
 After installing the initiator tool on your nodes, edit the YAML for your cluster, editing the kubelet configuration to mount the iSCSI binary and configuration, as shown in the sample below.
 
->**Note:**
+>**Notes:**
+>  
+>- Before updating your Kubernetes YAML to mount the iSCSI binary and configuration, make sure either the `open-iscsi` (deb) or `iscsi-initiator-utils` (yum) package is installed on your cluster nodes. If this package isn't installed _before_ the bind mounts are created in your Kubernetes YAML, Docker will automatically create the directories and files on each node and will not allow the package install to succeed.</br>
+></br> 
 >
->Before updating your Kubernetes YAML to mount the iSCSI binary and configuration, make sure either the `open-iscsi` (deb) or `iscsi-initiator-utils` (yum) package is installed on your cluster nodes. If this package isn't installed _before_ the bind mounts are created in your Kubernetes YAML, Docker will automatically create the directories and files on each node and will not allow the package install to succeed.
+>- The example YAML below does not apply to K3s. Since the K3s kubelet does not run in a container, adding extra binds is not necessary. However, all iSCSI tools must still be installed on your K3s nodes.
 
 ```
 services:

--- a/content/rancher/v2.6/en/cluster-admin/volumes-and-storage/iscsi-volumes/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/volumes-and-storage/iscsi-volumes/_index.md
@@ -22,7 +22,7 @@ After installing the initiator tool on your nodes, edit the YAML for your cluste
 >- Before updating your Kubernetes YAML to mount the iSCSI binary and configuration, make sure either the `open-iscsi` (deb) or `iscsi-initiator-utils` (yum) package is installed on your cluster nodes. If this package isn't installed _before_ the bind mounts are created in your Kubernetes YAML, Docker will automatically create the directories and files on each node and will not allow the package install to succeed.</br>
 ></br> 
 >
->- The example YAML below does not apply to K3s. Since the K3s kubelet does not run in a container, adding extra binds is not necessary. However, all iSCSI tools must still be installed on your K3s nodes.
+>- The example YAML below does not apply to K3s, but only to RKE clusters. Since the K3s kubelet does not run in a container, adding extra binds is not necessary. However, all iSCSI tools must still be installed on your K3s nodes.
 
 ```
 services:


### PR DESCRIPTION
Closes #3805

Reference: [2.5 docs](https://rancher.com/docs/rancher/v2.5/en/cluster-admin/volumes-and-storage/iscsi-volumes/) and [2.6 docs](https://rancher.com/docs/rancher/v2.6/en/cluster-admin/volumes-and-storage/iscsi-volumes/)