### PR TITLE
Update default admin password for Vagrant quickstart (v2.6 only)

### DIFF
--- a/content/rancher/v2.6/en/quick-start-guide/deployment/quickstart-vagrant/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/quickstart-vagrant/_index.md
@@ -30,7 +30,7 @@ The following steps quickly deploy a Rancher Server with a single node cluster a
 
 4. To initiate the creation of the environment run, `vagrant up --provider=virtualbox`.
 
-5. Once provisioning finishes, go to `https://192.168.56.101` in the browser. The default user/password is `admin/admin`.
+5. Once provisioning finishes, go to `https://192.168.56.101` in the browser. The default user/password is `admin/adminPassword`.
 
 **Result:** Rancher Server and your Kubernetes cluster is installed on VirtualBox.
 


### PR DESCRIPTION
Updates the v2.6 docs for local quickstart, to specify the new default admin password from [quickstart PR #202](https://github.com/rancher/quickstart/pull/202)

A quick look at rancher v2.5 makes me think the password length requirements only changed for v2.6+ If the 2.5 docs should also be updated, please let me know, or feel free to add a commit to this branch.