### PR TITLE
Add test/demo note to quickstart subpages

### DIFF
--- a/content/rancher/v2.0-v2.4/en/quick-start-guide/deployment/amazon-aws-qs/_index.md
+++ b/content/rancher/v2.0-v2.4/en/quick-start-guide/deployment/amazon-aws-qs/_index.md
@@ -5,6 +5,8 @@ weight: 100
 ---
 The following steps will quickly deploy a Rancher Server on AWS with a single node cluster attached.
 
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+
 ## Prerequisites
 
 >**Note**

--- a/content/rancher/v2.0-v2.4/en/quick-start-guide/deployment/digital-ocean-qs/_index.md
+++ b/content/rancher/v2.0-v2.4/en/quick-start-guide/deployment/digital-ocean-qs/_index.md
@@ -5,6 +5,8 @@ weight: 100
 ---
 The following steps will quickly deploy a Rancher Server on DigitalOcean with a single node cluster attached.
 
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+
 ## Prerequisites
 
 >**Note**

--- a/content/rancher/v2.0-v2.4/en/quick-start-guide/deployment/google-gcp-qs/_index.md
+++ b/content/rancher/v2.0-v2.4/en/quick-start-guide/deployment/google-gcp-qs/_index.md
@@ -5,6 +5,8 @@ weight: 100
 ---
 The following steps will quickly deploy a Rancher server on GCP in a single-node RKE Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
 
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+
 ## Prerequisites
 
 >**Note**

--- a/content/rancher/v2.0-v2.4/en/quick-start-guide/deployment/microsoft-azure-qs/_index.md
+++ b/content/rancher/v2.0-v2.4/en/quick-start-guide/deployment/microsoft-azure-qs/_index.md
@@ -6,6 +6,8 @@ weight: 100
 
 The following steps will quickly deploy a Rancher server on Azure in a single-node RKE Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
 
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+
 ## Prerequisites
 
 >**Note**

--- a/content/rancher/v2.0-v2.4/en/quick-start-guide/deployment/quickstart-manual-setup/_index.md
+++ b/content/rancher/v2.0-v2.4/en/quick-start-guide/deployment/quickstart-manual-setup/_index.md
@@ -8,6 +8,8 @@ Howdy Partner! This tutorial walks you through:
 - Creation of your first cluster
 - Deployment of an application, Nginx
 
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+
 ## Quick Start Outline
 
 This Quick Start Guide is divided into different tasks for easier consumption.
@@ -96,13 +98,13 @@ In this task, you can use the versatile **Custom** option. This option lets you 
 
 11. When you finish running the command on your Linux host, click **Done**.
 
-**Result:** 
+**Result:**
 
 Your cluster is created and assigned a state of **Provisioning.** Rancher is standing up your cluster.
 
 You can access your cluster after its state is updated to **Active.**
 
