### PR TITLE
Updated note to be more noticeable to link to extra_args page

### DIFF
--- a/content/rke/latest/en/config-options/services/_index.md
+++ b/content/rke/latest/en/config-options/services/_index.md
@@ -6,7 +6,9 @@ weight: 230
 
 To deploy Kubernetes, RKE deploys several core components or services in Docker containers on the nodes. Based on the roles of the node, the containers deployed may be different.
 
-**All services support additional [custom arguments, Docker mount binds and extra environment variables]({{<baseurl>}}/rke/latest/en/config-options/services/services-extras/).**
+>**Note:** All services support <b>additional custom arguments, Docker mount binds, and extra environment variables.</b> 
+>
+>Please see the [documentation]({{<baseurl>}}/rke/latest/en/config-options/services/services-extras/) for more details.
 
 | Component               | Services key name in cluster.yml |
 |-------------------------|----------------------------------|

--- a/content/rke/latest/en/config-options/services/_index.md
+++ b/content/rke/latest/en/config-options/services/_index.md
@@ -8,7 +8,7 @@ To deploy Kubernetes, RKE deploys several core components or services in Docker 
 
 >**Note:** All services support <b>additional custom arguments, Docker mount binds, and extra environment variables.</b> 
 >
->Please see the [documentation]({{<baseurl>}}/rke/latest/en/config-options/services/services-extras/) for more details.
+>To configure advanced options for Kubernetes services such as `kubelet`, `kube-controller`, and `kube-apiserver` that are not documented below, see the [`extra_args` documentation]({{<baseurl>}}/rke/latest/en/config-options/services/services-extras/) for more details.
 
 | Component               | Services key name in cluster.yml |
 |-------------------------|----------------------------------|


### PR DESCRIPTION
Closes #3929 

- Updated the [Default Kubernetes Services page](https://rancher.com/docs/rke/latest/en/config-options/services/) with a more noticeable link to the [`extra_args`](https://rancher.com/docs/rke/latest/en/config-options/services/services-extras/) page.
