### PR TITLE
k3s: Update information about dual-stack

### DIFF
--- a/content/k3s/latest/en/installation/install-options/how-to-flags/_index.md
+++ b/content/k3s/latest/en/installation/install-options/how-to-flags/_index.md
@@ -46,5 +46,4 @@ token: "secret"
 node-ip: 10.0.10.22,2a05:d012:c6f:4655:d73c:c825:a184:1b75 
 cluster-cidr: 10.42.0.0/16,2001:cafe:42:0::/56
 service-cidr: 10.43.0.0/16,2001:cafe:42:1::/112
-disable-network-policy: true
 ```

--- a/content/k3s/latest/en/installation/network-options/_index.md
+++ b/content/k3s/latest/en/installation/network-options/_index.md
@@ -76,10 +76,10 @@ Dual-stack networking must be configured when the cluster is first created. It c
 
 Dual-stack is supported on k3s v1.21 or above.
 
-To enable dual-stack in k3s, you must provide valid dual-stack `cluster-cidr` and `service-cidr`, and set `disable-network-policy` on all server nodes. Both servers and agents must provide valid dual-stack `node-ip` settings. Node address auto-detection and network policy enforcement are not supported on dual-stack clusters when using the default flannel CNI. Besides, only vxlan backend is supported at the moment. This is an example of a valid configuration:
+To enable dual-stack in K3s, you must provide valid dual-stack `cluster-cidr` and `service-cidr` on all server nodes. Both servers and agents must provide valid dual-stack `node-ip` settings. Node address auto-detection is not supported on dual-stack clusters, because kubelet fetches only the first IP address that it finds. Additionally, only vxlan backend is supported currently. This is an example of a valid configuration:
 
 ```
-k3s server --node-ip 10.0.10.7,2a05:d012:c6f:4611:5c2:5602:eed2:898c --cluster-cidr 10.42.0.0/16,2001:cafe:42:0::/56 --service-cidr 10.43.0.0/16,2001:cafe:42:1::/112 --disable-network-policy
+k3s server --node-ip 10.0.10.7,2a05:d012:c6f:4611:5c2:5602:eed2:898c --cluster-cidr 10.42.0.0/16,2001:cafe:42:0::/56 --service-cidr 10.43.0.0/16,2001:cafe:42:1::/112
 ```
 
 Note that you can choose whatever `cluster-cidr` and `service-cidr` value, however the `node-ip` values must correspond to the ip addresses of your main interface. Remember to allow ipv6 traffic if you are deploying in a public cloud.
@@ -91,7 +91,7 @@ If you are using a custom cni plugin, i.e. a cni plugin different from flannel, 
 IPv6 only setup is supported on k3s v1.22 or above. As in dual-stack operation, IPv6 node addresses cannot be auto-detected; all nodes must have an explicitly configured IPv6 `node-ip`. This is an example of a valid configuration:
 
 ```
-k3s server --node-ip 2a05:d012:c6f:4611:5c2:5602:eed2:898c --cluster-cidr 2001:cafe:42:0::/56 --service-cidr 2001:cafe:42:1::/112 --disable-network-policy
+k3s server --node-ip 2a05:d012:c6f:4611:5c2:5602:eed2:898c --cluster-cidr 2001:cafe:42:0::/56 --service-cidr 2001:cafe:42:1::/112
 ```
 
 Note that you can specify only one IPv6 `cluster-cidr` value.


### PR DESCRIPTION
Starting from k3s-io/k3s#5387, dual-stack and IPv6-only don't require
disabling network policy controller anymore - they can be used
regardless of IP family.

Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>

### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
