### PR TITLE
Mention Terraform more prominently in docs

### DIFF
--- a/content/rancher/v2.6/en/cluster-provisioning/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/_index.md
@@ -20,6 +20,7 @@ This section covers the following topics:
   - [Launching Kubernetes and Provisioning Nodes in an Infrastructure Provider](#launching-kubernetes-and-provisioning-nodes-in-an-infrastructure-provider)
   - [Launching Kubernetes on Existing Custom Nodes](#launching-kubernetes-on-existing-custom-nodes)
 - [Registering Existing Clusters](#registering-existing-clusters)
+- [Programmatically Creating Clusters](#programmatically-creating-clusters)
 
   <!-- /TOC -->
 
@@ -78,3 +79,9 @@ Registering EKS clusters now provides additional benefits. For the most part, re
 When you delete an EKS cluster that was created in Rancher, the cluster is destroyed. When you delete an EKS cluster that was registered in Rancher, it is disconnected from the Rancher server, but it still exists and you can still access it in the same way you did before it was registered in Rancher.
 
 For more information, see [this page.](./registered-clusters)
+
+# Programmatically Creating Clusters
+
+The most common way to programmatically deploy Kubernetes clusters through Rancher is by using the Rancher2 Terraform provider. The documentation for creating clusters with Terraform is [here.](https://registry.terraform.io/providers/rancher/rancher2/latest/docs/resources/cluster)
+
+EKS, GKE, AKS clusters and RKE clusters can be created or imported with Terraform.

--- a/content/rancher/v2.6/en/cluster-provisioning/hosted-kubernetes-clusters/aks/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/hosted-kubernetes-clusters/aks/_index.md
@@ -16,6 +16,7 @@ You can use Rancher to create a cluster hosted in Microsoft Azure Kubernetes Ser
 - [Private Clusters](#private-clusters)
 - [Minimum AKS Permissions](#minimum-aks-permissions)
 - [Syncing](#syncing)
+- [Programmatically Creating AKS Clusters](#programmatically-creating-aks-clusters)
 
 # Prerequisites in Microsoft Azure
 
@@ -152,3 +153,7 @@ For more information about connecting to an AKS private cluster, see the [AKS do
 The AKS provisioner can synchronize the state of an AKS cluster between Rancher and the provider. For an in-depth technical explanation of how this works, see [Syncing.]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/editing-clusters/syncing)
 
 For information on configuring the refresh interval, see [this section.]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/editing-clusters/gke-config-reference/#configuring-the-refresh-interval)
+
+# Programmatically Creating AKS Clusters
+
+The most common way to programmatically deploy AKS clusters through Rancher is by using the Rancher2 Terraform provider. The documentation for creating clusters with Terraform is [here.](https://registry.terraform.io/providers/rancher/rancher2/latest/docs/resources/cluster)

--- a/content/rancher/v2.6/en/cluster-provisioning/hosted-kubernetes-clusters/eks/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/hosted-kubernetes-clusters/eks/_index.md
@@ -17,6 +17,7 @@ Amazon EKS provides a managed control plane for your Kubernetes cluster. Amazon 
 - [Minimum EKS Permissions](#minimum-eks-permissions)
 - [Syncing](#syncing)
 - [Troubleshooting](#troubleshooting)
+- [Programmatically Creating EKS Clusters](#programmatically-creating-eks-clusters)
 # Prerequisites in Amazon Web Services
 
 >**Note**
@@ -109,3 +110,7 @@ If your changes were overwritten, it could be due to the way the cluster data is
 If an unauthorized error is returned while attempting to modify or register the cluster and the cluster was not created with the role or user that your credentials belong to, refer to [Security and Compliance.](#security-and-compliance)
 
 For any issues or troubleshooting details for your Amazon EKS Kubernetes cluster, please see this [documentation](https://docs.aws.amazon.com/eks/latest/userguide/troubleshooting.html).
+
+# Programmatically Creating EKS Clusters
+
+The most common way to programmatically deploy EKS clusters through Rancher is by using the Rancher2 Terraform provider. The documentation for creating clusters with Terraform is [here.](https://registry.terraform.io/providers/rancher/rancher2/latest/docs/resources/cluster)

--- a/content/rancher/v2.6/en/cluster-provisioning/hosted-kubernetes-clusters/gke/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/hosted-kubernetes-clusters/gke/_index.md
@@ -10,6 +10,7 @@ weight: 2105
 - [Configuration Reference](#configuration-reference)
 - [Updating Kubernetes Version](#updating-kubernetes-version)
 - [Syncing](#syncing)
+- [Programmatically Creating GKE Clusters](#programmatically-creating-gke-clusters)
 
 # Prerequisites
 
@@ -98,3 +99,6 @@ The GKE provisioner can synchronize the state of a GKE cluster between Rancher a
 
 For information on configuring the refresh interval, see [this section.]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/editing-clusters/gke-config-reference/#configuring-the-refresh-interval)
 
+# Programmatically Creating GKE Clusters
+
+The most common way to programmatically deploy GKE clusters through Rancher is by using the Rancher2 Terraform provider. The documentation for creating clusters with Terraform is [here.](https://registry.terraform.io/providers/rancher/rancher2/latest/docs/resources/cluster)

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/_index.md
@@ -54,3 +54,7 @@ In this scenario, you want to install Kubernetes on bare-metal servers, on-prem 
 If you want to reuse a node from a previous custom cluster, [clean the node]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/cleaning-cluster-nodes/) before using it in a cluster again. If you reuse a node that hasn't been cleaned, cluster provisioning may fail.
 
 For more information, refer to the section on [custom nodes.]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/custom-nodes/)
+
+# Programmatically Creating RKE Clusters
+
+The most common way to programmatically deploy RKE clusters through Rancher is by using the Rancher2 Terraform provider. The documentation for creating clusters with Terraform is [here.](https://registry.terraform.io/providers/rancher/rancher2/latest/docs/resources/cluster)


### PR DESCRIPTION
In the Rancher Users Slack, I've seen several people asking about how to programmatically deploy EKS clusters. The best way to do it is through Terraform, so I have mentioned that in more places that it is relevant and linked to the Terraform docs about creating clusters. This affects RKE1, EKS, AKS and GKE clusters.