### PR TITLE
Updating section for git-based chart repositories

### DIFF
--- a/content/rancher/v2.6/en/helm-charts/_index.md
+++ b/content/rancher/v2.6/en/helm-charts/_index.md
@@ -74,11 +74,14 @@ To add a private CA for Helm Chart repositories:
     [...]
     ```
 
-- **Git-based chart repositories**: It is not currently possible to add a private CA. For git-based chart repositories with a certificate signed by a private CA, you must disable TLS verification. Click **Edit YAML** for the chart repo, and add the key/value pair as follows: 
+- **Git-based chart repositories**: You must add a base64 encoded copy of the CA certificate in DER format to the spec.caBundle field of the chart repo, such as `openssl x509 -outform der -in ca.pem | base64 -w0`. Click **Edit YAML** for the chart repo and set, as in the following example:</br>
     ```
     [...]
     spec:
-      insecureSkipTLSVerify: true
+      caBundle:
+    MIIFXzCCA0egAwIBAgIUWNy8WrvSkgNzV0zdWRP79j9cVcEwDQYJKoZIhvcNAQELBQAwPzELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMRQwEgYDVQQKDAtNeU9yZywgSW5jLjENMAsGA1UEAwwEcm9vdDAeFw0yMTEyMTQwODMyMTdaFw0yNDEwMDMwODMyMT
+    ...
+    nDxZ/tNXt/WPJr/PgEB3hQdInDWYMg7vGO0Oz00G5kWg0sJ0ZTSoA10ZwdjIdGEeKlj1NlPyAqpQ+uDnmx6DW+zqfYtLnc/g6GuLLVPamraqN+gyU8CHwAWPNjZonFN9Vpg0PIk1I2zuOc4EHifoTAXSpnjfzfyAxCaZsnTptimlPFJJqAMj+FfDArGmr4=
     [...]
     ```
     


### PR DESCRIPTION
Fixes issue #3864 

- References [Rancher v2.6 docs](https://rancher.com/docs/rancher/v2.6/en/helm-charts/#repositories)
- Confirmed that this is already in place (cc: @PennyScissors ) and is awaiting QA by @ronhorton. Once signed off by Ron, will be able to merge.
- Since commit history was mangled in #3887 , recommitting it to staging.