### PR TITLE
Update RKE CIS Benchmark 1.5 and 1.6 hardening guide and verification guide

### DIFF
--- a/content/rancher/v2.5/en/security/rancher-2.5/1.5-benchmark-2.5/_index.md
+++ b/content/rancher/v2.5/en/security/rancher-2.5/1.5-benchmark-2.5/_index.md
@@ -1281,7 +1281,7 @@ on the master node and ensure the correct value for the `--bind-address` paramet
 **Expected result**:
 
 ```
-'--bind-address' is present OR '--bind-address' is not present
+'--bind-address' argument is set to 127.0.0.1
 ```
 
 ### 1.4 Scheduler
@@ -1327,7 +1327,7 @@ on the master node and ensure the correct value for the `--bind-address` paramet
 **Expected result**:
 
 ```
-'--bind-address' is present OR '--bind-address' is not present
+'--bind-address' argument is set to 127.0.0.1
 ```
 
 ## 2 Etcd Node Configuration

--- a/content/rancher/v2.5/en/security/rancher-2.5/1.5-hardening-2.5/_index.md
+++ b/content/rancher/v2.5/en/security/rancher-2.5/1.5-hardening-2.5/_index.md
@@ -667,6 +667,7 @@ rancher_kubernetes_engine_config:
       service_node_port_range: 30000-32767
     kube_controller:
       extra_args:
+        bind-address: 127.0.0.1
         address: 127.0.0.1
         feature-gates: RotateKubeletServerCertificate=true
         profiling: 'false'
@@ -685,6 +686,7 @@ rancher_kubernetes_engine_config:
       generate_serving_certificate: true
     scheduler:
       extra_args:
+        bind-address: 127.0.0.1
         address: 127.0.0.1
         profiling: 'false'
   ssh_agent_auth: false

--- a/content/rancher/v2.5/en/security/rancher-2.5/1.6-benchmark-2.5/_index.md
+++ b/content/rancher/v2.5/en/security/rancher-2.5/1.6-benchmark-2.5/_index.md
@@ -1803,13 +1803,13 @@ on the master node and ensure the correct value for the --bind-address parameter
 **Expected Result**:
 
 ```console
-'--bind-address' is not present OR '--bind-address' is not present
+'--bind-address' argument is set to 127.0.0.1
 ```
 
 **Returned Value**:
 
 ```console
-root        4788    4773  4 16:16 ?        00:00:09 kube-controller-manager --configure-cloud-routes=false --cloud-provider= --service-cluster-ip-range=10.43.0.0/16 --v=2 --pod-eviction-timeout=5m0s --leader-elect=true --cluster-cidr=10.42.0.0/16 --kubeconfig=/etc/kubernetes/ssl/kubecfg-kube-controller-manager.yaml --profiling=false --node-monitor-grace-period=40s --service-account-private-key-file=/etc/kubernetes/ssl/kube-service-account-token-key.pem --address=0.0.0.0 --allow-untagged-cloud=true --root-ca-file=/etc/kubernetes/ssl/kube-ca.pem --allocate-node-cidrs=true --enable-hostpath-provisioner=false --terminated-pod-gc-threshold=1000 --feature-gates=RotateKubeletServerCertificate=true --use-service-account-credentials=true
+root        4788    4773  4 16:16 ?        00:00:09 kube-controller-manager --configure-cloud-routes=false --cloud-provider= --service-cluster-ip-range=10.43.0.0/16 --v=2 --bind-address=127.0.0.1 --pod-eviction-timeout=5m0s --leader-elect=true --cluster-cidr=10.42.0.0/16 --kubeconfig=/etc/kubernetes/ssl/kubecfg-kube-controller-manager.yaml --profiling=false --node-monitor-grace-period=40s --service-account-private-key-file=/etc/kubernetes/ssl/kube-service-account-token-key.pem --address=127.0.0.1 --allow-untagged-cloud=true --root-ca-file=/etc/kubernetes/ssl/kube-ca.pem --allocate-node-cidrs=true --enable-hostpath-provisioner=false --terminated-pod-gc-threshold=1000 --feature-gates=RotateKubeletServerCertificate=true --use-service-account-credentials=true
 
 ```
 ## 1.4 Scheduler
@@ -1859,13 +1859,13 @@ on the master node and ensure the correct value for the --bind-address parameter
 **Expected Result**:
 
 ```console
-'--bind-address' is not present OR '--bind-address' is not present
+'--bind-address' argument is set to 127.0.0.1
 ```
 
 **Returned Value**:
 
 ```console
-root        4947    4930  1 16:16 ?        00:00:02 kube-scheduler --kubeconfig=/etc/kubernetes/ssl/kubecfg-kube-scheduler.yaml --leader-elect=true --profiling=false --v=2 --address=0.0.0.0
+root        4947    4930  1 16:16 ?        00:00:02 kube-scheduler --kubeconfig=/etc/kubernetes/ssl/kubecfg-kube-scheduler.yaml --leader-elect=true --profiling=false --v=2 --address=127.0.0.1 --bind-address=127.0.0.1
 
 ```
 ## 2 Etcd Node Configuration Files

--- a/content/rancher/v2.5/en/security/rancher-2.5/1.6-hardening-2.5/_index.md
+++ b/content/rancher/v2.5/en/security/rancher-2.5/1.6-hardening-2.5/_index.md
@@ -511,6 +511,8 @@ rancher_kubernetes_engine_config:
     kube_controller:
       extra_args:
         feature-gates: RotateKubeletServerCertificate=true
+        bind-address: 127.0.0.1
+        address: 127.0.0.1
     kubelet:
       extra_args:
         feature-gates: RotateKubeletServerCertificate=true
@@ -519,6 +521,10 @@ rancher_kubernetes_engine_config:
           TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
       fail_swap_on: false
       generate_serving_certificate: true
+    scheduler:
+      extra_args:
+        bind-address: 127.0.0.1
+        address: 127.0.0.1
   ssh_agent_auth: false
   upgrade_strategy:
     max_unavailable_controlplane: '1'


### PR DESCRIPTION
Update RKE CIS Benchmark 1.5 and 1.6 hardening guide and verification guide for CIS profiles: 

- [rke-profile-hardened-1.5](https://github.com/rancher/security-scan/tree/master/package/cfg/rke-cis-1.5-hardened)
- [rke-profile-hardened-1.6](https://github.com/rancher/security-scan/tree/master/package/cfg/rke-cis-1.6-hardened)

The pages that were updated are:

[ rke-profile-hardened-1.5 CIS Hardening Guide](https://rancher.com/docs/rancher/v2.5/en/security/rancher-2.5/1.5-hardening-2.5/)
[ rke-profile-hardened-1.5 CIS Self Assessment Guide](https://rancher.com/docs/rancher/v2.5/en/security/rancher-2.5/1.5-benchmark-2.5/)

[ rke-profile-hardened-1.6 CIS Hardening Guide](https://rancher.com/docs/rancher/v2.5/en/security/rancher-2.5/1.6-hardening-2.5/)
[ rke-profile-hardened-1.6 CIS Self Assessment Guide](https://rancher.com/docs/rancher/v2.5/en/security/rancher-2.5/1.6-benchmark-2.5/)