### PR TITLE
[K3s] Add new command for acquiring the bearer token

### DIFF
--- a/content/k3s/latest/en/installation/kube-dashboard/_index.md
+++ b/content/k3s/latest/en/installation/kube-dashboard/_index.md
@@ -52,6 +52,12 @@ sudo k3s kubectl create -f dashboard.admin-user.yml -f dashboard.admin-user-role
 
 ### Obtain the Bearer Token
 
+_On v1.24+_
+```bash
+sudo k3s kubectl -n kubernetes-dashboard create token admin-user
+```
+
+_On v1.23 and older_
 ```bash
 sudo k3s kubectl -n kubernetes-dashboard describe secret admin-user-token | grep '^token'
 ```


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

K8s v1.24+ now has a new way to acquire the bearer token for Kubernetes dashboard installation. 