### PR TITLE
The key under "mirrors" must match the endpoint

### DIFF
--- a/content/k3s/latest/en/installation/private-registry/_index.md
+++ b/content/k3s/latest/en/installation/private-registry/_index.md
@@ -60,7 +60,7 @@ Below are examples showing how you may configure `/etc/rancher/k3s/registries.ya
 
 ```
 mirrors:
-  docker.io:
+  "mycustomreg.com:5000":
     endpoint:
       - "https://mycustomreg.com:5000"
 configs:
@@ -79,7 +79,7 @@ configs:
 
 ```
 mirrors:
-  docker.io:
+  "mycustomreg.com:5000":
     endpoint:
       - "https://mycustomreg.com:5000"
 configs:
@@ -102,7 +102,7 @@ Below are examples showing how you may configure `/etc/rancher/k3s/registries.ya
 
 ```
 mirrors:
-  docker.io:
+  "mycustomreg.com:5000":
     endpoint:
       - "http://mycustomreg.com:5000"
 configs:
@@ -117,7 +117,7 @@ configs:
 
 ```
 mirrors:
-  docker.io:
+  "mycustomreg.com:5000":
     endpoint:
       - "http://mycustomreg.com:5000"
 ```


### PR DESCRIPTION
If you use "docker.io" you will still get:

```
http: server gave HTTP response to HTTPS client
```

like @danlister pointed out at https://github.com/k3s-io/k3s/issues/1713#issuecomment-621335992.