### PR TITLE
Always link to the latest Longhorn docs version

### DIFF
--- a/content/rancher/v2.6/en/cluster-admin/volumes-and-storage/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/volumes-and-storage/_index.md
@@ -44,7 +44,7 @@ For details and prerequisites, refer to [this page.](./provisioning-new-storage)
 
 Longhorn is free, open source software. Originally developed by Rancher Labs, it is now being developed as a sandbox project of the Cloud Native Computing Foundation. It can be installed on any Kubernetes cluster with Helm, with kubectl, or with the Rancher UI.
 
-If you have a pool of block storage, Longhorn can help you provide persistent storage to your Kubernetes cluster without relying on cloud providers. For more information about Longhorn features, refer to the [documentation.](https://longhorn.io/docs/1.0.2/what-is-longhorn/)
+If you have a pool of block storage, Longhorn can help you provide persistent storage to your Kubernetes cluster without relying on cloud providers. For more information about Longhorn features, refer to the [documentation.](https://longhorn.io/docs/latest/what-is-longhorn/)
 
 Rancher v2.5 simplified the process of installing Longhorn on a Rancher-managed cluster. For more information, see [this page.]({{<baseurl>}}/rancher/v2.6/en/longhorn)
 

--- a/content/rancher/v2.6/en/longhorn/_index.md
+++ b/content/rancher/v2.6/en/longhorn/_index.md
@@ -6,7 +6,7 @@ weight: 19
 
 [Longhorn](https://longhorn.io/) is a lightweight, reliable and easy-to-use distributed block storage system for Kubernetes.
 
-Longhorn is free, open source software. Originally developed by Rancher Labs, it is now being developed as a sandbox project of the Cloud Native Computing Foundation. It can be installed on any Kubernetes cluster with Helm, with kubectl, or with the Rancher UI. You can learn more about its architecture [here.](https://longhorn.io/docs/1.0.2/concepts/)
+Longhorn is free, open source software. Originally developed by Rancher Labs, it is now being developed as a sandbox project of the Cloud Native Computing Foundation. It can be installed on any Kubernetes cluster with Helm, with kubectl, or with the Rancher UI. You can learn more about its architecture [here.](https://longhorn.io/docs/latest/concepts/)
 
 With Longhorn, you can:
 

--- a/content/rancher/v2.6/en/longhorn/_index.md
+++ b/content/rancher/v2.6/en/longhorn/_index.md
@@ -24,12 +24,12 @@ With Longhorn, you can:
 
 ### Installing Longhorn with Rancher
 
-1. Fulfill all [Installation Requirements.](https://longhorn.io/docs/1.1.0/deploy/install/#installation-requirements)
+1. Fulfill all [Installation Requirements.](https://longhorn.io/docs/latest/deploy/install/#installation-requirements)
 1. Go to the cluster where you want to install Longhorn.
 1. Click **Apps & Marketplace**.
 1. Click **Charts**.
 1. Click **Longhorn**.
-1. Optional: To customize the initial settings, click **Longhorn Default Settings** and edit the configuration. For help customizing the settings, refer to the [Longhorn documentation.](https://longhorn.io/docs/1.0.2/references/settings/)
+1. Optional: To customize the initial settings, click **Longhorn Default Settings** and edit the configuration. For help customizing the settings, refer to the [Longhorn documentation.](https://longhorn.io/docs/latest/references/settings/)
 1. Click **Install**.
 
 **Result:** Longhorn is deployed in the Kubernetes cluster.
@@ -64,7 +64,7 @@ Longhorn creates a dedicated storage controller for each volume and synchronousl
 
 The storage controller and replicas are themselves orchestrated using Kubernetes.
 
-You can learn more about its architecture [here.](https://longhorn.io/docs/1.0.2/concepts/)
+You can learn more about its architecture [here.](https://longhorn.io/docs/latest/concepts/)
 
 <figcaption>Longhorn Architecture</figcaption>
 ![Longhorn Architecture]({{<baseurl>}}/img/rancher/longhorn-architecture.svg)


### PR DESCRIPTION
This reduces maintenance overhead and prevents us linking to outdated docs because we forgot to change the link to point to a newer version.

Fixes https://github.com/rancher/docs/issues/4015