### PR TITLE
Remove invalid link to cloud providers in v2.5

### DIFF
--- a/content/rancher/v2.5/en/cluster-provisioning/rke-clusters/cloud-providers/_index.md
+++ b/content/rancher/v2.5/en/cluster-provisioning/rke-clusters/cloud-providers/_index.md
@@ -6,7 +6,7 @@ aliases:
   - /rancher/v2.5/en/cluster-provisioning/rke-clusters/options/cloud-providers
   - /rancher/v2.x/en/cluster-provisioning/rke-clusters/cloud-providers/
 ---
-A _cloud provider_ is a module in Kubernetes that provides an interface for managing nodes, load balancers, and networking routes. For more information, refer to the [official Kubernetes documentation on cloud providers.](https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/)
+A _cloud provider_ is a module in Kubernetes that provides an interface for managing nodes, load balancers, and networking routes.
 
 When a cloud provider is set up in Rancher, the Rancher server can automatically provision new nodes, load balancers or persistent storage devices when launching Kubernetes definitions, if the cloud provider you're using supports such automation.
 
@@ -39,7 +39,7 @@ For details on enabling the vSphere cloud provider, refer to [this page.](./vsph
 
 ### Setting up a Custom Cloud Provider
 
-The `Custom` cloud provider is available if you want to configure any [Kubernetes cloud provider](https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/).
+The `Custom` cloud provider is available if you want to configure any Kubernetes cloud provider.
 
 For the custom cloud provider option, you can refer to the [RKE docs]({{<baseurl>}}/rke/latest/en/config-options/cloud-providers/) on how to edit the yaml file for your specific cloud provider. There are specific cloud providers that have more detailed configuration :
 

--- a/content/rancher/v2.5/en/cluster-provisioning/rke-clusters/cloud-providers/_index.md
+++ b/content/rancher/v2.5/en/cluster-provisioning/rke-clusters/cloud-providers/_index.md
@@ -41,7 +41,7 @@ For details on enabling the vSphere cloud provider, refer to [this page.](./vsph
 
 The `Custom` cloud provider is available if you want to configure any Kubernetes cloud provider.
 
-For the custom cloud provider option, you can refer to the [RKE docs]({{<baseurl>}}/rke/latest/en/config-options/cloud-providers/) on how to edit the yaml file for your specific cloud provider. There are specific cloud providers that have more detailed configuration :
+For the custom cloud provider option, you can refer to the [RKE docs]({{<baseurl>}}/rke/latest/en/config-options/cloud-providers/) on how to edit the yaml file for your specific cloud provider. There are specific cloud providers that have more detailed configuration:
 
 * [vSphere]({{<baseurl>}}/rke/latest/en/config-options/cloud-providers/vsphere/)
 * [OpenStack]({{<baseurl>}}/rke/latest/en/config-options/cloud-providers/openstack/)

--- a/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/cloud-providers/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/rke-clusters/cloud-providers/_index.md
@@ -2,7 +2,7 @@
 title: Setting up Cloud Providers
 weight: 2300
 ---
-A _cloud provider_ is a module in Kubernetes that provides an interface for managing nodes, load balancers, and networking routes. For more information, refer to the [official Kubernetes documentation on cloud providers.](https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/)
+A _cloud provider_ is a module in Kubernetes that provides an interface for managing nodes, load balancers, and networking routes.
 
 When a cloud provider is set up in Rancher, the Rancher server can automatically provision new nodes, load balancers or persistent storage devices when launching Kubernetes definitions, if the cloud provider you're using supports such automation.
 
@@ -35,9 +35,9 @@ For details on enabling the vSphere cloud provider, refer to [this page.](./vsph
 
 ### Setting up a Custom Cloud Provider
 
-The `Custom` cloud provider is available if you want to configure any [Kubernetes cloud provider](https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/).
+The `Custom` cloud provider is available if you want to configure any Kubernetes cloud provider.
 
-For the custom cloud provider option, you can refer to the [RKE docs]({{<baseurl>}}/rke/latest/en/config-options/cloud-providers/) on how to edit the yaml file for your specific cloud provider. There are specific cloud providers that have more detailed configuration :
+For the custom cloud provider option, you can refer to the [RKE docs]({{<baseurl>}}/rke/latest/en/config-options/cloud-providers/) on how to edit the yaml file for your specific cloud provider. There are specific cloud providers that have more detailed configuration:
 
 * [vSphere]({{<baseurl>}}/rke/latest/en/config-options/cloud-providers/vsphere/)
 * [OpenStack]({{<baseurl>}}/rke/latest/en/config-options/cloud-providers/openstack/)


### PR DESCRIPTION
Kubernetes removed the official documentation for cloud providers in https://github.com/kubernetes/website/pull/23517. Users are now instructed to view the individual documentation provided by each cloud provider.

### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
