### PR TITLE
Remove RKE2 Ingress Section

### DIFF
--- a/content/rancher/v2.6/en/installation/requirements/_index.md
+++ b/content/rancher/v2.6/en/installation/requirements/_index.md
@@ -153,10 +153,6 @@ For RKE and K3s installations, you don't have to install the Ingress manually be
 
 For hosted Kubernetes clusters (EKS, GKE, AKS) and RKE2 Kubernetes installations, you will need to set up the ingress.
 
-### Ingress for RKE2
-
-Currently, RKE2 deploys nginx-ingress as a deployment by default, so you will need to deploy it as a DaemonSet by following [these steps.]({{<baseurl>}}/rancher/v2.6/en/installation/resources/k8s-tutorials/ha-rke2/#5-configure-nginx-to-be-a-daemonset)
-
 ### Ingress for EKS
 For an example of how to deploy an nginx-ingress-controller with a LoadBalancer service, refer to [this section.]({{<baseurl>}}/rancher/v2.6/en/installation/install-rancher-on-k8s/amazon-eks/#5-install-an-ingress)
 


### PR DESCRIPTION
Proposing removal of this section as this was changed some time ago and the NGiNX Ingress now deploys by default as a DaemonSet

### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
