### PR TITLE
Add banner to out-of-date doc versions w/ link to latest

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -15,11 +15,11 @@
     </div>
 
     <div class="head-blank">
-    
+
     </div>
 
     <div class="row max-sized contents-container background-base-gray-side">
-      
+
       {{ $url := urls.Parse .Permalink }}
       {{ $path := split $url.Path "/" }}
       {{ $product := index $path 1 }}
@@ -37,10 +37,15 @@
       {{end}}
       {{ if in .Dir "os/v1.x" }}
       <div class="alert alert-notice">
-          <strong>RancherOS 1.x is currently in a maintain-only-as-essential mode.</strong> It is no longer being actively maintained at a code level other than addressing critical or security fixes. For more information about the support status of RancherOS, see <a href="https://rancher.com/docs/os/v1.x/en/support/"> this page.</a> 
+          <strong>RancherOS 1.x is currently in a maintain-only-as-essential mode.</strong> It is no longer being actively maintained at a code level other than addressing critical or security fixes. For more information about the support status of RancherOS, see <a href="https://rancher.com/docs/os/v1.x/en/support/"> this page.</a>
       </div>
       {{end}}
-      
+      {{ if or (in .Dir "/v2.0-v2.4") (in .Dir "/v2.5") }}
+      <div class="alert alert-notice">
+          <strong>You are viewing the documentation for an older Rancher release.</strong> If you're looking for the documentation for the latest Rancher release, go to <a href="https://rancher.com/docs/rancher/v2.6/en/"> this page</a> instead.
+      </div>
+      {{end}}
+
       <div class="
         col-xl-3
         col-lg-4


### PR DESCRIPTION
Closes https://github.com/rancher/docs/issues/3820

This PR adds a generic banner to outdated Rancher versions (currently <2.6) and provides them a link to the latest version (currently 2.6). As previously discussed, there's currently no easy way to add links/redirects that take users to a different version of a given page. This will be revisited when we revamp our docs site. 

Also, seems like there's something in the styling/responsiveness of the site where using messages under a certain length (~160 chars) would cause the yellow banner to expand and take up half the page.
