### PR TITLE
Corrected to lowercase `resources` in example

### DIFF
--- a/content/rke/latest/en/config-options/secrets-encryption/_index.md
+++ b/content/rke/latest/en/config-options/secrets-encryption/_index.md
@@ -147,7 +147,7 @@ kube-api:
                 Keys:
                     - Name: key1
                     Secret: <BASE 64 ENCODED SECRET>
-              Resources:
+              resources:
                 - secrets
             - identity: {}
 ```


### PR DESCRIPTION
Closes #4041

- Resolved the `apiVersion` formatting issue in [#4039](https://github.com/rancher/docs/pull/4039)
- This PR corrects `Resources` to lowercase; testing confirmed that you must use lowercase `resources` in the code block referenced as it will not work with the uppercase version
- Reference: [custom encryption config example with 32-byte random key](https://rancher.com/docs/rke/latest/en/config-options/secrets-encryption/#example-using-custom-encryption-configuration-with-user-provided-32-byte-random-key)