### PR TITLE
Fix link in Logging -> Flows to link to the correct upstream docs page

### DIFF
--- a/content/rancher/v2.6/en/logging/custom-resource-config/flows/_index.md
+++ b/content/rancher/v2.6/en/logging/custom-resource-config/flows/_index.md
@@ -3,7 +3,7 @@ title: Flows and ClusterFlows
 weight: 1
 ---
 
-For the full details on configuring `Flows` and `ClusterFlows`, see the [Banzai Cloud Logging operator documentation.](https://banzaicloud.com/docs/one-eye/logging-operator/configuration/output/)
+For the full details on configuring `Flows` and `ClusterFlows`, see the [Banzai Cloud Logging operator documentation.](https://banzaicloud.com/docs/one-eye/logging-operator/configuration/flow/)
 
 - [Configuration](#configuration)
 - [YAML Example](#yaml-example)


### PR DESCRIPTION
The link was pointing to the upstream outputs page, instead of the flows page.
