### PR TITLE
Fix broken links missing a '/'

### DIFF
--- a/content/rancher/v2.5/en/backups/_index.md
+++ b/content/rancher/v2.5/en/backups/_index.md
@@ -63,7 +63,7 @@ The Backup and Restore custom resources can be created in the Rancher UI, or by 
 
 The `rancher-backup` operator can be installed from the Rancher UI, or with the Helm CLI. In both cases, the `rancher-backup` Helm chart is installed on the Kubernetes cluster running the Rancher server. It is a cluster-admin only feature and available only for the **local** cluster.  (*If you do not see `rancher-backup` in the Rancher UI, you may have selected the wrong cluster.*)
 
->**NOTE:** There are two known issues in Fleet that occur after performing a restoration using the backup-restore-operator: Fleet agents are inoperable and clientSecretName and helmSecretName are not included in Fleet gitrepos. Refer [here]({{<baseurl>}}rancher/v2.5/en/deploy-across-clusters/fleet/#troubleshooting) for workarounds.
+>**NOTE:** There are two known issues in Fleet that occur after performing a restoration using the backup-restore-operator: Fleet agents are inoperable and clientSecretName and helmSecretName are not included in Fleet gitrepos. Refer [here]({{<baseurl>}}/rancher/v2.5/en/deploy-across-clusters/fleet/#troubleshooting) for workarounds.
 
 ### Installing rancher-backup with the Rancher UI
 

--- a/content/rancher/v2.6/en/backups/_index.md
+++ b/content/rancher/v2.6/en/backups/_index.md
@@ -49,7 +49,7 @@ The Backup and Restore custom resources can be created in the Rancher UI, or by 
 
 The `rancher-backup` operator can be installed from the Rancher UI, or with the Helm CLI. In both cases, the `rancher-backup` Helm chart is installed on the Kubernetes cluster running the Rancher server. It is a cluster-admin only feature and available only for the **local** cluster.  (*If you do not see `rancher-backup` in the Rancher UI, you may have selected the wrong cluster.*)
 
->**NOTE:** There is a known issue in Fleet that occurs after performing a restoration using the backup-restore-operator: Secrets used for clientSecretName and helmSecretName are not included in Fleet gitrepos. Refer [here]({{<baseurl>}}rancher/v2.6/en/deploy-across-clusters/fleet/#troubleshooting) for a workaround.
+>**NOTE:** There is a known issue in Fleet that occurs after performing a restoration using the backup-restore-operator: Secrets used for clientSecretName and helmSecretName are not included in Fleet gitrepos. Refer [here]({{<baseurl>}}/rancher/v2.6/en/deploy-across-clusters/fleet/#troubleshooting) for a workaround.
 
 ### Installing rancher-backup with the Rancher UI
 

--- a/content/rancher/v2.6/en/backups/back-up-rancher/_index.md
+++ b/content/rancher/v2.6/en/backups/back-up-rancher/_index.md
@@ -31,7 +31,7 @@ Backups are created as .tar.gz files. These files can be pushed to S3 or Minio, 
 1. Configure the default storage location. For help, refer to the [storage configuration section.](../configuration/storage-config)
 1. Click **Install**.
 
->**NOTE:** There is a known issue in Fleet that occurs after performing a restoration using the backup-restore-operator: Secrets used for clientSecretName and helmSecretName are not included in Fleet gitrepos. Refer [here]({{<baseurl>}}rancher/v2.6/en/deploy-across-clusters/fleet/#troubleshooting) for a workaround.
+>**NOTE:** There is a known issue in Fleet that occurs after performing a restoration using the backup-restore-operator: Secrets used for clientSecretName and helmSecretName are not included in Fleet gitrepos. Refer [here]({{<baseurl>}}/rancher/v2.6/en/deploy-across-clusters/fleet/#troubleshooting) for a workaround.
 
 ### 2. Perform a Backup
 


### PR DESCRIPTION
Baseurl does not include a `/` so we need to provide it to make it a working link.

Example:
* Before: `https://rancher.com/docsrancher/v2.6/en/deploy-across-clusters/fleet/#troubleshooting`
* After: `https://rancher.com/docs/rancher/v2.6/en/deploy-across-clusters/fleet/#troubleshooting`
