### PR TITLE
impacted version update

### DIFF
--- a/content/rancher/v2.6/en/installation/resources/advanced/firewall/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/advanced/firewall/_index.md
@@ -3,7 +3,7 @@ title: Opening Ports with firewalld
 weight: 1
 ---
 
-> We recommend disabling firewalld. For Kubernetes 1.19, firewalld must be turned off.
+> We recommend disabling firewalld. For Kubernetes 1.19.x and higher, firewalld must be turned off.
 
 Some distributions of Linux [derived from RHEL,](https://en.wikipedia.org/wiki/Red_Hat_Enterprise_Linux#Rebuilds) including Oracle Linux, may have default firewall rules that block communication with Helm.
 


### PR DESCRIPTION
firewalld/iptables issue still unresolved on newer releases.

### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
