### PR TITLE
Update local_cluster_auth_endpoint ca_certs

### DIFF
--- a/content/rancher/v2.6/en/cluster-admin/editing-clusters/rke-config-reference/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/editing-clusters/rke-config-reference/_index.md
@@ -341,7 +341,10 @@ Example:
 local_cluster_auth_endpoint:
   enabled: true
   fqdn: "FQDN"
-  ca_certs: "BASE64_CACERT"
+  ca_certs: |-
+    -----BEGIN CERTIFICATE-----
+    ...
+    -----END CERTIFICATE-----
 ```
 
 ### Custom Network Plug-in


### PR DESCRIPTION
Clarify format of ca_certs field in local_cluster_auth_endpoint to prevent confusion with double base 64 encoding, existing reference to "BASE64_CACERT" could mislead user into thinking they had to provide a base64 encoded string of the certificate
