### PR TITLE
Remove Kubewarden references

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -39,7 +39,7 @@ module.exports = {
           className: 'navbar__docs',
         },
         {
-          href: 'https://github.com/kubewarden/',
+          href: 'https://github.com/rancher/',
           label: 'GitHub',
           position: 'right',
           className: 'navbar__github btn btn-secondary icon-github',
@@ -67,7 +67,7 @@ module.exports = {
           /* other docs plugin options */
           sidebarPath: require.resolve('./sidebars.js'),
           showLastUpdateTime: true,
-          editUrl: 'https://github.com/kubewarden/docs/edit/main/',
+          editUrl: 'https://github.com/rancher/docs/edit/master/',
           lastVersion: 'current',
           versions: {
             current: {
@@ -83,5 +83,5 @@ module.exports = {
         },
       },
     ],
-  ], 
+  ],
 };


### PR DESCRIPTION
### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
