### PR TITLE
[Rancher] Restructure ingress controller docs on Rancher installation page

### DIFF
--- a/content/rancher/v2.6/en/installation/install-rancher-on-k8s/_index.md
+++ b/content/rancher/v2.6/en/installation/install-rancher-on-k8s/_index.md
@@ -32,7 +32,7 @@ For help setting up a Kubernetes cluster, we provide these tutorials:
 
 ### Ingress Controller
 
-The Rancher UI and API is exposed through an Ingress. This means the Kubernetes cluster, that you install Rancher in, must contain an Ingress controller
+The Rancher UI and API are exposed through an Ingress. This means the Kubernetes cluster that you install Rancher in must contain an Ingress controller.
 
 For RKE, RKE2, and K3s installations, you don't have to install the Ingress controller manually because one is installed by default.
 

--- a/content/rancher/v2.6/en/installation/install-rancher-on-k8s/_index.md
+++ b/content/rancher/v2.6/en/installation/install-rancher-on-k8s/_index.md
@@ -38,7 +38,7 @@ For RKE, RKE2 and K3s installations, you don't have to install the Ingress contr
 
 For distributions that do not include an Ingress Controller by default, like a hosted Kubernetes cluster, such as EKS, GKE, or AKS, you have to deploy an Ingress controller first. Note, that the Rancher Helm chart does not set an ingressClassName on the ingress by default. Because of this, you have to configure the Ingress controller to also watch ingresses without an ingressClassName.
 
-Examples are included in the **Amazon EKS**, **AKS** and **GKE** tutorials above.
+Examples are included in the **Amazon EKS**, **AKS**, and **GKE** tutorials above.
 
 ### CLI Tools
 

--- a/content/rancher/v2.6/en/installation/install-rancher-on-k8s/_index.md
+++ b/content/rancher/v2.6/en/installation/install-rancher-on-k8s/_index.md
@@ -34,7 +34,7 @@ For help setting up a Kubernetes cluster, we provide these tutorials:
 
 The Rancher UI and API is exposed through an Ingress. This means the Kubernetes cluster, that you install Rancher in, must contain an Ingress controller
 
-For RKE, RKE2 and K3s installations, you don't have to install the Ingress controller manually because one is installed by default.
+For RKE, RKE2, and K3s installations, you don't have to install the Ingress controller manually because one is installed by default.
 
 For distributions that do not include an Ingress Controller by default, like a hosted Kubernetes cluster such as EKS, GKE, or AKS, you have to deploy an Ingress controller first. Note that the Rancher Helm chart does not set an `ingressClassName` on the ingress by default. Because of this, you have to configure the Ingress controller to also watch ingresses without an `ingressClassName`.
 

--- a/content/rancher/v2.6/en/installation/install-rancher-on-k8s/_index.md
+++ b/content/rancher/v2.6/en/installation/install-rancher-on-k8s/_index.md
@@ -36,7 +36,7 @@ The Rancher UI and API is exposed through an Ingress. This means the Kubernetes 
 
 For RKE, RKE2 and K3s installations, you don't have to install the Ingress controller manually because one is installed by default.
 
-For distributions that do not include an Ingress Controller by default, like a hosted Kubernetes cluster, such as EKS, GKE, or AKS, you have to deploy an Ingress controller first. Note, that the Rancher Helm chart does not set an ingressClassName on the ingress by default. Because of this, you have to configure the Ingress controller to also watch ingresses without an ingressClassName.
+For distributions that do not include an Ingress Controller by default, like a hosted Kubernetes cluster such as EKS, GKE, or AKS, you have to deploy an Ingress controller first. Note that the Rancher Helm chart does not set an `ingressClassName` on the ingress by default. Because of this, you have to configure the Ingress controller to also watch ingresses without an `ingressClassName`.
 
 Examples are included in the **Amazon EKS**, **AKS**, and **GKE** tutorials above.
 

