### PR TITLE
Updating max version of Rancher charts

### DIFF
--- a/content/rancher/v2.6/en/helm-charts/_index.md
+++ b/content/rancher/v2.6/en/helm-charts/_index.md
@@ -20,19 +20,19 @@ Starting in Rancher v2.6.0, a new versioning scheme for Rancher feature charts w
 | external-ip-webhook | 100.0.0+up1.0.0 | 100.0.1+up1.0.1 |
 | harvester-cloud-provider | 100.0.2+up0.1.12 | 100.0.2+up0.1.12 |
 | harvester-csi-driver | 100.0.2+up0.1.11 | 100.0.2+up0.1.11 |
+| neuvector | 100.0.0+up2.2.0 | 100.0.0+up2.2.0 |
 | rancher-alerting-drivers | 100.0.0 | 100.0.2 |
 | rancher-backup | 2.0.1 | 2.1.2 |
 | rancher-cis-benchmark | 2.0.1 | 2.0.4 |
 | rancher-gatekeeper | 100.0.0+up3.6.0 | 100.1.0+up3.7.1 |
-| rancher-istio | 100.0.0+up1.10.4 | 100.2.0+up1.12.6 |
+| rancher-istio | 100.0.0+up1.10.4 | 100.3.0+up1.13.3 |
 | rancher-logging | 100.0.0+up3.12.0 | 100.1.2+up3.17.4 |
-| rancher-longhorn | 100.0.0+up1.1.2 | 100.1.1+up1.2.3 |
-| rancher-monitoring | 100.0.0+up16.6.0 | 100.1.0+up19.0.3
+| rancher-longhorn | 100.0.0+up1.1.2 | 100.1.2+up1.2.4 |
+| rancher-monitoring | 100.0.0+up16.6.0 | 100.1.2+up19.0.3
 | rancher-sriov (experimental) | 100.0.0+up0.1.0 | 100.0.3+up0.1.0 |
 | rancher-vsphere-cpi | 100.3.0+up1.2.1 | 100.3.0+up1.2.1 |
 | rancher-vsphere-csi | 100.3.0+up2.5.1-rancher1 | 100.3.0+up2.5.1-rancher1 |
-| rancher-wins-upgrader | 0.0.100 | 100.0.0+up0.0.1 |
-| neuvector | 100.0.0+up2.2.0 | 100.0.0+up2.2.0 |
+| rancher-wins-upgrader | 0.0.100 | 100.0.1+up0.0.1 |
 
 </br>
 **Charts based on upstream:** For charts that are based on upstreams, the +up annotation should inform you of what upstream version the Rancher chart is tracking. Check the upstream version compatibility with Rancher during upgrades also.


### PR DESCRIPTION
Updating [Helm charts in Rancher page](https://rancher.com/docs/rancher/v2.6/en/helm-charts/).
