### PR TITLE
Add Nutanix node-pools

### DIFF
--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/nutanix/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/nutanix/_index.md
@@ -6,14 +6,14 @@ metaDescription: Use Rancher to create a Nutanix AOS (AHV) cluster. It may consi
 weight: 2225
 ---
 
-By using Rancher with Nutanix AOS (AHV), you can bring cloud operations on-premises.
+[Nutanix Acropolis Operating System](https://www.nutanix.com/products/acropolis) (Nutanix AOS) is an operating system for the Nutanix hyper-converged infrastructure platform. AOS comes with a built-in hypervisor called [Acropolis Hypervisor](https://www.nutanix.com/products/ahv), or AHV. By using Rancher with Nutanix AOS (AHV), you can bring cloud operations on-premises.
 
-Rancher can provision nodes in AOS (AHV) and install Kubernetes on them. When creating a Kubernetes cluster in AOS, Rancher first provisions the specified number of virtual machines by communicating with the Prism Central API. Then it installs Kubernetes on top of them.
+Rancher can provision nodes in AOS (AHV) and install Kubernetes on them. When creating a Kubernetes cluster in AOS, Rancher first provisions the specified number of virtual machines by communicating with the Prism Central API. Then it installs Kubernetes on top of the VMs.
 
 A Nutanix cluster may consist of multiple groups of VMs with distinct properties, such as the amount of memory or the number of vCPUs. This grouping allows for fine-grained control over the sizing of nodes for each Kubernetes role.
 
-- [Creating a Nutanix Cluster](#creating-a-nutanix-cluster)
-- [Provisioning Storage](#provisioning-storage)
+- [Creating a Nutanix Cluster]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/nutanix/provisioning-nutanix-clusters/#creating-a-nutanix-aos-cluster)
+- [Provisioning Storage]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/nutanix/provisioning-nutanix-clusters)
 
 # Creating a Nutanix Cluster
 

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/nutanix/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/nutanix/_index.md
@@ -1,0 +1,20 @@
+---
+title: Creating a Nutanix AOS Cluster
+shortTitle: Nutanix
+description: Use Rancher to create a Nutanix AOS (AHV) cluster. It may consist of groups of VMs with distinct properties which allow for fine-grained control over the sizing of nodes. 
+metaDescription: Use Rancher to create a Nutanix AOS (AHV) cluster. It may consist of groups of VMs with distinct properties which allow for fine-grained control over the sizing of nodes. 
+weight: 2225
+---
+
+By using Rancher with Nutanix AOS (AHV), you can bring cloud operations on-premises.
+
+Rancher can provision nodes in AOS (AHV) and install Kubernetes on them. When creating a Kubernetes cluster in AOS, Rancher first provisions the specified number of virtual machines by communicating with the Prism Central API. Then it installs Kubernetes on top of them.
+
+A Nutanix cluster may consist of multiple groups of VMs with distinct properties, such as the amount of memory or the number of vCPUs. This grouping allows for fine-grained control over the sizing of nodes for each Kubernetes role.
+
+- [Creating a Nutanix Cluster](#creating-a-nutanix-cluster)
+- [Provisioning Storage](#provisioning-storage)
+
+# Creating a Nutanix Cluster
+
+In [this section,](./provisioning-nutanix-clusters) you'll learn how to use Rancher to install an [RKE]({{<baseurl>}}/rke/latest/en/) Kubernetes cluster in Nutanix AOS.

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/nutanix/nutanix-node-template-config/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/nutanix/nutanix-node-template-config/_index.md
@@ -1,0 +1,62 @@
+---
+title: Nutanix Node Template Configuration
+weight: 2
+---
+
+- [Account Access](#account-access)
+- [Scheduling](#scheduling)
+- [Instance Options](#instance-options)
+- [Networks](#networks)
+- [VM Categories](#vm-categories)
+- [cloud-init](#cloud-init)
+
+# Account Access
+
+| Parameter                    | Required | Description | Default
+|:-----------------------------|:--------:|:-----------------------------------------------------------------|:-----
+| Management Endpoint          |   *      | Hostname/IP address of Prism Central                             |
+| Username                     |   *      | Username of the Prism Central user                               |
+| Password                     |   *      | Password of the Prism Central user                               |
+| Allow insecure communication |          | Set to true to allow insecure SSL communication to Prism Central | False
+
+# Scheduling
+
+Choose what Nutanix cluster the virtual machine will be scheduled to. 
+
+| Parameter | Required | Description
+|:----------|:--------:|:----------------------------------------------------------------------------
+| Cluster   |   *      | Name of the Nutanix cluster where the VM should be deployed (case sensitive)
+
+# Instance Options
+
+In the **Instance Options** section, configure the number of vCPUs, memory, and disk size for the VMs created by this template.
+
+| Parameter            | Required | Description                                                                                 | Default
+|:---------------------|:--------:|:--------------------------------------------------------------------------------------------|:-------
+| CPUs                 |          | Number of vCPUs allocated to the VM (cores)                                                 | 2
+| Memory               |          | Amount of RAM allocated to the VM (MB)                                                      | 2 GB
+| Template Image       | *        | Name of the Disk Image template to clone as the VM's primary disk (must support cloud-init) |
+| VM Disk Size         |          | New size of the VM's primary disk (in GiB)                                                  |
+| Additional Disk Size |          | Size of an additional disk to add to the VM (in GiB)                                        |
+| Storage Container    |          | Storage container _UUID_ in which to provision an additional disk                           |
+| Cloud Config YAML    |          | Cloud-init to provide to the VM (will be patched with Rancher root user)                  |
+| Network              | *        | Name(s) of the network(s) to attach to the VM                                               |
+| VM Categories        |          | Name(s) of any categories to be applied to the VM                                           |
+
+The VM may use any modern Linux operating system that is configured with support for [cloud-init](https://cloudinit.readthedocs.io/en/latest/) using the [Config Drive v2 datasource](https://cloudinit.readthedocs.io/en/latest/topics/datasources/configdrive.html).
+
+# Networks
+
+The node template allows a VM to be provisioned with multiple networks. In the **Network** field, you can click **Add** to add any networks available to you in AOS.
+
+# VM Categories
+
+A category is a grouping of entities into a key value pair. Typically, VMs are assigned to a category based on some criteria. Policies can then be tied to those entities that are assigned (grouped by) a specific category value.
+
+# cloud-init
+
+[Cloud-init](https://cloudinit.readthedocs.io/en/latest/) allows you to initialize your nodes by applying configuration on the first boot. This may involve things such as creating users or authorizing SSH keys.
+
+To make use of cloud-init initialization, paste a cloud config using valid YAML syntax into the **Cloud Config YAML** field. Refer to the [cloud-init documentation](https://cloudinit.readthedocs.io/en/latest/topics/examples.html) for a commented set of examples of supported cloud config directives.
+
+Note that cloud-init based network configuration is not recommended and only supported via user data `runcmd` rather than by NoCloud or other network configuration datasources. Nutanix IP Address Management (IPAM) or other DHCP service is recommended.

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/nutanix/nutanix-node-template-config/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/nutanix/nutanix-node-template-config/_index.md
@@ -14,9 +14,9 @@ weight: 2
 
 | Parameter                    | Required | Description | Default
 |:-----------------------------|:--------:|:-----------------------------------------------------------------|:-----
-| Management Endpoint          |   *      | Hostname/IP address of Prism Central                             |
-| Username                     |   *      | Username of the Prism Central user                               |
-| Password                     |   *      | Password of the Prism Central user                               |
+| Management Endpoint          |   ✓      | Hostname/IP address of Prism Central                             |
+| Username                     |   ✓      | Username of the Prism Central user                               |
+| Password                     |   ✓      | Password of the Prism Central user                               |
 | Allow insecure communication |          | Set to true to allow insecure SSL communication to Prism Central | False
 
 # Scheduling
@@ -25,7 +25,7 @@ Choose what Nutanix cluster the virtual machine will be scheduled to.
 
 | Parameter | Required | Description
 |:----------|:--------:|:----------------------------------------------------------------------------
-| Cluster   |   *      | Name of the Nutanix cluster where the VM should be deployed (case sensitive)
+| Cluster   |   ✓      | Name of the Nutanix cluster where the VM should be deployed (case sensitive)
 
 # Instance Options
 
@@ -35,12 +35,12 @@ In the **Instance Options** section, configure the number of vCPUs, memory, and 
 |:---------------------|:--------:|:--------------------------------------------------------------------------------------------|:-------
 | CPUs                 |          | Number of vCPUs allocated to the VM (cores)                                                 | 2
 | Memory               |          | Amount of RAM allocated to the VM (MB)                                                      | 2 GB
-| Template Image       | *        | Name of the Disk Image template to clone as the VM's primary disk (must support cloud-init) |
+| Template Image       | ✓        | Name of the Disk Image template to clone as the VM's primary disk (must support cloud-init) |
 | VM Disk Size         |          | New size of the VM's primary disk (in GiB)                                                  |
 | Additional Disk Size |          | Size of an additional disk to add to the VM (in GiB)                                        |
 | Storage Container    |          | Storage container _UUID_ in which to provision an additional disk                           |
 | Cloud Config YAML    |          | Cloud-init to provide to the VM (will be patched with Rancher root user)                  |
-| Network              | *        | Name(s) of the network(s) to attach to the VM                                               |
+| Network              | ✓        | Name(s) of the network(s) to attach to the VM                                               |
 | VM Categories        |          | Name(s) of any categories to be applied to the VM                                           |
 
 The VM may use any modern Linux operating system that is configured with support for [cloud-init](https://cloudinit.readthedocs.io/en/latest/) using the [Config Drive v2 datasource](https://cloudinit.readthedocs.io/en/latest/topics/datasources/configdrive.html).
@@ -59,4 +59,6 @@ A category is a grouping of entities into a key value pair. Typically, VMs are a
 
 To make use of cloud-init initialization, paste a cloud config using valid YAML syntax into the **Cloud Config YAML** field. Refer to the [cloud-init documentation](https://cloudinit.readthedocs.io/en/latest/topics/examples.html) for a commented set of examples of supported cloud config directives.
 
-Note that cloud-init based network configuration is not recommended and only supported via user data `runcmd` rather than by NoCloud or other network configuration datasources. Nutanix IP Address Management (IPAM) or other DHCP service is recommended.
+Note that cloud-init based network configuration is not recommended and only supported via user data `runcmd` rather than by NoCloud or other network configuration datasources. 
+
+Nutanix IP Address Management (IPAM) or another DHCP service is recommended.

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/nutanix/provisioning-nutanix-clusters/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/nutanix/provisioning-nutanix-clusters/_index.md
@@ -1,0 +1,91 @@
+---
+title: Provisioning Kubernetes Clusters in Nutanix AOS
+weight: 1
+---
+
+In this section, you'll learn how to use Rancher to install an [RKE]({{<baseurl>}}/rke/latest/en/) Kubernetes cluster in Nutanix AOS (AHV).
+
+First, you will locate Rancher's built-in Nutanix [node driver and activate it]({{<baseurl>}}/rancher/v2.6/en/admin-settings/drivers/node-drivers/#activating-deactivating-node-drivers).
+
+Then you will create a node template, which Rancher will use to provision nodes in Nutanix AOS. 
+
+Finally, you will create a Nutanix AOS cluster in Rancher, and when configuring the new cluster, you will define node pools for it. Each node pool will have a Kubernetes role of etcd, controlplane, or worker. Rancher will install RKE Kubernetes on the new nodes, and it will set up each node with the Kubernetes role defined by the node pool.
+
+For details on configuring the Nutanix AOS node template, refer to the [Nutanix AOS node template configuration reference.]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/nutanix/nutanix-node-template-config/)
+
+For details on configuring RKE Kubernetes clusters in Rancher, refer to the [cluster configuration reference.]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/options)
+
+- [Preparation in Nutanix AOS](#preparation-in-Nutanix AOS)
+- [Creating a Nutanix AOS Cluster](#creating-a-Nutanix AOS-cluster)
+
+# Preparation in Nutanix AOS
+
+This section describes the requirements for setting up Nutanix AOS so that Rancher can provision VMs and clusters.
+
+The node templates are documented and tested with Nutanix AOS version 5.20.2 and 6.0.1.
+
+### Create Credentials in Nutanix AOS
+
+Before proceeding to create a cluster, you must ensure that you have a Nutanix Prism Central user with admin permissions. When you set up a node template, the template will need to use these credentials.
+
+### Network Permissions
+
+It must be ensured that the hosts running the Rancher server are able to establish the following network connections:
+
+- To the Nutanix Prism Central API (usually port 9440/TCP).
+- To port 22/TCP and 2376/TCP on the created VMs
+
+See [Node Networking Requirements]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/node-requirements/#networking-requirements) for a detailed list of port requirements applicable for creating nodes on an infrastructure provider.
+
+### VM-VM Anti-Affinity Policies
+
+Setting up [VM-VM Anti-Affinity Policies](https://portal.nutanix.com/page/documents/details?targetId=AHV-Admin-Guide-v6_1:ahv-vm-anti-affinity-t.html) is recommended. These rules allow VMs assigned the etcd and control-plane roles to operate on separate AHV hosts when they are assigned to different node pools. This practice ensures that the failure of a single physical machine does not affect the availability of those planes.
+
+# Creating a Nutanix AOS Cluster
+
+1. [Create a node template ](#1-create-a-node-template)
+2. [Create a cluster with node pools using the node template](#2-create-a-cluster-with-node-pools-using-the-node-template)
+
+### 1. Create a node template
+
+Creating a [node template]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/#node-templates) for Nutanix AOS will allow Rancher to provision new nodes in Nutanix AOS. Node templates can be reused for other clusters.
+
+1. Click **☰ > Cluster Management**.
+1. Click **RKE1 Configuration > Node Templates**.
+1. Click **Create**.
+1. Click **Add Template**.
+1. Click **Nutanix**.
+1. Fill out a node template for Nutanix AOS. For help filling out the form, refer to the Nutanix AOS node template [configuration reference.]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/nutanix/nutanix-node-template-config/).
+1. Click **Create**.
+
+### 2. Create a cluster with node pools using the node template
+
+Use Rancher to create a Kubernetes cluster in Nutanix AOS.
+
+1. In the upper left corner, click **☰ > Cluster Management**.
+1. On the **Clusters** page, click **Create**.
+1. Click **Nutanix**.
+1. Enter a **Cluster Name**, then click **Continue**.
+1. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
+1. Use **Cluster Options** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. To see more cluster options, click on **Show advanced options**. For help configuring the cluster, refer to the [RKE cluster configuration reference.]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/options)
+1. Add one or more node pools to your cluster. Each node pool uses a node template to provision new nodes. For more information about node pools, including best practices for assigning Kubernetes roles to the nodes, see [this section.]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/#node-pools)
+1. Review your options to confirm they're correct. Then click **Create**.
+
+**Result:** 
+
+Your cluster is created and assigned a state of **Provisioning**. Rancher is standing up your cluster.
+
+You can access your cluster after its state is updated to **Active**.
+
+**Active** clusters are assigned two Projects: 
+
+- `Default`, containing the `default` namespace
+- `System`, containing the `cattle-system`, `ingress-nginx`, `kube-public`, and `kube-system` namespaces
+
+
+# Optional Next Steps
+
+After creating your cluster, you can access it through the Rancher UI. As a best practice, we recommend setting up these alternate ways of accessing your cluster:
+
+- **Access your cluster with the kubectl CLI:** Follow [these steps]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/cluster-access/kubectl/#accessing-clusters-with-kubectl-on-your-workstation) to access clusters with kubectl on your workstation. In this case, you will be authenticated through the Rancher server’s authentication proxy, then Rancher will connect you to the downstream cluster. This method lets you manage the cluster without the Rancher UI.
+- **Access your cluster with the kubectl CLI, using the authorized cluster endpoint:** Follow [these steps]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/cluster-access/kubectl/#authenticating-directly-with-a-downstream-cluster) to access your cluster with kubectl directly, without authenticating through Rancher. We recommend setting up this alternative method to access your cluster so that in case you can’t connect to Rancher, you can still access the cluster.

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/nutanix/provisioning-nutanix-clusters/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/nutanix/provisioning-nutanix-clusters/_index.md
@@ -3,34 +3,34 @@ title: Provisioning Kubernetes Clusters in Nutanix AOS
 weight: 1
 ---
 
-In this section, you'll learn how to use Rancher to install an [RKE]({{<baseurl>}}/rke/latest/en/) Kubernetes cluster in Nutanix AOS (AHV).
+To use Rancher to install an [RKE]({{<baseurl>}}/rke/latest/en/) Kubernetes cluster in Nutanix AOS (AHV):
 
-First, you will locate Rancher's built-in Nutanix [node driver and activate it]({{<baseurl>}}/rancher/v2.6/en/admin-settings/drivers/node-drivers/#activating-deactivating-node-drivers).
+1. Locate Rancher's built-in Nutanix [node driver and activate it]({{<baseurl>}}/rancher/v2.6/en/admin-settings/drivers/node-drivers/#activating-deactivating-node-drivers).
 
-Then you will create a node template, which Rancher will use to provision nodes in Nutanix AOS. 
+1. Create a node template, which Rancher will use to provision nodes in Nutanix AOS. 
 
-Finally, you will create a Nutanix AOS cluster in Rancher, and when configuring the new cluster, you will define node pools for it. Each node pool will have a Kubernetes role of etcd, controlplane, or worker. Rancher will install RKE Kubernetes on the new nodes, and it will set up each node with the Kubernetes role defined by the node pool.
+1. Create a Nutanix AOS cluster in Rancher. When configuring the new cluster, you will define node pools for it. Each node pool will have a Kubernetes role of etcd, controlplane, or worker. Rancher will install RKE Kubernetes on the new nodes, and it will set up each node with the Kubernetes role defined by the node pool.
 
 For details on configuring the Nutanix AOS node template, refer to the [Nutanix AOS node template configuration reference.]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/nutanix/nutanix-node-template-config/)
 
-For details on configuring RKE Kubernetes clusters in Rancher, refer to the [cluster configuration reference.]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/options)
+For details on configuring RKE Kubernetes clusters in Rancher, refer to the [cluster configuration reference.]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/editing-clusters/rke-config-reference/)
 
-- [Preparation in Nutanix AOS](#preparation-in-Nutanix AOS)
-- [Creating a Nutanix AOS Cluster](#creating-a-Nutanix AOS-cluster)
+- [Preparation in Nutanix AOS](#preparation-in-nutanix-aos)
+- [Creating a Nutanix AOS Cluster](#creating-a-nutanix-aos-cluster)
 
 # Preparation in Nutanix AOS
 
-This section describes the requirements for setting up Nutanix AOS so that Rancher can provision VMs and clusters.
+The following sections describe the requirements for setting up Nutanix AOS so that Rancher can provision VMs and clusters.
 
-The node templates are documented and tested with Nutanix AOS version 5.20.2 and 6.0.1.
+**Note:** The node templates are documented and tested with Nutanix AOS version 5.20.2 and 6.0.1.
 
 ### Create Credentials in Nutanix AOS
 
-Before proceeding to create a cluster, you must ensure that you have a Nutanix Prism Central user with admin permissions. When you set up a node template, the template will need to use these credentials.
+Before proceeding to create a cluster, you must ensure that you have a [Nutanix Prism Central user account](https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Security-Guide-v6_0:wc-user-create-wc-t.html) with admin permissions. When you set up a node template, the template will need to use these credentials.
 
 ### Network Permissions
 
-It must be ensured that the hosts running the Rancher server are able to establish the following network connections:
+You must ensure that the hosts running the Rancher server are able to establish the following network connections:
 
 - To the Nutanix Prism Central API (usually port 9440/TCP).
 - To port 22/TCP and 2376/TCP on the created VMs
@@ -62,18 +62,16 @@ Creating a [node template]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rk
 
 Use Rancher to create a Kubernetes cluster in Nutanix AOS.
 
-1. In the upper left corner, click **☰ > Cluster Management**.
+1. Click **☰ > Cluster Management**.
 1. On the **Clusters** page, click **Create**.
 1. Click **Nutanix**.
 1. Enter a **Cluster Name**, then click **Continue**.
-1. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users that can access the cluster. Use the **Role** drop-down to set permissions for each user.
-1. Use **Cluster Options** to choose the version of Kubernetes that will be installed, what network provider will be used and if you want to enable project network isolation. To see more cluster options, click on **Show advanced options**. For help configuring the cluster, refer to the [RKE cluster configuration reference.]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/options)
+1. Use **Member Roles** to configure user authorization for the cluster. Click **Add Member** to add users who can access the cluster. Use the **Role** drop-down to set permissions for each user.
+1. Use **Cluster Options** to choose the version of Kubernetes that will be installed, what network provider will be used, and whether you want to enable project network isolation. To see more cluster options, click on **Show advanced options**. For help configuring the cluster, refer to the [RKE cluster configuration reference.]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/editing-clusters/rke-config-reference/)
 1. Add one or more node pools to your cluster. Each node pool uses a node template to provision new nodes. For more information about node pools, including best practices for assigning Kubernetes roles to the nodes, see [this section.]({{<baseurl>}}/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/#node-pools)
 1. Review your options to confirm they're correct. Then click **Create**.
 
-**Result:** 
-
-Your cluster is created and assigned a state of **Provisioning**. Rancher is standing up your cluster.
+**Result:** Your cluster is created and assigned a state of **Provisioning**. Rancher is standing up your cluster.
 
 You can access your cluster after its state is updated to **Active**.
 
@@ -88,4 +86,5 @@ You can access your cluster after its state is updated to **Active**.
 After creating your cluster, you can access it through the Rancher UI. As a best practice, we recommend setting up these alternate ways of accessing your cluster:
 
 - **Access your cluster with the kubectl CLI:** Follow [these steps]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/cluster-access/kubectl/#accessing-clusters-with-kubectl-on-your-workstation) to access clusters with kubectl on your workstation. In this case, you will be authenticated through the Rancher server’s authentication proxy, then Rancher will connect you to the downstream cluster. This method lets you manage the cluster without the Rancher UI.
+
 - **Access your cluster with the kubectl CLI, using the authorized cluster endpoint:** Follow [these steps]({{<baseurl>}}/rancher/v2.6/en/cluster-admin/cluster-access/kubectl/#authenticating-directly-with-a-downstream-cluster) to access your cluster with kubectl directly, without authenticating through Rancher. We recommend setting up this alternative method to access your cluster so that in case you can’t connect to Rancher, you can still access the cluster.


### PR DESCRIPTION
This adds Nutanix node-pool doc in coordination for support in 2.6.4.

### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
