### PR TITLE
Use `server` as field that needs to be changed

### DIFF
--- a/content/k3s/latest/en/cluster-access/_index.md
+++ b/content/k3s/latest/en/cluster-access/_index.md
@@ -22,4 +22,4 @@ helm --kubeconfig /etc/rancher/k3s/k3s.yaml ls --all-namespaces
 
 ### Accessing the Cluster from Outside with kubectl
 
-Copy `/etc/rancher/k3s/k3s.yaml` on your machine located outside the cluster as `~/.kube/config`. Then replace "localhost" with the IP or name of your K3s server. `kubectl` can now manage your K3s cluster.
+Copy `/etc/rancher/k3s/k3s.yaml` on your machine located outside the cluster as `~/.kube/config`. Then replace the value of the `server` field with the IP or name of your K3s server. `kubectl` can now manage your K3s cluster.


### PR DESCRIPTION
Related to https://github.com/rancher/docs/issues/4110

Current docs indicate to look for `localhost`, but `127.0.0.1` is actually the value found in the file. Rather than asking users to look for the value this changes it to look for the field itself, i.e. `server`.
