### PR TITLE
Updated version of cert-manager listed in 2.5 version of docs

### DIFF
--- a/content/rancher/v2.5/en/installation/other-installation-methods/behind-proxy/install-rancher/_index.md
+++ b/content/rancher/v2.5/en/installation/other-installation-methods/behind-proxy/install-rancher/_index.md
@@ -26,14 +26,14 @@ kubectl create namespace cert-manager
 Install the CustomResourceDefinitions of cert-manager:
 
 ```
-kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.15.2/cert-manager.crds.yaml
+kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.5.1/cert-manager.crds.yaml
 ```
 
 And install it with Helm. Note that cert-manager also needs your proxy configured in case it needs to communicate with Let's Encrypt or other external certificate issuers:
 
 ```
 helm upgrade --install cert-manager jetstack/cert-manager \
-  --namespace cert-manager --version v0.15.2 \
+  --namespace cert-manager --version v1.5.1 \
   --set http_proxy=http://${proxy_host} \
   --set https_proxy=http://${proxy_host} \
   --set noProxy=127.0.0.0/8\\,10.0.0.0/8\\,cattle-system.svc\\,172.16.0.0/12\\,192.168.0.0/16\\,.svc\\,.cluster.local


### PR DESCRIPTION
Closes #3896 

- Updated 2.5 docs with v1.5.1; opening a new issue to validate 1.6 as 1.5.1 is EOL.