### PR TITLE
Update gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,20 @@
-/build
-/public
-/resources
+# Dependencies
 /node_modules
-package-lock.json
-*.tern-port
-*/**/.tern-port
-.DS_Store
-.vscode/settings.json
-/scripts/converters/output
-/scripts/converters/results_to_markdown/*.json
-/scripts/converters/results_to_markdown/.terraform
-/scripts/converters/results_to_markdown/terraform.tfstate*
-/scripts/converters/results_to_markdown/*.tfvars
 
-.idea/
+# Production
+/build
+
+# Generated files
+.docusaurus
+.cache-loader
+
+# Misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*


### PR DESCRIPTION
### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