--- a/content/rancher/v2.6/en/installation/install-rancher-on-k8s/_index.md
+++ b/content/rancher/v2.6/en/installation/install-rancher-on-k8s/_index.md
@@ -12,8 +12,8 @@ In this section, you'll learn how to deploy Rancher on a Kubernetes cluster usin
 # Prerequisites
 
 - [Kubernetes Cluster](#kubernetes-cluster)
+- [Ingress Controller](#ingress-controller)
 - [CLI Tools](#cli-tools)
-- [Ingress Controller (Only for Hosted Kubernetes)](#ingress-controller-for-hosted-kubernetes)
 
 ### Kubernetes Cluster
 
@@ -26,9 +26,19 @@ For help setting up a Kubernetes cluster, we provide these tutorials:
 - **RKE:** For the tutorial to install an RKE Kubernetes cluster, refer to [this page.]({{<baseurl>}}/rancher/v2.6/en/installation/resources/k8s-tutorials/ha-rke/) For help setting up the infrastructure for a high-availability RKE cluster, refer to [this page.]({{<baseurl>}}/rancher/v2.6/en/installation/resources/k8s-tutorials/infrastructure-tutorials/infra-for-ha)
 - **K3s:** For the tutorial to install a K3s Kubernetes cluster, refer to [this page.]({{<baseurl>}}/rancher/v2.6/en/installation/resources/k8s-tutorials/ha-with-external-db) For help setting up the infrastructure for a high-availability K3s cluster, refer to [this page.]({{<baseurl>}}/rancher/v2.6/en/installation/resources/k8s-tutorials/infrastructure-tutorials/infra-for-ha-with-external-db)
 - **RKE2:** For the tutorial to install an RKE2 Kubernetes cluster, refer to [this page.]({{<baseurl>}}/rancher/v2.6/en/installation/resources/k8s-tutorials/ha-rke2) For help setting up the infrastructure for a high-availability RKE2 cluster, refer to [this page.]({{<baseurl>}}/rancher/v2.6/en/installation/resources/k8s-tutorials/infrastructure-tutorials/infra-for-rke2-ha)
-- **Amazon EKS:** For details on how to install Rancher on Amazon EKS, including how to install an ingress so that the Rancher server can be accessed, refer to [this page.]({{<baseurl>}}/rancher/v2.6/en/installation/install-rancher-on-k8s/amazon-eks)
-- **AKS:** For details on how to install Rancher with Azure Kubernetes Service, including how to install an ingress so that the Rancher server can be accessed, refer to [this page.]({{<baseurl>}}/rancher/v2.6/en/installation/install-rancher-on-k8s/aks)
-- **GKE:** For details on how to install Rancher with Google Kubernetes Engine, including how to install an ingress so that the Rancher server can be accessed, refer to [this page.]({{<baseurl>}}/rancher/v2.6/en/installation/install-rancher-on-k8s/gke)
+- **Amazon EKS:** For details on how to install Rancher on Amazon EKS, including how to install an Ingress controller so that the Rancher server can be accessed, refer to [this page.]({{<baseurl>}}/rancher/v2.6/en/installation/resources/k8s-tutorials/amazon-eks)
+- **AKS:** For details on how to install Rancher with Azure Kubernetes Service, including how to install an Ingress controller so that the Rancher server can be accessed, refer to [this page.]({{<baseurl>}}/rancher/v2.6/en/installation/resources/k8s-tutorials/aks)
+- **GKE:** For details on how to install Rancher with Google Kubernetes Engine, including how to install an Ingress controller so that the Rancher server can be accessed, refer to [this page.]({{<baseurl>}}/rancher/v2.6/en/installation/resources/k8s-tutorials/gke)
+
+### Ingress Controller
+
+The Rancher UI and API is exposed through an Ingress. This means the Kubernetes cluster, that you install Rancher in, must contain an Ingress controller
+
+For RKE, RKE2 and K3s installations, you don't have to install the Ingress controller manually because one is installed by default.
+
+For distributions that do not include an Ingress Controller by default, like a hosted Kubernetes cluster, such as EKS, GKE, or AKS, you have to deploy an Ingress controller first. Note, that the Rancher Helm chart does not set an ingressClassName on the ingress by default. Because of this, you have to configure the Ingress controller to also watch ingresses without an ingressClassName.
+
+Examples are included in the **Amazon EKS**, **AKS** and **GKE** tutorials above.
 
 ### CLI Tools
 
@@ -36,12 +46,6 @@ The following CLI tools are required for setting up the Kubernetes cluster. Plea
 
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl) - Kubernetes command-line tool.
 - [helm](https://docs.helm.sh/using_helm/#installing-helm) - Package management for Kubernetes. Refer to the [Helm version requirements]({{<baseurl>}}/rancher/v2.6/en/installation/resources/helm-version) to choose a version of Helm to install Rancher. Refer to the [instructions provided by the Helm project](https://helm.sh/docs/intro/install/) for your specific platform.
-
-### Ingress Controller (For Hosted Kubernetes)
-
-To deploy Rancher on a hosted Kubernetes cluster such as EKS, GKE, or AKS, you should deploy a compatible Ingress controller first to configure [SSL termination on Rancher.](#3-choose-your-ssl-configuration)
-
-For an example of how to deploy an ingress on EKS, refer to [this section.]({{<baseurl>}}/rancher/v2.6/en/installation/install-rancher-on-k8s/amazon-eks/#5-install-an-ingress)
 
 # Install the Rancher Helm Chart
 

--- a/content/rancher/v2.6/en/installation/requirements/_index.md
+++ b/content/rancher/v2.6/en/installation/requirements/_index.md
@@ -22,8 +22,6 @@ Make sure the node(s) for the Rancher server fulfill the following requirements:
   - [RKE2 Kubernetes](#rke2-kubernetes)
   - [Docker](#docker)
 - [Ingress](#ingress)
-  - [Ingress for RKE2](#ingress-for-rke2)
-  - [Ingress for EKS](#ingress-for-eks)
 - [Disks](#disks)
 - [Networking Requirements](#networking-requirements)
   - [Node IP Addresses](#node-ip-addresses)
@@ -153,8 +151,9 @@ For RKE and K3s installations, you don't have to install the Ingress manually be
 
 For hosted Kubernetes clusters (EKS, GKE, AKS) and RKE2 Kubernetes installations, you will need to set up the ingress.
 
-### Ingress for EKS
-For an example of how to deploy an nginx-ingress-controller with a LoadBalancer service, refer to [this section.]({{<baseurl>}}/rancher/v2.6/en/installation/install-rancher-on-k8s/amazon-eks/#5-install-an-ingress)
+- **Amazon EKS:** For details on how to install Rancher on Amazon EKS, including how to install an ingress so that the Rancher server can be accessed, refer to [this page.]({{<baseurl>}}/rancher/v2.6/en/installation/resources/k8s-tutorials/amazon-eks)
+- **AKS:** For details on how to install Rancher with Azure Kubernetes Service, including how to install an ingress so that the Rancher server can be accessed, refer to [this page.]({{<baseurl>}}/rancher/v2.6/en/installation/resources/k8s-tutorials/aks)
+- **GKE:** For details on how to install Rancher with Google Kubernetes Engine, including how to install an ingress so that the Rancher server can be accessed, refer to [this page.]({{<baseurl>}}/rancher/v2.6/en/installation/resources/k8s-tutorials/gke)
 
 # Disks
 

--- a/content/rancher/v2.6/en/installation/resources/k8s-tutorials/aks/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/k8s-tutorials/aks/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Installing Rancher on Azure Kubernetes Service
 shortTitle: AKS
-weight: 4
+weight: 3
 ---
 
 This page covers how to install Rancher on Microsoft's Azure Kubernetes Service (AKS).

--- a/content/rancher/v2.6/en/installation/resources/k8s-tutorials/amazon-eks/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/k8s-tutorials/amazon-eks/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Installing Rancher on Amazon EKS
 shortTitle: Amazon EKS
-weight: 4
+weight: 3
 ---
 
 This page covers two ways to install Rancher on EKS.

--- a/content/rancher/v2.6/en/installation/resources/k8s-tutorials/gke/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/k8s-tutorials/gke/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Installing Rancher on a Google Kubernetes Engine Cluster
 shortTitle: GKE
-weight: 5
+weight: 3
 ---
 
 In this section, you'll learn how to install Rancher using Google Kubernetes Engine.


### PR DESCRIPTION
* Make it clearer in which cases you need to install an additional ingress controller and in which you don't
* Move Ingress Controller docs closer to the cluster provisioning docs
* Move hosted kubernetes cluster docs to k8s-tutorial so that they are next to the RKE, RKE2 and K3s docs in the menu
* Clearly distinguish between ingress and ingress controller

Fixes https://github.com/rancher/docs/issues/4109