-**Active** clusters are assigned two Projects: 
+**Active** clusters are assigned two Projects:
 
 - `Default`, containing the `default` namespace
 - `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces

--- a/content/rancher/v2.0-v2.4/en/quick-start-guide/deployment/quickstart-vagrant/_index.md
+++ b/content/rancher/v2.0-v2.4/en/quick-start-guide/deployment/quickstart-vagrant/_index.md
@@ -4,6 +4,8 @@ weight: 200
 ---
 The following steps quickly deploy a Rancher Server with a single node cluster attached.
 
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+
 ## Prerequisites
 
 - [Vagrant](https://www.vagrantup.com): Vagrant is required as this is used to provision the machine based on the Vagrantfile.
@@ -14,7 +16,7 @@ The following steps quickly deploy a Rancher Server with a single node cluster a
 - Vagrant will require plugins to create VirtualBox VMs. Install them with the following commands:
 
   `vagrant plugin install vagrant-vboxmanage`
-  
+
   `vagrant plugin install vagrant-vbguest`
 
 ## Getting Started

--- a/content/rancher/v2.5/en/quick-start-guide/deployment/amazon-aws-qs/_index.md
+++ b/content/rancher/v2.5/en/quick-start-guide/deployment/amazon-aws-qs/_index.md
@@ -5,6 +5,8 @@ weight: 100
 ---
 The following steps will quickly deploy a Rancher server on AWS in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
 
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+
 ## Prerequisites
 
 >**Note**
@@ -24,7 +26,7 @@ The following steps will quickly deploy a Rancher server on AWS in a single-node
 3. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
 
 4. Edit `terraform.tfvars` and customize the following variables:
-    - `aws_access_key` - Amazon AWS Access Key 
+    - `aws_access_key` - Amazon AWS Access Key
     - `aws_secret_key` - Amazon AWS Secret Key
     - `rancher_server_admin_password` - Admin password for created Rancher server
 

--- a/content/rancher/v2.5/en/quick-start-guide/deployment/amazon-aws-qs/_index.md
+++ b/content/rancher/v2.5/en/quick-start-guide/deployment/amazon-aws-qs/_index.md
@@ -5,7 +5,7 @@ weight: 100
 ---
 The following steps will quickly deploy a Rancher server on AWS in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
 
->**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.5/en/installation/).
 
 ## Prerequisites
 

--- a/content/rancher/v2.5/en/quick-start-guide/deployment/digital-ocean-qs/_index.md
+++ b/content/rancher/v2.5/en/quick-start-guide/deployment/digital-ocean-qs/_index.md
@@ -5,7 +5,7 @@ weight: 100
 ---
 The following steps will quickly deploy a Rancher server on DigitalOcean in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
 
->**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.5/en/installation/).
 
 ## Prerequisites
 

--- a/content/rancher/v2.5/en/quick-start-guide/deployment/digital-ocean-qs/_index.md
+++ b/content/rancher/v2.5/en/quick-start-guide/deployment/digital-ocean-qs/_index.md
@@ -5,6 +5,8 @@ weight: 100
 ---
 The following steps will quickly deploy a Rancher server on DigitalOcean in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
 
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+
 ## Prerequisites
 
 >**Note**

--- a/content/rancher/v2.5/en/quick-start-guide/deployment/google-gcp-qs/_index.md
+++ b/content/rancher/v2.5/en/quick-start-guide/deployment/google-gcp-qs/_index.md
@@ -5,6 +5,8 @@ weight: 100
 ---
 The following steps will quickly deploy a Rancher server on GCP in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
 
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+
 ## Prerequisites
 
 >**Note**
@@ -25,7 +27,7 @@ The following steps will quickly deploy a Rancher server on GCP in a single-node
 3. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
 
 4. Edit `terraform.tfvars` and customize the following variables:
-    - `gcp_account_json` - GCP service account file path and file name 
+    - `gcp_account_json` - GCP service account file path and file name
     - `rancher_server_admin_password` - Admin password for created Rancher server
 
 5. **Optional:** Modify optional variables within `terraform.tfvars`.

--- a/content/rancher/v2.5/en/quick-start-guide/deployment/google-gcp-qs/_index.md
+++ b/content/rancher/v2.5/en/quick-start-guide/deployment/google-gcp-qs/_index.md
@@ -5,7 +5,7 @@ weight: 100
 ---
 The following steps will quickly deploy a Rancher server on GCP in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
 
->**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.5/en/installation/).
 
 ## Prerequisites
 

--- a/content/rancher/v2.5/en/quick-start-guide/deployment/microsoft-azure-qs/_index.md
+++ b/content/rancher/v2.5/en/quick-start-guide/deployment/microsoft-azure-qs/_index.md
@@ -6,6 +6,8 @@ weight: 100
 
 The following steps will quickly deploy a Rancher server on Azure in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
 
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+
 ## Prerequisites
 
 >**Note**
@@ -27,7 +29,7 @@ The following steps will quickly deploy a Rancher server on Azure in a single-no
 3. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
 
 4. Edit `terraform.tfvars` and customize the following variables:
-    - `azure_subscription_id` - Microsoft Azure Subscription ID 
+    - `azure_subscription_id` - Microsoft Azure Subscription ID
     - `azure_client_id` - Microsoft Azure Client ID
     - `azure_client_secret` - Microsoft Azure Client Secret
     - `azure_tenant_id` - Microsoft Azure Tenant ID
@@ -41,7 +43,7 @@ Suggestions include:
     - `instance_type` - Compute instance size used, minimum is `Standard_DS2_v2` but `Standard_DS2_v3` or `Standard_DS3_v2` could be used if within budget
     - `add_windows_node` - If true, an additional Windows worker node is added to the workload cluster
     - `windows_admin_password` - The admin password of the windows worker node
-    
+
 6. Run `terraform init`.
 
 7. To initiate the creation of the environment, run `terraform apply --auto-approve`. Then wait for output similar to the following:

--- a/content/rancher/v2.5/en/quick-start-guide/deployment/microsoft-azure-qs/_index.md
+++ b/content/rancher/v2.5/en/quick-start-guide/deployment/microsoft-azure-qs/_index.md
@@ -6,7 +6,7 @@ weight: 100
 
 The following steps will quickly deploy a Rancher server on Azure in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
 
->**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.5/en/installation/).
 
 ## Prerequisites
 

--- a/content/rancher/v2.5/en/quick-start-guide/deployment/quickstart-manual-setup/_index.md
+++ b/content/rancher/v2.5/en/quick-start-guide/deployment/quickstart-manual-setup/_index.md
@@ -10,6 +10,8 @@ Howdy Partner! This tutorial walks you through:
 - Creation of your first cluster
 - Deployment of an application, Nginx
 
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+
 ## Quick Start Outline
 
 This Quick Start Guide is divided into different tasks for easier consumption.
@@ -104,13 +106,13 @@ In this task, you can use the versatile **Custom** option. This option lets you 
 
 1. When you finish running the command on your Linux host, click **Done**.
 
-**Result:** 
+**Result:**
 
 Your cluster is created and assigned a state of **Provisioning.** Rancher is standing up your cluster.
 
 You can access your cluster after its state is updated to **Active.**
 
-**Active** clusters are assigned two Projects: 
+**Active** clusters are assigned two Projects:
 
 - `Default`, containing the `default` namespace
 - `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces

