### PR TITLE
Created new section for RKE1 v. RKE2 difference highlights

### DIFF
--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/behavior-differences-between-rke1-and-rke2/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/behavior-differences-between-rke1-and-rke2/_index.md
@@ -9,7 +9,7 @@ RKE1 and RKE2 have several slight behavioral differences to note, and this page 
 
 ### Control Plane Components
 
-RKE1 uses Docker for deploying and managing control plane components and the container runtime for Kubernetes. By contrast, RKE2 launches control plane components such as static pods that are managed by the kubelet. RKE2's container runtime is containerd, which allows things such as container registry mirroring (RKE1 with Docker does not).
+RKE1 uses Docker for deploying and managing control plane components, and it also uses Docker as the container runtime for Kubernetes. By contrast, RKE2 launches control plane components such as static pods that are managed by the kubelet. RKE2's container runtime is containerd, which allows things such as container registry mirroring (RKE1 with Docker does not).
 
 ### Cluster API
 
@@ -21,13 +21,13 @@ The following are some specific example configuration changes that may cause the
 
 - When editing the cluster and enabling `drain before delete`, the existing control plane nodes and worker are deleted and new nodes are created.
 
-- When nodes are being provisioned and a scale down operation is performed, rather than scaling down directly, nodes are deleted and new nodes are provisioned to reach the desired node count.
+- When nodes are being provisioned and a scale down operation is performed, rather than scaling down the desired number of nodes, it is possible that the currently provisioning nodes get deleted and new nodes are provisioned to reach the desired node count.
 
 Users who are used to RKE1 provisioning should take note of this new RKE2 behavior which may be unexpected.
 
 ### Terminology
 
-You will notice that some terms have changed or gone away going from RKE1 to RKE2. For example, in RKE2, **node templates** have been deprecated, and you can configure your cluster nodes directly. Another example is that the term **node pool** in RKE1 is now known as **machine pool** in RKE2.
+You will notice that some terms have changed or gone away going from RKE1 to RKE2. For example, in RKE1 provisioning, you use **node templates**; in RKE2 provisioning, you can configure your cluster nodes directly. Another example is that the term **node pool** in RKE1 is now known as **machine pool** in RKE2.
 
 
 

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/behavior-differences-between-rke1-and-rke2/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/behavior-differences-between-rke1-and-rke2/_index.md
@@ -13,7 +13,7 @@ RKE1 uses Docker for deploying and managing control plane components and the con
 
 ### Cluster API
 
-RKE2/K3s V2 provisioning is built on top of the Cluster API (CAPI) upstream framework which often makes RKE2-provisioned clusters behave differently than RKE1-provisioned clusters. 
+RKE2/K3s provisioning is built on top of the Cluster API (CAPI) upstream framework which often makes RKE2-provisioned clusters behave differently than RKE1-provisioned clusters. 
 
 When you make changes to your cluster configuration in RKE2, this may result in nodes reprovisioning. This is controlled by CAPI controllers and not by Rancher itself. Note that for etcd nodes, the same behavior does not apply.
 

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/behavior-differences-between-rke1-and-rke2/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/behavior-differences-between-rke1-and-rke2/_index.md
@@ -27,7 +27,7 @@ Users who are used to RKE1 provisioning should take note of this new RKE2 behavi
 
 ### Terminology
 
-You will notice that some terms have changed or gone away going from RKE1 to RKE2. For example, in RKE2, **node templates** have been deprecated, and you can confiugure your cluster nodes directly. Another example is that the term **node pool** in RKE1 is now known as **machine pool** in RKE2.
+You will notice that some terms have changed or gone away going from RKE1 to RKE2. For example, in RKE2, **node templates** have been deprecated, and you can configure your cluster nodes directly. Another example is that the term **node pool** in RKE1 is now known as **machine pool** in RKE2.
 
 
 

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/behavior-differences-between-rke1-and-rke2/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/behavior-differences-between-rke1-and-rke2/_index.md
@@ -21,7 +21,7 @@ The following are some specific example configuration changes that may cause the
 
 - When editing the cluster and enabling `drain before delete`, the existing control plane nodes and worker are deleted and new nodes are created.
 
-- When nodes are being provisioned, performing a scale down operation may, in some cases, result in both nodes getting deleted and a new one being provisioned.
+- When nodes are being provisioned and a scale down operation is performed, rather than scaling down directly, nodes are deleted and new nodes are provisioned to reach the desired node count.
 
 Users who are used to RKE1 provisioning should take note of this new RKE2 behavior which may be unexpected.
 

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/behavior-differences-between-rke1-and-rke2/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/behavior-differences-between-rke1-and-rke2/_index.md
@@ -9,7 +9,7 @@ RKE1 and RKE2 have several slight behavioral differences to note, and this page 
 
 ### Control Plane Components
 
-RKE1 uses Docker for deploying and managing control plane components, and it also uses Docker as the container runtime for Kubernetes. By contrast, RKE2 launches control plane components such as static pods that are managed by the kubelet. RKE2's container runtime is containerd, which allows things such as container registry mirroring (RKE1 with Docker does not).
+RKE1 uses Docker for deploying and managing control plane components, and it also uses Docker as the container runtime for Kubernetes. By contrast, RKE2 launches control plane components as static pods that are managed by the kubelet. RKE2's container runtime is containerd, which allows things such as container registry mirroring (RKE1 with Docker does not).
 
 ### Cluster API
 
@@ -21,13 +21,13 @@ The following are some specific example configuration changes that may cause the
 
 - When editing the cluster and enabling `drain before delete`, the existing control plane nodes and worker are deleted and new nodes are created.
 
