### PR TITLE
Remove invalid link to kubernetes cloud providers

### DIFF
--- a/content/rke/latest/en/config-options/cloud-providers/_index.md
+++ b/content/rke/latest/en/config-options/cloud-providers/_index.md
@@ -3,7 +3,7 @@ title: Cloud Providers
 weight: 250
 ---
 
-RKE supports the ability to set your specific [cloud provider](https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/) for your Kubernetes cluster. There are specific cloud configurations for these cloud providers.
+RKE supports the ability to set your specific cloud provider for your Kubernetes cluster. There are specific cloud configurations for these cloud providers.
 To enable a cloud provider its name as well as any required configuration options must be provided under the `cloud_provider` directive in the cluster YML.
 
 * [AWS]({{<baseurl>}}/rke/latest/en/config-options/cloud-providers/aws)


### PR DESCRIPTION
Kubernetes removed the official documentation for cloud providers in https://github.com/kubernetes/website/pull/23517. Users are now instructed to view the individual documentation provided by each cloud provider.

### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
