### PR TITLE
Make docs version show up in search results

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -10,4 +10,4 @@ RUN mkdir -p /output /theme/rancher-website-theme && tar -xzf /run/master.tar.gz
 # Expose default hugo port
 EXPOSE 9001
 
-ENTRYPOINT ["hugo", "serve", "--bind=0.0.0.0", "--buildDrafts", "--buildFuture", "--baseURL=" ]
+ENTRYPOINT ["hugo", "serve", "--bind=0.0.0.0", "--buildDrafts", "--buildFuture" ]

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -16,7 +16,7 @@ COPY .git .git
 ADD https://github.com/rancherlabs/website-theme/archive/master.tar.gz /run/master.tar.gz
 RUN mkdir -p /output /theme/rancher-website-theme && tar -xzf /run/master.tar.gz -C /run/node_modules/rancher-website-theme --strip=1 && rm /run/master.tar.gz
 
-RUN ["hugo", "--buildFuture", "--baseURL=https://rancher.com/docs", "--destination=/output"]
+RUN ["hugo", "--buildFuture", "--destination=/output"]
 
 # Make sure something got built
 RUN stat /output/index.html

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -33,13 +33,26 @@ const bootstrapDocsSearch = function () {
     })
   );
 
+  const docsVersion =
 
   search.addWidget(
     instantsearch.widgets.infiniteHits({
       container: '#hits',
       templates: {
         empty: '<h3>No results</h3>',
-        item: `<h3><a href="{{permalink}}">{{{_highlightResult.title.value}}}</a></h3><div class="body">{{{_snippetResult.content.value}}}</div>`
+        item: `
+        <h3>
+          <a href="{{permalink}}">
+            {{{_highlightResult.title.value}}}
+          </a>
+        </h3>
+        <div class="body">
+          {{{_snippetResult.content.value}}}
+        </div>
+        <hr/>
+
+        <p>{{permalink}}</p>
+        `
       },
       escapeHits: true,
     })

--- a/config.toml
+++ b/config.toml
@@ -36,7 +36,7 @@ home = ["HTML", "RSS", "Algolia"]
 # page = ["HTML", "Algolia"]
 
 [params.algolia]
-vars = ["title", "summary", "date", "publishdate", "expirydate", "permalink"]
+vars = ["title", "summary", "date", "publishdate", "expirydate", "permalink", "docs_version"]
 params = ["categories", "tags"]
 
 [[menu.main]]

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = ""
+baseURL = ".Permalink"
 languageCode = "en-us"
 title = "Rancher Labs"
 

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -1,0 +1,9 @@
+{{/* Generates a valid Algolia search index */}}
+{{- $.Scratch.Add "index" slice -}}
+{{- $section := $.Site.GetPage "section" .Section }}
+{{- range .Site.AllPages -}}
+  {{- if or (and (.IsDescendant $section) (and (not .Draft) (not .Params.private))) $section.IsHome -}}
+{{- $.Scratch.Add "index" (dict "objectID" .Permalink "docs_version" .UniqueID "postref" .UniqueID "date" .Date.UTC.Unix "content" .Content "description" .Description "dir" .Dir "expirydate" .ExpiryDate.UTC.Unix "fuzzywordcount" .FuzzyWordCount "keywords" .Keywords "kind" .Kind "lang" .Lang "lastmod" .Lastmod.UTC.Unix "permalink" .Permalink "publishdate" .PublishDate "readingtime" .ReadingTime "relpermalink" .RelPermalink "summary" .Summary "title" .Title "type" .Type "url" .URL "weight" .Weight "wordcount" .WordCount "section" .Section "tags" .Params.Tags "categories" .Params.Categories "authors" .Params.Authors)}}
+  {{- end -}}
+{{- end -}}
+{{- $.Scratch.Get "index" | jsonify -}}


### PR DESCRIPTION
The intention of this PR is to make the docs version show up in search results when you click the magnifying glass in the top nav of the docs.

This is a stopgap measure that is meant to improve the user experience in the short term. The long term solution is to migrate to docusaurus in which algolia search will be limited to only one docs version at a time.

Currently it shows identical entries in the list when they are really entries for two different docs versions.

I have been able to get something to show up below each list item, as shown in this screen shot:
<img width="1387" alt="Screen Shot 2022-02-22 at 2 51 17 PM" src="https://user-images.githubusercontent.com/20599230/155225738-90ccdbc9-d24e-4e2d-9299-f2d48f01c584.png">

This PR is in progress because I haven't figured out how to get just the docs version in there. Currently I'm adding the URL that the search result list item is pointing to, which contains the version in it. I can use Javascript to extract the version from the URL itself, but I can't use javascript in this template which is used to render the list item: https://github.com/rancher/docs/blob/master/assets/js/app.js#L42 It seems those variables that are already in the template (such as `_highlightresult`, `_snippetresult` and `permalink`) have to be passed in to algolia in a special way. I find this Hugo layout file in the rancherlabs/website repo to be fascinating because it looks like it is used to put variables in the list results. https://github.com/rancherlabs/website-theme/blob/master/layouts/_default/list.algolia.json I found docs about how those variables work but I have yet to make sense of it. https://www.algolia.com/doc/api-reference/widgets/infinite-hits/js/