### PR TITLE
Fix no_proxy to noProxy for rancher chart

### DIFF
--- a/content/rancher/v2.6/en/installation/other-installation-methods/behind-proxy/install-rancher/_index.md
+++ b/content/rancher/v2.6/en/installation/other-installation-methods/behind-proxy/install-rancher/_index.md
@@ -65,7 +65,7 @@ helm upgrade --install rancher rancher-latest/rancher \
    --namespace cattle-system \
    --set hostname=rancher.example.com \
    --set proxy=http://${proxy_host}
-   --set no_proxy=127.0.0.0/8\\,10.0.0.0/8\\,cattle-system.svc\\,172.16.0.0/12\\,192.168.0.0/16\\,.svc\\,.cluster.local
+   --set noProxy=127.0.0.0/8\\,10.0.0.0/8\\,cattle-system.svc\\,172.16.0.0/12\\,192.168.0.0/16\\,.svc\\,.cluster.local
 ```
 
 After waiting for the deployment to finish:


### PR DESCRIPTION
value is noProxy (per https://github.com/rancher/rancher/blob/v2.6.3/chart/values.yaml#L89 and https://rancher.com/docs/rancher/v2.6/en/installation/install-rancher-on-k8s/chart-options/), this is correct in v2.5 doc at https://rancher.com/docs/rancher/v2.5/en/installation/other-installation-methods/behind-proxy/install-rancher/