--- a/content/rancher/v2.5/en/quick-start-guide/deployment/quickstart-manual-setup/_index.md
+++ b/content/rancher/v2.5/en/quick-start-guide/deployment/quickstart-manual-setup/_index.md
@@ -10,7 +10,7 @@ Howdy Partner! This tutorial walks you through:
 - Creation of your first cluster
 - Deployment of an application, Nginx
 
->**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.5/en/installation/).
 
 ## Quick Start Outline
 

--- a/content/rancher/v2.5/en/quick-start-guide/deployment/quickstart-vagrant/_index.md
+++ b/content/rancher/v2.5/en/quick-start-guide/deployment/quickstart-vagrant/_index.md
@@ -6,6 +6,8 @@ aliases:
 ---
 The following steps quickly deploy a Rancher Server with a single node cluster attached.
 
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+
 ## Prerequisites
 
 - [Vagrant](https://www.vagrantup.com): Vagrant is required as this is used to provision the machine based on the Vagrantfile.
@@ -16,7 +18,7 @@ The following steps quickly deploy a Rancher Server with a single node cluster a
 - Vagrant will require plugins to create VirtualBox VMs. Install them with the following commands:
 
   `vagrant plugin install vagrant-vboxmanage`
-  
+
   `vagrant plugin install vagrant-vbguest`
 
 ## Getting Started

--- a/content/rancher/v2.5/en/quick-start-guide/deployment/quickstart-vagrant/_index.md
+++ b/content/rancher/v2.5/en/quick-start-guide/deployment/quickstart-vagrant/_index.md
@@ -6,7 +6,7 @@ aliases:
 ---
 The following steps quickly deploy a Rancher Server with a single node cluster attached.
 
->**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.5/en/installation/).
 
 ## Prerequisites
 

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/amazon-aws-qs/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/amazon-aws-qs/_index.md
@@ -5,7 +5,7 @@ weight: 100
 ---
 The following steps will quickly deploy a Rancher server on AWS in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
 
->**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.6/en/installation/).
 
 ## Prerequisites
 

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/amazon-aws-qs/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/amazon-aws-qs/_index.md
@@ -5,6 +5,8 @@ weight: 100
 ---
 The following steps will quickly deploy a Rancher server on AWS in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
 
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+
 ## Prerequisites
 
 >**Note**
@@ -24,7 +26,7 @@ The following steps will quickly deploy a Rancher server on AWS in a single-node
 3. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
 
 4. Edit `terraform.tfvars` and customize the following variables:
