### PR TITLE
Correct typo in cluster agent name

### DIFF
--- a/content/rancher/v2.6/en/installation/resources/update-ca-cert/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/update-ca-cert/_index.md
@@ -133,7 +133,7 @@ Using a Kubeconfig for each downstream cluster update the environment variable f
 
 ```
 $ kubectl edit -n cattle-system ds/cattle-node-agent
-$ kubectl edit -n cattle-system deployment/cluster-agent
+$ kubectl edit -n cattle-system deployment/cattle-cluster-agent
 ```
 
 ### Method 3: Recreate Rancher agents


### PR DESCRIPTION
### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