-- When nodes are being provisioned and a scale down operation is performed, rather than scaling down the desired number of nodes, it is possible that the currently provisioning nodes get deleted and new nodes are provisioned to reach the desired node count.
+- When nodes are being provisioned and a scale down operation is performed, rather than scaling down the desired number of nodes, it is possible that the currently provisioning nodes get deleted and new nodes are provisioned to reach the desired node count. Please note that this is a bug in Cluster API, and it will be fixed in an upcoming release. Once fixed, Rancher will update the documentation.
 
 Users who are used to RKE1 provisioning should take note of this new RKE2 behavior which may be unexpected.
 
 ### Terminology
 
-You will notice that some terms have changed or gone away going from RKE1 to RKE2. For example, in RKE1 provisioning, you use **node templates**; in RKE2 provisioning, you can configure your cluster nodes directly. Another example is that the term **node pool** in RKE1 is now known as **machine pool** in RKE2.
+You will notice that some terms have changed or gone away going from RKE1 to RKE2. For example, in RKE1 provisioning, you use **node templates**; in RKE2 provisioning, you can configure your cluster node pools when creating or editing the cluster. Another example is that the term **node pool** in RKE1 is now known as **machine pool** in RKE2.
 
 
 

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/behavior-differences-between-rke1-and-rke2/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/behavior-differences-between-rke1-and-rke2/_index.md
@@ -21,7 +21,7 @@ The following are some specific example configuration changes that may cause the
 
 - When editing the cluster and enabling `drain before delete`, the existing control plane nodes and worker are deleted and new nodes are created.
 
-- When nodes are being provisioned, performing a scale down operation may result in both nodes getting deleted and a new one being provisioned.
+- When nodes are being provisioned, performing a scale down operation may, in some cases, result in both nodes getting deleted and a new one being provisioned.
 
 Users who are used to RKE1 provisioning should take note of this new RKE2 behavior which may be unexpected.
 

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/behavior-differences-between-rke1-and-rke2/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/behavior-differences-between-rke1-and-rke2/_index.md
@@ -17,6 +17,12 @@ RKE2/K3s provisioning is built on top of the Cluster API (CAPI) upstream framewo
 
 When you make changes to your cluster configuration in RKE2, this **may** result in nodes reprovisioning. This is controlled by CAPI controllers and not by Rancher itself. Note that for etcd nodes, the same behavior does not apply.
 
+The following are some specific example configuration changes that may cause the described behavior:
+
+- When editing the cluster and enabling `drain before delete`, the existing control plane nodes and worker are deleted and new nodes are created.
+
+- When nodes are being provisioned, performing a scale down operation may result in both nodes getting deleted and a new one being provisioned.
+
 Users who are used to RKE1 provisioning should take note of this new RKE2 behavior which may be unexpected.
 
 ### Terminology

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/behavior-differences-between-rke1-and-rke2/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/behavior-differences-between-rke1-and-rke2/_index.md
@@ -15,7 +15,7 @@ RKE1 uses Docker for deploying and managing control plane components and the con
 
 RKE2/K3s provisioning is built on top of the Cluster API (CAPI) upstream framework which often makes RKE2-provisioned clusters behave differently than RKE1-provisioned clusters. 
 
-When you make changes to your cluster configuration in RKE2, this may result in nodes reprovisioning. This is controlled by CAPI controllers and not by Rancher itself. Note that for etcd nodes, the same behavior does not apply.
+When you make changes to your cluster configuration in RKE2, this **may** result in nodes reprovisioning. This is controlled by CAPI controllers and not by Rancher itself. Note that for etcd nodes, the same behavior does not apply.
 
 Users who are used to RKE1 provisioning should take note of this new RKE2 behavior which may be unexpected.
 

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/behavior-differences-between-rke1-and-rke2/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/behavior-differences-between-rke1-and-rke2/_index.md
@@ -1,0 +1,28 @@
+---
+title: Behavior Differences Between RKE1 and RKE2
+weight: 2450
+---
+
+RKE2, also known as RKE Government, is a Kubernetes distribution that focuses on security and compliance for U.S. Federal Government entities. It is considered the next iteration of the Rancher Kubernetes Engine, now known as RKE1.
+
+RKE1 and RKE2 have several slight behavioral differences to note, and this page will highlight some of these at a high level.
+
+### Control Plane Components
+
+RKE1 uses Docker for deploying and managing control plane components and the container runtime for Kubernetes. By contrast, RKE2 launches control plane components such as static pods that are managed by the kubelet. RKE2's container runtime is containerd, which allows things such as container registry mirroring (RKE1 with Docker does not).
+
+### Cluster API
+
+RKE2/K3s V2 provisioning is built on top of the Cluster API (CAPI) upstream framework which often makes RKE2-provisioned clusters behave differently than RKE1-provisioned clusters. 
+
+When you make changes to your cluster configuration in RKE2, this may result in nodes reprovisioning. This is controlled by CAPI controllers and not by Rancher itself. Note that for etcd nodes, the same behavior does not apply.
+
+Users who are used to RKE1 provisioning should take note of this new RKE2 behavior which may be unexpected.
+
+### Terminology
+
+You will notice that some terms have changed or gone away going from RKE1 to RKE2. For example, in RKE2, **node templates** have been deprecated, and you can confiugure your cluster nodes directly. Another example is that the term **node pool** in RKE1 is now known as **machine pool** in RKE2.
+
+
+
+


### PR DESCRIPTION
Closes #3925

Reference: [New RKE1 v. RKE2 behavior differences section](https://rancher.com/docs/rancher/v2.6/en/cluster-provisioning/rke-clusters/behavior-differences-between-rke1-and-rke2/)

- Adds an overview section to highlight the diffs between RKE1/RKE2 in a conceptual way.