-    - `aws_access_key` - Amazon AWS Access Key 
+    - `aws_access_key` - Amazon AWS Access Key
     - `aws_secret_key` - Amazon AWS Secret Key
     - `rancher_server_admin_password` - Admin password for created Rancher server
 

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/digital-ocean-qs/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/digital-ocean-qs/_index.md
@@ -5,7 +5,7 @@ weight: 120
 ---
 The following steps will quickly deploy a Rancher server on DigitalOcean in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
 
->**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.6/en/installation/).
 
 ## Prerequisites
 

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/digital-ocean-qs/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/digital-ocean-qs/_index.md
@@ -5,6 +5,8 @@ weight: 120
 ---
 The following steps will quickly deploy a Rancher server on DigitalOcean in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
 
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+
 ## Prerequisites
 
 >**Note**

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/equinix-metal-qs/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/equinix-metal-qs/_index.md
@@ -10,7 +10,7 @@ weight: 250
 - Creation of your first cluster
 - Deployment of an application, Nginx
 
->**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.6/en/installation/).
 
 ## Quick Start Outline
 

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/equinix-metal-qs/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/equinix-metal-qs/_index.md
@@ -10,6 +10,8 @@ weight: 250
 - Creation of your first cluster
 - Deployment of an application, Nginx
 
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+
 ## Quick Start Outline
 
 This Quick Start Guide is divided into different tasks for easier consumption.
@@ -41,7 +43,7 @@ This Quick Start Guide is divided into different tasks for easier consumption.
   - [Equinix Metal Pricing](https://metal.equinix.com/developers/docs/servers/server-specs/)
 
   **Note:**
-  > When provisioning a new Equinix Metal Server via the CLI or API you will need to be able to provide the following information:  project-id, plan, metro, and the operating-system 
+  > When provisioning a new Equinix Metal Server via the CLI or API you will need to be able to provide the following information:  project-id, plan, metro, and the operating-system
   > When using a cloud-hosted virtual machine you need to allow inbound TCP communication to ports 80 and 443.  Please see your cloud-host's documentation for information regarding port configuration.
   > For a full list of port requirements, refer to [Docker Installation]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/node-requirements/).
   > Provision the host according to our [Requirements]({{<baseurl>}}/rancher/v2.6/en/installation/requirements/).
@@ -102,13 +104,13 @@ In this task, you can use the versatile **Custom** option. This option lets you 
 
 11. When you finish running the command on your Linux host, click **Done**.
 
-**Result:** 
+**Result:**
 
 Your cluster is created and assigned a state of **Provisioning**. Rancher is standing up your cluster.
 
 You can access your cluster after its state is updated to **Active**.
 
