### PR TITLE
Use the current hostname for baseUrl

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -10,4 +10,4 @@ RUN mkdir -p /output /theme/rancher-website-theme && tar -xzf /run/master.tar.gz
 # Expose default hugo port
 EXPOSE 9001
 
-ENTRYPOINT ["hugo", "serve", "--bind=0.0.0.0", "--buildDrafts", "--buildFuture", "--baseURL=" ]
+ENTRYPOINT ["hugo", "serve", "--bind=0.0.0.0", "--buildDrafts", "--buildFuture" ]

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -16,7 +16,7 @@ COPY .git .git
 ADD https://github.com/rancherlabs/website-theme/archive/master.tar.gz /run/master.tar.gz
 RUN mkdir -p /output /theme/rancher-website-theme && tar -xzf /run/master.tar.gz -C /run/node_modules/rancher-website-theme --strip=1 && rm /run/master.tar.gz
 
-RUN ["hugo", "--buildFuture", "--baseURL=https://rancher.com/docs", "--destination=/output"]
+RUN ["hugo", "--buildFuture", "--destination=/output"]
 
 # Make sure something got built
 RUN stat /output/index.html

--- a/Dockerfile.staging
+++ b/Dockerfile.staging
@@ -16,7 +16,7 @@ COPY .git .git
 ADD https://github.com/rancherlabs/website-theme/archive/master.tar.gz /run/master.tar.gz
 RUN mkdir -p /output /theme/rancher-website-theme && tar -xzf /run/master.tar.gz -C /run/node_modules/rancher-website-theme --strip=1 && rm /run/master.tar.gz
 
-RUN ["hugo", "--buildDrafts", "--buildFuture", "--baseURL=https://staging.rancher.com/docs", "--destination=/output"]
+RUN ["hugo", "--buildDrafts", "--buildFuture", "--destination=/output"]
 
 # Make sure something got built
 RUN stat /output/index.html

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = ""
+baseURL = ".Permalink"
 languageCode = "en-us"
 title = "Rancher Labs"
 


### PR DESCRIPTION
Nelson said it would simplify the process of docs migration if we could have baseurl be whatever address the site is running on, instead of having to pass in the site name manually.

I have changed docker files for both dev and prod. The docker files no longer pass in any variables for the site name. Instead baseurl is now taken from the Hugo variable called `.Permalink`.

I have only tested this locally, as the links are currently pointing to local pages when the docs run locally. Next I would like these changes to be merged into staging so that we can confirm that links containing `baseUrl` are going to `https://staging.rancher.com` as expected. If that works as expected, this should be fine to merge to master.