### PR TITLE
Make explicit config is a file

### DIFF
--- a/content/rancher/v2.6/en/faq/kubectl/_index.md
+++ b/content/rancher/v2.6/en/faq/kubectl/_index.md
@@ -13,7 +13,7 @@ See [kubectl Installation](https://kubernetes.io/docs/tasks/tools/install-kubect
 
 When you create a Kubernetes cluster with RKE, RKE creates a `kube_config_cluster.yml` in the local directory that contains credentials to connect to your new cluster with tools like `kubectl` or `helm`.
 
-You can copy this file to `$HOME/.kube/config` or if you are working with multiple Kubernetes clusters, set the `KUBECONFIG` environmental variable to the path of `kube_config_cluster.yml`.
+You can copy this file as `$HOME/.kube/config` or if you are working with multiple Kubernetes clusters, set the `KUBECONFIG` environmental variable to the path of `kube_config_cluster.yml`.
 
 ```
 export KUBECONFIG=$(pwd)/kube_config_cluster.yml


### PR DESCRIPTION
I thought that config was a directory to move the file to. Some I hope this change will remove confusion.

### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
