### PR TITLE
missing v in -version=v2.x.x

### DIFF
--- a/content/rancher/v2.6/en/installation/install-rancher-on-k8s/upgrades/_index.md
+++ b/content/rancher/v2.6/en/installation/install-rancher-on-k8s/upgrades/_index.md
@@ -97,7 +97,7 @@ You'll use the backup as a restore point if something goes wrong during upgrade.
     You can fetch the chart for the specific version you are upgrading to by adding in the `--version=` tag.  For example:
     
     ```plain
-    helm fetch rancher-<CHART_REPO>/rancher --version=v2.4.11
+    helm fetch rancher-<CHART_REPO>/rancher --version=v2.6.6
     ```
 
 # 3. Upgrade Rancher
@@ -141,7 +141,7 @@ helm get values rancher -n cattle-system -o yaml > values.yaml
 helm upgrade rancher rancher-<CHART_REPO>/rancher \
   --namespace cattle-system \
   -f values.yaml \
-  --version=2.4.5
+  --version=v2.6.6
 ```
 
 # 4. Verify the Upgrade


### PR DESCRIPTION
missing v in -version=v2.6.6 and update to latest version v2.6.6

### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
