### PR TITLE
Corrected apiVersion term in RKE docs

### DIFF
--- a/content/rke/latest/en/config-options/secrets-encryption/_index.md
+++ b/content/rke/latest/en/config-options/secrets-encryption/_index.md
@@ -139,7 +139,7 @@ kube-api:
     secrets_encryption_config:
       enabled: true
       custom_config:
-        api_version: apiserver.config.k8s.io/v1
+        apiVersion: apiserver.config.k8s.io/v1
         kind: EncryptionConfiguration
         resources:
         - Providers:


### PR DESCRIPTION
Per Slack request: 

Hi, can anyone confirm if this is a mistake in the documentation? - [https://rancher.com/docs/rke/latest/en/config-options/secrets-encryption/#example-using-custom-encryption-con[…]ith-user-provided-32-byte-random-key](https://rancher.com/docs/rke/latest/en/config-options/secrets-encryption/#example-using-custom-encryption-configuration-with-user-provided-32-byte-random-key) see line 5 of the code snippet it says “api_version” the rest of the documentation and the input i’d expect is “apiVersion”.