### PR TITLE
Fix manual quickstart incorrect value in k3s.yaml

### DIFF
--- a/content/rancher/v2.6/en/quick-start-guide/deployment/quickstart-manual-setup/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/quickstart-manual-setup/_index.md
@@ -55,7 +55,7 @@ scp root@<IP_OF_LINUX_MACHINE>:/etc/rancher/k3s/k3s.yaml $env:USERPROFILE\.kube\
 
 ## Edit the Rancher server URL in the kubeconfig
 
-In the kubeconfig file, the server directive is defined as `localhost`. You will need to change the server directive from `localhost` to `<IP_OF_LINUX_NODE>:6443`. The Kubernetes API server will be reached at port 6443, while the Rancher server will be reached at ports 80 and 443. This edit is needed so that when you run Helm or kubectl commands from your local workstation, you will be able to communicate with the Kubernetes cluster that Rancher will be installed on.
+In the kubeconfig file, you will need to change the value of the `server` field to `<IP_OF_LINUX_NODE>:6443`. The Kubernetes API server will be reached at port 6443, while the Rancher server will be reached at ports 80 and 443. This edit is needed so that when you run Helm or kubectl commands from your local workstation, you will be able to communicate with the Kubernetes cluster that Rancher will be installed on.
 
 {{% tabs %}}
 {{% tab "Mac and Linux" %}}


### PR DESCRIPTION
Closes https://github.com/rancher/docs/issues/4110

Current docs indicate to look for `localhost`, but `127.0.0.1` is actually the value found in the file. Rather than asking users to look for the value this changes it to look for the field itself, i.e. `server`.