-**Active** clusters are assigned two Projects: 
+**Active** clusters are assigned two Projects:
 
 - `Default`, containing the `default` namespace
 - `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/google-gcp-qs/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/google-gcp-qs/_index.md
@@ -5,7 +5,7 @@ weight: 130
 ---
 The following steps will quickly deploy a Rancher server on GCP in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
 
->**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.6/en/installation/).
 
 ## Prerequisites
 

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/google-gcp-qs/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/google-gcp-qs/_index.md
@@ -5,6 +5,8 @@ weight: 130
 ---
 The following steps will quickly deploy a Rancher server on GCP in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
 
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+
 ## Prerequisites
 
 >**Note**
@@ -25,7 +27,7 @@ The following steps will quickly deploy a Rancher server on GCP in a single-node
 3. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
 
 4. Edit `terraform.tfvars` and customize the following variables:
-    - `gcp_account_json` - GCP service account file path and file name 
+    - `gcp_account_json` - GCP service account file path and file name
     - `rancher_server_admin_password` - Admin password for created Rancher server
 
 5. **Optional:** Modify optional variables within `terraform.tfvars`.

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/hetzner-cloud-qs/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/hetzner-cloud-qs/_index.md
@@ -5,7 +5,7 @@ weight: 140
 ---
 The following steps will quickly deploy a Rancher server on Hetzner Cloud in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
 
->**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.6/en/installation/).
 
 ## Prerequisites
 

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/hetzner-cloud-qs/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/hetzner-cloud-qs/_index.md
@@ -5,6 +5,8 @@ weight: 140
 ---
 The following steps will quickly deploy a Rancher server on Hetzner Cloud in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
 
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+
 ## Prerequisites
 
 >**Note**

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/microsoft-azure-qs/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/microsoft-azure-qs/_index.md
@@ -6,7 +6,7 @@ weight: 115
 
 The following steps will quickly deploy a Rancher server on Azure in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
 
->**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.6/en/installation/).
 
 ## Prerequisites
 

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/microsoft-azure-qs/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/microsoft-azure-qs/_index.md
@@ -6,6 +6,8 @@ weight: 115
 
 The following steps will quickly deploy a Rancher server on Azure in a single-node K3s Kubernetes cluster, with a single-node downstream Kubernetes cluster attached.
 
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+
 ## Prerequisites
 
 >**Note**
@@ -27,7 +29,7 @@ The following steps will quickly deploy a Rancher server on Azure in a single-no
 3. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
 
 4. Edit `terraform.tfvars` and customize the following variables:
-    - `azure_subscription_id` - Microsoft Azure Subscription ID 
+    - `azure_subscription_id` - Microsoft Azure Subscription ID
     - `azure_client_id` - Microsoft Azure Client ID
     - `azure_client_secret` - Microsoft Azure Client Secret
     - `azure_tenant_id` - Microsoft Azure Tenant ID
@@ -41,7 +43,7 @@ Suggestions include:
     - `instance_type` - Compute instance size used, minimum is `Standard_DS2_v2` but `Standard_DS2_v3` or `Standard_DS3_v2` could be used if within budget
     - `add_windows_node` - If true, an additional Windows worker node is added to the workload cluster
     - `windows_admin_password` - The admin password of the windows worker node
-    
+
 6. Run `terraform init`.
 
 7. To initiate the creation of the environment, run `terraform apply --auto-approve`. Then wait for output similar to the following:

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/quickstart-manual-setup/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/quickstart-manual-setup/_index.md
@@ -8,6 +8,8 @@ Howdy Partner! This tutorial walks you through:
 - Creation of your first cluster
 - Deployment of an application, Nginx
 
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+
 ## Quick Start Outline
 
 This Quick Start Guide is divided into different tasks for easier consumption.
@@ -96,13 +98,13 @@ In this task, you can use the versatile **Custom** option. This option lets you 
 
 11. When you finish running the command on your Linux host, click **Done**.
 
-**Result:** 
+**Result:**
 
 Your cluster is created and assigned a state of **Provisioning**. Rancher is standing up your cluster.
 
 You can access your cluster after its state is updated to **Active**.
 
-**Active** clusters are assigned two Projects: 
+**Active** clusters are assigned two Projects:
 
 - `Default`, containing the `default` namespace
 - `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/quickstart-manual-setup/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/quickstart-manual-setup/_index.md
@@ -8,7 +8,7 @@ Howdy Partner! This tutorial walks you through:
 - Creation of your first cluster
 - Deployment of an application, Nginx
 
->**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.6/en/installation/).
 
 ## Quick Start Outline
 

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/quickstart-vagrant/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/quickstart-vagrant/_index.md
@@ -4,7 +4,7 @@ weight: 200
 ---
 The following steps quickly deploy a Rancher Server with a single node cluster attached.
 
->**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.6/en/installation/).
 
 ## Prerequisites
 

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/quickstart-vagrant/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/quickstart-vagrant/_index.md
@@ -4,6 +4,8 @@ weight: 200
 ---
 The following steps quickly deploy a Rancher Server with a single node cluster attached.
 
+>**Note:** The intent of these guides is to quickly launch a sandbox that you can use to evaluate Rancher. These guides are not intended for production environments. For comprehensive setup instructions, see [Installation]({{<baseurl>}}/rancher/v2.0-v2.4/en/installation/).
+
 ## Prerequisites
 
 - [Vagrant](https://www.vagrantup.com): Vagrant is required as this is used to provision the machine based on the Vagrantfile.
@@ -14,7 +16,7 @@ The following steps quickly deploy a Rancher Server with a single node cluster a
 - Vagrant will require plugins to create VirtualBox VMs. Install them with the following commands:
 
   `vagrant plugin install vagrant-vboxmanage`
-  
+
   `vagrant plugin install vagrant-vbguest`
 
 ## Getting Started


### PR DESCRIPTION
Closes https://github.com/rancher/docs/issues/3909

This PR adds the caveat/note to the various subpages for the quickstart section. The general website page (https://rancher.com/quick-start) has not been updated since it is not managed in rancher/docs.