### PR TITLE
Add missing permissions for describe instance types for eks cluster provisioning

### DIFF
--- a/content/rancher/v2.5/en/cluster-provisioning/hosted-kubernetes-clusters/eks/permissions/_index.md
+++ b/content/rancher/v2.5/en/cluster-provisioning/hosted-kubernetes-clusters/eks/permissions/_index.md
@@ -25,6 +25,7 @@ Resource targeting uses `*` as the ARN of many of the resources created cannot b
                 "ec2:RevokeSecurityGroupIngress",
                 "ec2:RevokeSecurityGroupEgress",
                 "ec2:DescribeRegions",
+                "ec2:DescribeInstanceTypes",
                 "ec2:DescribeVpcs",
                 "ec2:DescribeTags",
                 "ec2:DescribeSubnets",

--- a/content/rancher/v2.6/en/cluster-provisioning/hosted-kubernetes-clusters/eks/permissions/_index.md
+++ b/content/rancher/v2.6/en/cluster-provisioning/hosted-kubernetes-clusters/eks/permissions/_index.md
@@ -24,6 +24,7 @@ Resource targeting uses `*` as the ARN of many of the resources created cannot b
                 "ec2:RunInstances",
                 "ec2:RevokeSecurityGroupIngress",
                 "ec2:RevokeSecurityGroupEgress",
+                "ec2:DescribeInstanceTypes",
                 "ec2:DescribeRegions",
                 "ec2:DescribeVpcs",
                 "ec2:DescribeTags",


### PR DESCRIPTION
### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.



Without this getting unauthorized errors in the UI.

![image](https://user-images.githubusercontent.com/4452738/167949998-1bd15c63-f836-4876-985b-d2ae34f49586.png)

`Action=DescribeInstanceTypes&Version=2016-11-15`

