### PR TITLE
[Rancher] Update ingress-nginx in the hosted kubernetes install tutorials

### DIFF
--- a/content/rancher/v2.6/en/installation/resources/k8s-tutorials/aks/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/k8s-tutorials/aks/_index.md
@@ -81,7 +81,8 @@ helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --namespace ingress-nginx \
   --set controller.service.type=LoadBalancer \
-  --version 3.12.0 \
+  --set controller.watchIngressWithoutClass=true \
+  --version 4.1.0 \
   --create-namespace
 ```
 

--- a/content/rancher/v2.6/en/installation/resources/k8s-tutorials/amazon-eks/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/k8s-tutorials/amazon-eks/_index.md
@@ -126,7 +126,8 @@ helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --namespace ingress-nginx \
   --set controller.service.type=LoadBalancer \
-  --version 3.12.0 \
+  --set controller.watchIngressWithoutClass=true \
+  --version 4.1.0 \
   --create-namespace
 ```
 

--- a/content/rancher/v2.6/en/installation/resources/k8s-tutorials/gke/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/k8s-tutorials/gke/_index.md
@@ -146,7 +146,8 @@ helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --namespace ingress-nginx \
   --set controller.service.type=LoadBalancer \
-  --version 3.12.0 \
+  --set controller.watchIngressWithoutClass=true \
+  --version 4.1.0 \
   --create-namespace
 ```
 


### PR DESCRIPTION
The newer ingress-nginx fixes known security vulnerabilities and is fully compatible with Rancher. Since the Rancher Helm chart does not set an ingressClass on the Rancher ingress, `controller.watchIngressWithoutClass` must be set to `true` (default value in newer ingress-nginx versions is `false`).

Fixes https://github.com/rancher/docs/issues/4064. See also https://github.com/rancher/rancher/issues/37193.

SURE-4878