### PR TITLE
Update Helm _index.md

### DIFF
--- a/content/k3s/latest/en/helm/_index.md
+++ b/content/k3s/latest/en/helm/_index.md
@@ -96,8 +96,9 @@ metadata:
   namespace: kube-system
 spec:
   valuesContent: |-
-    image: traefik
-    imageTag: v1.7.26-alpine
+    image:
+      name: traefik
+      tag: v2.6.1
     proxyProtocol:
       enabled: true
       trustedIPs:


### PR DESCRIPTION
Update the example that shows how to edit the HelmChartConfig. The `imageTag` is not longer used and I updated it to avoid confusion  #36590

### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
