### PR TITLE
Revert "Use the current hostname for baseUrl"

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -10,4 +10,4 @@ RUN mkdir -p /output /theme/rancher-website-theme && tar -xzf /run/master.tar.gz
 # Expose default hugo port
 EXPOSE 9001
 
-ENTRYPOINT ["hugo", "serve", "--bind=0.0.0.0", "--buildDrafts", "--buildFuture" ]
+ENTRYPOINT ["hugo", "serve", "--bind=0.0.0.0", "--buildDrafts", "--buildFuture", "--baseURL=" ]

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -16,7 +16,7 @@ COPY .git .git
 ADD https://github.com/rancherlabs/website-theme/archive/master.tar.gz /run/master.tar.gz
 RUN mkdir -p /output /theme/rancher-website-theme && tar -xzf /run/master.tar.gz -C /run/node_modules/rancher-website-theme --strip=1 && rm /run/master.tar.gz
 
-RUN ["hugo", "--buildFuture", "--destination=/output"]
+RUN ["hugo", "--buildFuture", "--baseURL=https://rancher.com/docs", "--destination=/output"]
 
 # Make sure something got built
 RUN stat /output/index.html

--- a/Dockerfile.staging
+++ b/Dockerfile.staging
@@ -16,7 +16,7 @@ COPY .git .git
 ADD https://github.com/rancherlabs/website-theme/archive/master.tar.gz /run/master.tar.gz
 RUN mkdir -p /output /theme/rancher-website-theme && tar -xzf /run/master.tar.gz -C /run/node_modules/rancher-website-theme --strip=1 && rm /run/master.tar.gz
 
-RUN ["hugo", "--buildDrafts", "--buildFuture", "--destination=/output"]
+RUN ["hugo", "--buildDrafts", "--buildFuture", "--baseURL=https://staging.rancher.com/docs", "--destination=/output"]
 
 # Make sure something got built
 RUN stat /output/index.html

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = ".Permalink"
+baseURL = ""
 languageCode = "en-us"
 title = "Rancher Labs"
 


### PR DESCRIPTION
Reverts rancher/docs#3895

- To be revisited after the 2.6.4 release