### PR TITLE
Include an alternative to the sh command:

### DIFF
--- a/content/k3s/latest/en/quick-start/_index.md
+++ b/content/k3s/latest/en/quick-start/_index.md
@@ -16,6 +16,8 @@ K3s provides an installation script that is a convenient way to install it as a 
 curl -sfL https://get.k3s.io | sh -
 ```
 
+If the preceding command fails to install K3s, change `sh` to `bash`, and rerun it.
+
 After running this installation:
 
 * The K3s service will be configured to automatically restart after node reboots or if the process crashes or is killed


### PR DESCRIPTION
When I ran the command as-is, I did not receive an error message that could help me fix the issue. My output looked as follows:

$ curl -sfL https://get.k3s.io | sh -
[INFO]  Finding release for channel stable
[INFO]  Using stable as release
[INFO]  Downloading hash https://github.com/k3s-io/k3s/releases/download/stable/sha256sum-amd64.txt
$ k3s kubectl get node

Command 'k3s' not found, did you mean:

  command 'k9s' from snap k9s (0.7.12)
  command 'k3b' from deb k3b (19.12.3-0ubuntu1)
  command 'kds' from deb kylin-display-switch (1.0.4-1)

See 'snap info <snapname>' for additional versions.

### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
