### PR TITLE
Update troubleshooting for Cannot Connect to Docker Daemon

### DIFF
--- a/content/rancher/v2.6/en/installation/resources/troubleshooting/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/troubleshooting/_index.md
@@ -182,4 +182,8 @@ If you want to use encrypted private keys, you should use `ssh-agent` to load yo
 
 ### Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
 
-The node is not reachable on the configured `address` and `port`.
+* The node is not reachable on the configured `address` and `port`.
+* You might be using the `containerd` Container Runtime. You can either switch to using `dockerd` in the `Kubernetes Settings`, or create an alias to use `nerdctl` instead: 
+```
+alias docker=nerdctl
+```


### PR DESCRIPTION
Adding a small update to the section: `Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?`
Both of these options work for me. Might help those who also run into this issue.

### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
