### PR TITLE
Update redirect to point to 2.6 page

### DIFF
--- a/content/rancher/v2.5/en/quick-start-guide/_index.md
+++ b/content/rancher/v2.5/en/quick-start-guide/_index.md
@@ -1,10 +1,8 @@
 ---
 title: Rancher Deployment Quick Start Guides
 metaDescription: Use this section to jump start your Rancher deployment and testing. It contains instructions for a simple Rancher setup and some common use cases.
-short title: Use this section to jump start your Rancher deployment and testing. It contains instructions for a simple Rancher setup and some common use cases. 
+short title: Use this section to jump start your Rancher deployment and testing. It contains instructions for a simple Rancher setup and some common use cases.
 weight: 2
-aliases:
-  - /rancher/v2.x/en/quick-start-guide/
 ---
 >**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.5/en/installation/).
 

--- a/content/rancher/v2.6/en/quick-start-guide/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/_index.md
@@ -1,8 +1,10 @@
 ---
 title: Rancher Deployment Quick Start Guides
 metaDescription: Use this section to jump start your Rancher deployment and testing. It contains instructions for a simple Rancher setup and some common use cases.
-short title: Use this section to jump start your Rancher deployment and testing. It contains instructions for a simple Rancher setup and some common use cases. 
+short title: Use this section to jump start your Rancher deployment and testing. It contains instructions for a simple Rancher setup and some common use cases.
 weight: 2
+aliases:
+  - /rancher/v2.x/en/quick-start-guide/
 ---
 >**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.6/en/installation/).
 


### PR DESCRIPTION
Closes https://github.com/rancher/docs/issues/3907

The link on https://www.rancher.com/quick-start should be updated to not use v2.x in it's link and point directly to the 2.6 page. The https://www.rancher.com/quick-start page is not managed on rancher/docs so this only provides an indirect fix by updating the redirect to point to the 2.6 page instead of the 2.5 one.