### PR TITLE
Adding NV limitations per feedback

### DIFF
--- a/content/rancher/v2.6/en/neuvector-integration/_index.md
+++ b/content/rancher/v2.6/en/neuvector-integration/_index.md
@@ -95,10 +95,22 @@ Below are the minimum recommended computing resources for the NeuVector chart in
 
 \* Minimum 1GB of memory total required for Controller, Manager, and Scanner containers combined.
 
-### Limitations
+
+### Support Limitations
+
+* Only admins and cluster owners are currently supported.
+
+* Fleet multi-cluster deployment is not supported.
+
+* NeuVector is not supported on a Windows cluster.
+
+* Airgap is not supported.
+
+### Other Limitations
 
 * Currently, NeuVector feature chart installation fails when a NeuVector partner chart already exists. To work around this issue, uninstall the NeuVector partner chart and reinstall the NeuVector feature chart.
 
 * Users cannot access the NeuVector UI from Rancher for a custom RKE1 cluster. To work around this, restart the controllers; note that while the controller pods are restarting, it will take additional time for the controller pods to become active.
 
 * Container runtime is not auto-detected for different cluster types when installing the NeuVector chart.
+


### PR DESCRIPTION
Based on feedback in Slack from @anupama2501:
```
Cluster members cannot see the neuvector icon or manage the neuvector app
Fleet multi cluster deployment is not supported.
Not supported on a Windows cluster
Airgap not supported
Hardened cluster neuvector installation not supported
SE Linux cluster not supported
```
- Per @cbron, will add the first 4 points only as most charts do not have these. 