### PR TITLE
cert-manager url change

### DIFF
--- a/content/rancher/v2.6/en/quick-start-guide/deployment/quickstart-manual-setup/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/quickstart-manual-setup/_index.md
@@ -92,7 +92,7 @@ helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
 
 kubectl create namespace cattle-system
 
-kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.7.1/cert-manager.crds.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.7.2/cert-manager.crds.yaml
 
 helm repo add jetstack https://charts.jetstack.io
 


### PR DESCRIPTION
kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.7.1/cert-manager.crds.yam
error: unable to read URL "https://github.com/jetstack/cert-manager/releases/download/v1.7.1/cert-manager.crds.yam", server reported 404 Not Found, status code=404

### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
