### PR TITLE
Update content/rancher/v2.6/en/logging/_index.md

### DIFF
--- a/content/rancher/v2.6/en/logging/_index.md
+++ b/content/rancher/v2.6/en/logging/_index.md
@@ -104,7 +104,7 @@ By default, Rancher collects logs for control plane components and node componen
 
 ### Unable to uninstall Logging V1 in Rancher v2.6+
 
-The UI changes when upgrading from Rancher v2.5 to Rancher v2.6 may cause issues when attempting to uninstall Logging V1 and other Multi-Cluster apps. Fortunately, as of Rancher v2.6.4., the legacy UI is still available at `https://<your-url>/g`. Use the instructions for [deleting a Multi-Cluster Application in Rancher v2.5](https://rancher.com/docs/rancher/v2.5/en/deploy-across-clusters/multi-cluster-apps/#deleting-a-multi-cluster-application) in the legacy UI to uninstall Logging V1. For manual uninstallation, follow the instructions [here](#the-cattle-logging-namespace-being-recreated).
+Logging V1 cannot be removed from a cluster using the Rancher v2.6 UI. Use the Legacy UI at `"https://<your-rancher-url>/g"` with the instructions for [deleting a Multi-Cluster Application in Rancher v2.5](https://rancher.com/docs/rancher/v2.5/en/deploy-across-clusters/multi-cluster-apps/#deleting-a-multi-cluster-application) to uninstall the Logging V1 application. For manual removal, follow [The `cattle-logging` Namespace Being Recreated](#the-cattle-logging-namespace-being-recreated) troubleshooting guide.
 
 ### The `cattle-logging` Namespace Being Recreated
 

--- a/content/rancher/v2.6/en/logging/_index.md
+++ b/content/rancher/v2.6/en/logging/_index.md
@@ -102,6 +102,10 @@ By default, Rancher collects logs for control plane components and node componen
 
 # Troubleshooting
 
+### Unable to uninstall Logging V1 in Rancher v2.6+
+
+The UI changes when upgrading from Rancher v2.5 to Rancher v2.6 may cause issues when attempting to uninstall Logging V1 and other Multi-Cluster apps. Fortunately, as of Rancher v2.6.4., the legacy UI is still available at `https://<your-url>/g`. Use the instructions for [deleting a Multi-Cluster Application in Rancher v2.5](https://rancher.com/docs/rancher/v2.5/en/deploy-across-clusters/multi-cluster-apps/#deleting-a-multi-cluster-application) in the legacy UI to uninstall Logging V1. For manual uninstallation, follow the instructions [here](#the-cattle-logging-namespace-being-recreated).
+
 ### The `cattle-logging` Namespace Being Recreated
 
 If your cluster previously deployed logging from the global view in the legacy Rancher UI, you may encounter an issue where its `cattle-logging` namespace is continually being recreated.

--- a/content/rancher/v2.6/en/logging/_index.md
+++ b/content/rancher/v2.6/en/logging/_index.md
@@ -102,7 +102,7 @@ By default, Rancher collects logs for control plane components and node componen
 
 # Troubleshooting
 
-### Unable to uninstall Logging V1 in Rancher v2.6+
+### Unable to Uninstall Logging V1 in Rancher v2.6+
 
 Logging V1 cannot be removed from a cluster using the Rancher v2.6 UI. Use the Legacy UI at `"https://<your-rancher-url>/g"` with the instructions for [deleting a Multi-Cluster Application in Rancher v2.5](https://rancher.com/docs/rancher/v2.5/en/deploy-across-clusters/multi-cluster-apps/#deleting-a-multi-cluster-application) to uninstall the Logging V1 application. For manual removal, follow [The `cattle-logging` Namespace Being Recreated](#the-cattle-logging-namespace-being-recreated) troubleshooting guide.
 


### PR DESCRIPTION
- Included troubleshooting steps covering Logging V1 uninstallation after upgrading to Rancher v2.6.x