### PR TITLE
Modified hyperlink redirect

### DIFF
--- a/content/rancher/v2.6/en/overview/architecture-recommendations/_index.md
+++ b/content/rancher/v2.6/en/overview/architecture-recommendations/_index.md
@@ -110,4 +110,4 @@ If you are using an [authorized cluster endpoint (ACE),]({{<baseurl>}}/rancher/v
 
 If you are using private CA signed certificates on the load balancer, you have to supply the CA certificate, which will be included in the generated kubeconfig file to validate the certificate chain. See the documentation on [kubeconfig files]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/cluster-access/kubectl/) and [API keys]({{<baseurl>}}/rancher/v2.6/en/user-settings/api-keys/#creating-an-api-key) for more information.
 
-As of Rancher v2.6.3, ACE support is available for registered RKE2 and K3s clusters. To view the manual steps to perform on the downstream cluster to enable the ACE, click [here]({{<baseurl>}}/v2.6/en/cluster-provisioning/registered-clusters/#authorized-cluster-endpoint-support-for-rke2-and-k3s-clusters).
+As of Rancher v2.6.3, ACE support is available for registered RKE2 and K3s clusters. To view the manual steps to perform on the downstream cluster to enable the ACE, click [here]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/registered-clusters/#authorized-cluster-endpoint-support-for-rke2-and-k3s-clusters).

--- a/content/rancher/v2.6/en/overview/architecture/_index.md
+++ b/content/rancher/v2.6/en/overview/architecture/_index.md
@@ -109,7 +109,7 @@ An authorized cluster endpoint allows users to connect to the Kubernetes API ser
 
 > The authorized cluster endpoint only works on Rancher-launched Kubernetes clusters. In other words, it only works in clusters where Rancher [used RKE]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters) to provision the cluster. The ACE is not available for clusters in a hosted Kubernetes provider, such as Amazon's EKS.
 
-> The [ACE is available for registered RKE2 and K3s clusters]({{<baseurl>}}/v2.6/en/cluster-provisioning/registered-clusters/#authorized-cluster-endpoint-support-for-rke2-and-k3s-clusters) as of Rancher v2.6.3. 
+> The [ACE is available for registered RKE2 and K3s clusters]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/registered-clusters/#authorized-cluster-endpoint-support-for-rke2-and-k3s-clusters) as of Rancher v2.6.3. 
 
 There are two main reasons why a user might need the authorized cluster endpoint:
 


### PR DESCRIPTION
Fixes issue rancher/docs#3891 

Modified the redirect hyperlink for ACE per issue. 

Page being displayed on live site before fix: 

<img width="508" alt="image" src="https://user-images.githubusercontent.com/21279125/154954222-6462ca70-a598-4c55-acf1-434053de09cf.png">

Page being displayed on local after fix:

<img width="718" alt="image" src="https://user-images.githubusercontent.com/21279125/154954340-6d8bfdbc-5b0e-4432-9bc0-89f53f1d7d6f.png">

**Since this is existing as of 2.6.3 and is just a modification to the hyperlink, therefore have made changes to master branch.**