### PR TITLE
Updated documentation around K3S_RESOLV_CONF environment variable 

### DIFF
--- a/content/k3s/latest/en/installation/install-options/agent-config/_index.md
+++ b/content/k3s/latest/en/installation/install-options/agent-config/_index.md
@@ -61,10 +61,11 @@ In this section, you'll learn how to configure the K3s agent.
 |------|----------------------|-------------|
 |   `--node-ip value, -i` value | N/A   |   IP address to advertise for node  |
 |   `--node-external-ip` value |  N/A   | External IP address to advertise for node      |
-|   `--resolv-conf` value |   `K3S_RESOLV_CONF`    |  Kubelet resolv.conf file. Note: If you wish to set kubelet parameter `--resolv-conf` to `""`, use `--kubelet-arg=resolv-conf=` instead       | 
+|   `--resolv-conf` value |   `K3S_RESOLV_CONF`    |  Kubelet resolv.conf file       | 
 |   `--flannel-iface` value |    N/A   | Override default flannel interface      |
 |   `--flannel-conf` value |    N/A     |  Override default flannel config file |
 
+> Note: if you wish to directly set the kubelet `--resolv-conf` value, use `--kubelet-arg=resolv-conf=value` instead. The k3s flag is only passed through to the kubelet if set to the path of a valid resolv.conf file.
 ### Customized Flags
 | Flag |  Description |
 |------|--------------|

--- a/content/k3s/latest/en/installation/install-options/agent-config/_index.md
+++ b/content/k3s/latest/en/installation/install-options/agent-config/_index.md
@@ -61,7 +61,7 @@ In this section, you'll learn how to configure the K3s agent.
 |------|----------------------|-------------|
 |   `--node-ip value, -i` value | N/A   |   IP address to advertise for node  |
 |   `--node-external-ip` value |  N/A   | External IP address to advertise for node      |
-|   `--resolv-conf` value |   `K3S_RESOLV_CONF`    |  Kubelet resolv.conf file      | 
+|   `--resolv-conf` value |   `K3S_RESOLV_CONF`    |  Kubelet resolv.conf file. Note: If you wish to set kubelet parameter `--resolv-conf` to `""`, use `--kubelet-arg=resolv-conf=` instead       | 
 |   `--flannel-iface` value |    N/A   | Override default flannel interface      |
 |   `--flannel-conf` value |    N/A     |  Override default flannel config file |
 


### PR DESCRIPTION
Addressing issue [k3s agent not respecting K3S_RESOLV_CONF=""](https://github.com/k3s-io/k3s/issues/5627) 

### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
