### PR TITLE
Update titles to match current naming

### DIFF
--- a/content/rancher/v2.0-v2.4/_index.md
+++ b/content/rancher/v2.0-v2.4/_index.md
@@ -1,5 +1,5 @@
 ---
-title: v2.0-v2.4.x
+title: Rancher 2.0-2.4
 weight: 3
 showBreadcrumb: false
 ---

--- a/content/rancher/v2.0-v2.4/en/_index.md
+++ b/content/rancher/v2.0-v2.4/en/_index.md
@@ -1,8 +1,8 @@
 ---
-title: "Rancher v2.0-v2.4"
+title: "Rancher 2.0-2.4"
 shortTitle: "Rancher 2.0-2.4"
 description: "Rancher adds significant value on top of Kubernetes: managing hundreds of clusters from one interface, centralizing RBAC, enabling monitoring and alerting. Read more."
-metaTitle: "Rancher 2.x Docs: What is New?"
+metaTitle: "Rancher 2.0-2.4 Docs: What is New?"
 metaDescription: "Rancher 2 adds significant value on top of Kubernetes: managing hundreds of clusters from one interface, centralizing RBAC, enabling monitoring and alerting. Read more."
 insertOneSix: true
 weight: 1

--- a/content/rancher/v2.5/_index.md
+++ b/content/rancher/v2.5/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Rancher 2.5.7-2.5.9
+title: Rancher 2.5
 weight: 2
 showBreadcrumb: false
 ---

--- a/content/rancher/v2.5/en/_index.md
+++ b/content/rancher/v2.5/en/_index.md
@@ -2,7 +2,7 @@
 title: "Rancher 2.5"
 shortTitle: "Rancher 2.5"
 description: "Rancher adds significant value on top of Kubernetes: managing hundreds of clusters from one interface, centralizing RBAC, enabling monitoring and alerting. Read more."
-metaTitle: "Rancher 2.5.7-2.5.9 Docs: What is New?"
+metaTitle: "Rancher 2.5 Docs: What is New?"
 metaDescription: "Rancher 2 adds significant value on top of Kubernetes: managing hundreds of clusters from one interface, centralizing RBAC, enabling monitoring and alerting. Read more."
 insertOneSix: false
 weight: 2

--- a/content/rancher/v2.6/_index.md
+++ b/content/rancher/v2.6/_index.md
@@ -1,5 +1,5 @@
 ---
-title: v2.6.x
+title: Rancher 2.6
 weight: 1
 showBreadcrumb: false
 ---

--- a/content/rancher/v2.6/en/_index.md
+++ b/content/rancher/v2.6/en/_index.md
@@ -2,7 +2,7 @@
 title: "Rancher 2.6"
 shortTitle: "Rancher 2.6  (Latest)"
 description: "Rancher adds significant value on top of Kubernetes: managing hundreds of clusters from one interface, centralizing RBAC, enabling monitoring and alerting. Read more."
-metaTitle: "Rancher 2.x Docs: What is New?"
+metaTitle: "Rancher 2.6 Docs: What is New?"
 metaDescription: "Rancher 2 adds significant value on top of Kubernetes: managing hundreds of clusters from one interface, centralizing RBAC, enabling monitoring and alerting. Read more."
 insertOneSix: false
 weight: 1


### PR DESCRIPTION
There's currently a mismatch between the titles on https://rancher.com/docs/rancher/ . This updates them to match.

![mismatch](https://user-images.githubusercontent.com/1832069/151630143-2b9026b7-82f9-45cd-94b5-7bc18b538b2e.png)
