### PR TITLE
Update quickstart paths

### DIFF
--- a/content/rancher/v2.5/en/quick-start-guide/deployment/amazon-aws-qs/_index.md
+++ b/content/rancher/v2.5/en/quick-start-guide/deployment/amazon-aws-qs/_index.md
@@ -38,7 +38,7 @@ The AWS module just creates an EC2 KeyPair, an EC2 SecurityGroup and an EC2 inst
 
 1. Clone [Rancher Quickstart](https://github.com/rancher/quickstart) to a folder using `git clone https://github.com/rancher/quickstart`.
 
-2. Go into the AWS folder containing the terraform files by executing `cd quickstart/aws`.
+2. Go into the AWS folder containing the terraform files by executing `cd quickstart/rancher/aws`.
 
 3. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
 
@@ -70,7 +70,7 @@ Suggestions include:
     ```
 
 8. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
-9. ssh to the Rancher server using the `id_rsa` key generated in `quickstart/aws`.
+9. ssh to the Rancher server using the `id_rsa` key generated in `quickstart/rancher/aws`.
 
 #### Result
 
@@ -82,6 +82,6 @@ Use Rancher to create a deployment. For more information, see [Creating Deployme
 
 ## Destroying the Environment
 
-1. From the `quickstart/aws` folder, execute `terraform destroy --auto-approve`.
+1. From the `quickstart/rancher/aws` folder, execute `terraform destroy --auto-approve`.
 
 2. Wait for confirmation that all resources have been destroyed.

--- a/content/rancher/v2.5/en/quick-start-guide/deployment/digital-ocean-qs/_index.md
+++ b/content/rancher/v2.5/en/quick-start-guide/deployment/digital-ocean-qs/_index.md
@@ -21,7 +21,7 @@ The following steps will quickly deploy a Rancher server on DigitalOcean in a si
 
 1. Clone [Rancher Quickstart](https://github.com/rancher/quickstart) to a folder using `git clone https://github.com/rancher/quickstart`.
 
-2. Go into the DigitalOcean folder containing the terraform files by executing `cd quickstart/do`.
+2. Go into the DigitalOcean folder containing the terraform files by executing `cd quickstart/rancher/do`.
 
 3. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
 
@@ -51,7 +51,7 @@ Suggestions include:
     ```
 
 8. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
-9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/do`.
+9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/rancher/do`.
 
 #### Result
 
@@ -63,6 +63,6 @@ Use Rancher to create a deployment. For more information, see [Creating Deployme
 
 ## Destroying the Environment
 
-1. From the `quickstart/do` folder, execute `terraform destroy --auto-approve`.
+1. From the `quickstart/rancher/do` folder, execute `terraform destroy --auto-approve`.
 
 2. Wait for confirmation that all resources have been destroyed.

--- a/content/rancher/v2.5/en/quick-start-guide/deployment/google-gcp-qs/_index.md
+++ b/content/rancher/v2.5/en/quick-start-guide/deployment/google-gcp-qs/_index.md
@@ -22,7 +22,7 @@ The following steps will quickly deploy a Rancher server on GCP in a single-node
 
 1. Clone [Rancher Quickstart](https://github.com/rancher/quickstart) to a folder using `git clone https://github.com/rancher/quickstart`.
 
-2. Go into the GCP folder containing the terraform files by executing `cd quickstart/gcp`.
+2. Go into the GCP folder containing the terraform files by executing `cd quickstart/rancher/gcp`.
 
 3. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
 
@@ -53,7 +53,7 @@ Suggestions include:
     ```
 
 8. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
-9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/gcp`.
+9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/rancher/gcp`.
 
 #### Result
 
@@ -65,6 +65,6 @@ Use Rancher to create a deployment. For more information, see [Creating Deployme
 
 ## Destroying the Environment
 
-1. From the `quickstart/gcp` folder, execute `terraform destroy --auto-approve`.
+1. From the `quickstart/rancher/gcp` folder, execute `terraform destroy --auto-approve`.
 
 2. Wait for confirmation that all resources have been destroyed.

--- a/content/rancher/v2.5/en/quick-start-guide/deployment/microsoft-azure-qs/_index.md
+++ b/content/rancher/v2.5/en/quick-start-guide/deployment/microsoft-azure-qs/_index.md
@@ -24,7 +24,7 @@ The following steps will quickly deploy a Rancher server on Azure in a single-no
 
 1. Clone [Rancher Quickstart](https://github.com/rancher/quickstart) to a folder using `git clone https://github.com/rancher/quickstart`.
 
-2. Go into the Azure folder containing the terraform files by executing `cd quickstart/azure`.
+2. Go into the Azure folder containing the terraform files by executing `cd quickstart/rancher/azure`.
 
 3. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
 
@@ -59,7 +59,7 @@ Suggestions include:
     ```
 
 8. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
-9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/azure`.
+9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/rancher/azure`.
 
 #### Result
 
@@ -71,6 +71,6 @@ Use Rancher to create a deployment. For more information, see [Creating Deployme
 
 ## Destroying the Environment
 
-1. From the `quickstart/azure` folder, execute `terraform destroy --auto-approve`.
+1. From the `quickstart/rancher/azure` folder, execute `terraform destroy --auto-approve`.
 
 2. Wait for confirmation that all resources have been destroyed.

--- a/content/rancher/v2.5/en/quick-start-guide/deployment/quickstart-vagrant/_index.md
+++ b/content/rancher/v2.5/en/quick-start-guide/deployment/quickstart-vagrant/_index.md
@@ -25,7 +25,7 @@ The following steps quickly deploy a Rancher Server with a single node cluster a
 
 1. Clone [Rancher Quickstart](https://github.com/rancher/quickstart) to a folder using `git clone https://github.com/rancher/quickstart`.
 
-2. Go into the folder containing the Vagrantfile by executing `cd quickstart/vagrant`.
+2. Go into the folder containing the Vagrantfile by executing `cd quickstart/rancher/vagrant`.
 
 3. **Optional:** Edit `config.yaml` to:
 
@@ -44,6 +44,6 @@ Use Rancher to create a deployment. For more information, see [Creating Deployme
 
 ## Destroying the Environment
 
-1. From the `quickstart/vagrant` folder execute `vagrant destroy -f`.
+1. From the `quickstart/rancher/vagrant` folder execute `vagrant destroy -f`.
 
 2. Wait for the confirmation that all resources have been destroyed.

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/amazon-aws-qs/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/amazon-aws-qs/_index.md
@@ -70,7 +70,7 @@ Suggestions include:
     ```
 
 8. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
-9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/aws`.
+9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/rancher/aws`.
 
 ##### Result
 
@@ -82,6 +82,6 @@ Use Rancher to create a deployment. For more information, see [Creating Deployme
 
 ## Destroying the Environment
 
-1. From the `quickstart/aws` folder, execute `terraform destroy --auto-approve`.
+1. From the `quickstart/rancher/aws` folder, execute `terraform destroy --auto-approve`.
 
 2. Wait for confirmation that all resources have been destroyed.

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/digital-ocean-qs/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/digital-ocean-qs/_index.md
@@ -21,7 +21,7 @@ The following steps will quickly deploy a Rancher server on DigitalOcean in a si
 
 1. Clone [Rancher Quickstart](https://github.com/rancher/quickstart) to a folder using `git clone https://github.com/rancher/quickstart`.
 
-2. Go into the DigitalOcean folder containing the terraform files by executing `cd quickstart/do`.
+2. Go into the DigitalOcean folder containing the terraform files by executing `cd quickstart/rancher/do`.
 
 3. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
 
@@ -51,7 +51,7 @@ Suggestions include:
     ```
 
 8. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
-9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/do`.
+9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/rancher/do`.
 
 #### Result
 
@@ -63,6 +63,6 @@ Use Rancher to create a deployment. For more information, see [Creating Deployme
 
 ## Destroying the Environment
 
-1. From the `quickstart/do` folder, execute `terraform destroy --auto-approve`.
+1. From the `quickstart/rancher/do` folder, execute `terraform destroy --auto-approve`.
 
 2. Wait for confirmation that all resources have been destroyed.

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/google-gcp-qs/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/google-gcp-qs/_index.md
@@ -22,7 +22,7 @@ The following steps will quickly deploy a Rancher server on GCP in a single-node
 
 1. Clone [Rancher Quickstart](https://github.com/rancher/quickstart) to a folder using `git clone https://github.com/rancher/quickstart`.
 
-2. Go into the GCP folder containing the terraform files by executing `cd quickstart/gcp`.
+2. Go into the GCP folder containing the terraform files by executing `cd quickstart/rancher/gcp`.
 
 3. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
 
@@ -53,7 +53,7 @@ Suggestions include:
     ```
 
 8. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
-9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/gcp`.
+9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/rancher/gcp`.
 
 #### Result
 
@@ -65,6 +65,6 @@ Use Rancher to create a deployment. For more information, see [Creating Deployme
 
 ## Destroying the Environment
 
-1. From the `quickstart/gcp` folder, execute `terraform destroy --auto-approve`.
+1. From the `quickstart/rancher/gcp` folder, execute `terraform destroy --auto-approve`.
 
 2. Wait for confirmation that all resources have been destroyed.

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/hetzner-cloud-qs/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/hetzner-cloud-qs/_index.md
@@ -21,7 +21,7 @@ The following steps will quickly deploy a Rancher server on Hetzner Cloud in a s
 
 1. Clone [Rancher Quickstart](https://github.com/rancher/quickstart) to a folder using `git clone https://github.com/rancher/quickstart`.
 
-2. Go into the Hetzner folder containing the terraform files by executing `cd quickstart/hcloud`.
+2. Go into the Hetzner folder containing the terraform files by executing `cd quickstart/rancher/hcloud`.
 
 3. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
 
@@ -51,7 +51,7 @@ Suggestions include:
     ```
 
 8. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
-9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/hcloud`.
+9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/rancher/hcloud`.
 
 #### Result
 
@@ -63,6 +63,6 @@ Use Rancher to create a deployment. For more information, see [Creating Deployme
 
 ## Destroying the Environment
 
-1. From the `quickstart/hcloud` folder, execute `terraform destroy --auto-approve`.
+1. From the `quickstart/rancher/hcloud` folder, execute `terraform destroy --auto-approve`.
 
 2. Wait for confirmation that all resources have been destroyed.

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/microsoft-azure-qs/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/microsoft-azure-qs/_index.md
@@ -24,7 +24,7 @@ The following steps will quickly deploy a Rancher server on Azure in a single-no
 
 1. Clone [Rancher Quickstart](https://github.com/rancher/quickstart) to a folder using `git clone https://github.com/rancher/quickstart`.
 
-2. Go into the Azure folder containing the terraform files by executing `cd quickstart/azure`.
+2. Go into the Azure folder containing the terraform files by executing `cd quickstart/rancher/azure`.
 
 3. Rename the `terraform.tfvars.example` file to `terraform.tfvars`.
 
@@ -59,7 +59,7 @@ Suggestions include:
     ```
 
 8. Paste the `rancher_server_url` from the output above into the browser. Log in when prompted (default username is `admin`, use the password set in `rancher_server_admin_password`).
-9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/azure`.
+9. ssh to the Rancher Server using the `id_rsa` key generated in `quickstart/rancher/azure`.
 
 #### Result
 
@@ -71,6 +71,6 @@ Use Rancher to create a deployment. For more information, see [Creating Deployme
 
 ## Destroying the Environment
 
-1. From the `quickstart/azure` folder, execute `terraform destroy --auto-approve`.
+1. From the `quickstart/rancher/azure` folder, execute `terraform destroy --auto-approve`.
 
 2. Wait for confirmation that all resources have been destroyed.

--- a/content/rancher/v2.6/en/quick-start-guide/deployment/quickstart-vagrant/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/quickstart-vagrant/_index.md
@@ -23,7 +23,7 @@ The following steps quickly deploy a Rancher Server with a single node cluster a
 
 1. Clone [Rancher Quickstart](https://github.com/rancher/quickstart) to a folder using `git clone https://github.com/rancher/quickstart`.
 
-2. Go into the folder containing the Vagrantfile by executing `cd quickstart/vagrant`.
+2. Go into the folder containing the Vagrantfile by executing `cd quickstart/rancher/vagrant`.
 
 3. **Optional:** Edit `config.yaml` to:
 
@@ -42,6 +42,6 @@ Use Rancher to create a deployment. For more information, see [Creating Deployme
 
 ## Destroying the Environment
 
-1. From the `quickstart/vagrant` folder execute `vagrant destroy -f`.
+1. From the `quickstart/rancher/vagrant` folder execute `vagrant destroy -f`.
 
 2. Wait for the confirmation that all resources have been destroyed.


### PR DESCRIPTION
Closes https://github.com/rancher/docs/issues/4155

This PR is a follow-up to https://github.com/rancher/docs/pull/4152 and updates the paths for the remaining providers and 2.5 docs.
