### PR TITLE
Update AAD auth doc

### DIFF
--- a/content/rancher/v2.5/en/admin-settings/authentication/azure-ad/_index.md
+++ b/content/rancher/v2.5/en/admin-settings/authentication/azure-ad/_index.md
@@ -206,3 +206,8 @@ Enter the values that you copied to your [text file](#tip).
 1. Click **Authenticate with Azure**.
 
 **Result:** Azure Active Directory authentication is configured.
+
+> **Note:**
+>
+> The AD user pertaining to the credentials used to test will be mapped to the local principal account and assigned administrator privileges in Rancher. You should therefore make a conscious decision on which account you use to perform this step.
+


### PR DESCRIPTION
Include note on the fact that the user that is used to test authentication is bound to the 'admin' account.

### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
