### PR TITLE
update support Docker versions URL

### DIFF
--- a/content/rke/latest/en/config-options/_index.md
+++ b/content/rke/latest/en/config-options/_index.md
@@ -50,7 +50,7 @@ cluster_name: mycluster
 
 ### Supported Docker Versions
 
-By default, RKE will check the installed Docker version on all hosts and fail with an error if the version is not supported by Kubernetes. The list of [supported Docker versions](https://github.com/rancher/rke/blob/master/docker/docker.go#L37-L41) are set specifically for each Kubernetes version. To override this behavior, set this option to `true`.
+By default, RKE will check the installed Docker version on all hosts and fail with an error if the version is not supported by Kubernetes. The list of [supported Docker versions](https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_docker_info.go#L3-L15) are set specifically for each Kubernetes version. To override this behavior, set this option to `true`.
 
 The default value is `false`.
 

--- a/content/rke/latest/en/config-options/_index.md
+++ b/content/rke/latest/en/config-options/_index.md
@@ -50,9 +50,10 @@ cluster_name: mycluster
 
 ### Supported Docker Versions
 
-By default, RKE will check the installed Docker version on all hosts and fail with an error if the version is not supported by Kubernetes. The list of supported Docker versions are set specifically for each Kubernetes version in kontainer-driver-metadata depending on the RKE version used (to override this behavior, set this option to `true`). Refer to the following:
-- For RKE v1.3.x, see this [link](https://github.com/rancher/kontainer-driver-metadata/blob/release-v2.6/rke/k8s_docker_info.go for RKE v1.3.x)
-- For RKE v1.2.x, see this [link](https://github.com/rancher/kontainer-driver-metadata/blob/release-v2.5/rke/k8s_docker_info.go)
+By default, RKE will check the installed Docker version on all hosts and fail with an error if the version is not supported by Kubernetes. The list of supported Docker versions is set specifically for each Kubernetes version in kontainer-driver-metadata depending on the RKE version used, as shown below. To override this behavior, set this option to `true`. Refer to the following:
+
+- For RKE v1.3.x, see this [link](https://github.com/rancher/kontainer-driver-metadata/blob/release-v2.6/rke/k8s_docker_info.go).
+- For RKE v1.2.x, see this [link](https://github.com/rancher/kontainer-driver-metadata/blob/release-v2.5/rke/k8s_docker_info.go).
 
 The default value is `false`.
 

--- a/content/rke/latest/en/config-options/_index.md
+++ b/content/rke/latest/en/config-options/_index.md
@@ -50,7 +50,9 @@ cluster_name: mycluster
 
 ### Supported Docker Versions
 
-By default, RKE will check the installed Docker version on all hosts and fail with an error if the version is not supported by Kubernetes. The list of [supported Docker versions](https://github.com/rancher/kontainer-driver-metadata/blob/master/rke/k8s_docker_info.go#L3-L15) are set specifically for each Kubernetes version. To override this behavior, set this option to `true`.
+By default, RKE will check the installed Docker version on all hosts and fail with an error if the version is not supported by Kubernetes. The list of supported Docker versions are set specifically for each Kubernetes version in kontainer-driver-metadata depending on the RKE version used (to override this behavior, set this option to `true`). Refer to the following:
+- For RKE v1.3.x, see this [link](https://github.com/rancher/kontainer-driver-metadata/blob/release-v2.6/rke/k8s_docker_info.go for RKE v1.3.x)
+- For RKE v1.2.x, see this [link](https://github.com/rancher/kontainer-driver-metadata/blob/release-v2.5/rke/k8s_docker_info.go)
 
 The default value is `false`.
 


### PR DESCRIPTION
RKE loads support Docker versions from metadata now, so the support Docker versions URL should be updated.