### PR TITLE
Show example using installer

### DIFF
--- a/content/k3s/latest/en/installation/ha-embedded/_index.md
+++ b/content/k3s/latest/en/installation/ha-embedded/_index.md
@@ -15,7 +15,6 @@ To run K3s in this mode, you must have an odd number of server nodes. We recomme
 To get started, first launch a server node with the `cluster-init` flag to enable clustering and a token that will be used as a shared secret to join additional servers to the cluster.
 ```
 K3S_TOKEN=SECRET
-export INSTALL_K3S_VERSION=v1.23.6+k3s1
 curl -sfL https://get.k3s.io | sh -s - server --cluster-init
 ```
 

--- a/content/k3s/latest/en/installation/ha-embedded/_index.md
+++ b/content/k3s/latest/en/installation/ha-embedded/_index.md
@@ -14,8 +14,7 @@ To run K3s in this mode, you must have an odd number of server nodes. We recomme
 
 To get started, first launch a server node with the `cluster-init` flag to enable clustering and a token that will be used as a shared secret to join additional servers to the cluster.
 ```
-K3S_TOKEN=SECRET
-curl -sfL https://get.k3s.io | sh -s - server --cluster-init
+curl -sfL https://get.k3s.io | K3S_TOKEN=SECRET sh -s - server --cluster-init
 ```
 
 After launching the first server, join the second and third servers to the cluster using the shared secret:

--- a/content/k3s/latest/en/installation/ha-embedded/_index.md
+++ b/content/k3s/latest/en/installation/ha-embedded/_index.md
@@ -14,7 +14,9 @@ To run K3s in this mode, you must have an odd number of server nodes. We recomme
 
 To get started, first launch a server node with the `cluster-init` flag to enable clustering and a token that will be used as a shared secret to join additional servers to the cluster.
 ```
-K3S_TOKEN=SECRET k3s server --cluster-init
+K3S_TOKEN=SECRET
+export INSTALL_K3S_VERSION=v1.23.6+k3s1
+curl -sfL https://get.k3s.io | sh -s - server --cluster-init
 ```
 
 After launching the first server, join the second and third servers to the cluster using the shared secret:


### PR DESCRIPTION
The current doc assumes that k3s is already installed.
As most users use the installer to initiate a cluster it is confusing not having an example with the installer.

### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
