### PR TITLE
Fix the broken link in _index.md

### DIFF
--- a/content/rancher/v2.0-v2.4/en/project-admin/tools/_index.md
+++ b/content/rancher/v2.0-v2.4/en/project-admin/tools/_index.md
@@ -43,4 +43,4 @@ For details on project-level logging, see [this section.](./project-logging)
 
 _Available as of v2.2.0_
 
-Using Rancher, you can monitor the state and processes of your cluster nodes, Kubernetes components, and software deployments through integration with [Prometheus](https://prometheus.io/), a leading open-source monitoring solution. For details, refer to the [monitoring section.]({{<baseurl>}}/rancher/v2.0-v2.4/en/cluster-admin/tools/monitoring)
+Using Rancher, you can monitor the state and processes of your cluster nodes, Kubernetes components, and software deployments through integration with [Prometheus](https://prometheus.io/), a leading open-source monitoring solution. For details, refer to the [monitoring section.]({{<baseurl>}}/rancher/v2.0-v2.4/en/cluster-admin/tools/cluster-monitoring)


### PR DESCRIPTION
`/rancher/v2.0-v2.4/en/cluster-admin/tools/monitoring` returns 404 page. I think the correct one is `/rancher/v2.0-v2.4/en/cluster-admin/tools/cluster-monitoring`

### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
