### PR TITLE
Updated nginx versions and added note on new `-set ingress.ingressClassName=nginx` value

### DIFF
--- a/content/rancher/v2.6/en/installation/resources/k8s-tutorials/aks/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/k8s-tutorials/aks/_index.md
@@ -124,10 +124,10 @@ Use that DNS name from the previous step as the Rancher server URL when you inst
 
 **_New in v2.6.7_**
 
-When installing Rancher on top of this setup, you will also need to pass the value below into the Rancher helm install command in order to set the name of the ingress controller to be used with Rancher's ingress resource:
+When installing Rancher on top of this setup, you will also need to pass the value below into the Rancher Helm install command in order to set the name of the ingress controller to be used with Rancher's ingress resource:
 
 ```
 --set ingress.ingressClassName=nginx
 ```
 
-Refer [here for your cert options]({{<baseurl>}}/rancher/v2.6/en/installation/install-rancher-on-k8s/#5-install-rancher-with-helm-and-your-chosen-certificate-option).
+Refer [here for the Helm install command]({{<baseurl>}}/rancher/v2.6/en/installation/install-rancher-on-k8s/#5-install-rancher-with-helm-and-your-chosen-certificate-option) for your chosen certificate option.

--- a/content/rancher/v2.6/en/installation/resources/k8s-tutorials/aks/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/k8s-tutorials/aks/_index.md
@@ -83,7 +83,7 @@ helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --namespace ingress-nginx \
   --set controller.service.type=LoadBalancer \
-  --version 3.12.0 \
+  --version 4.0.18 \
   --create-namespace
 ```
 

--- a/content/rancher/v2.6/en/installation/resources/k8s-tutorials/aks/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/k8s-tutorials/aks/_index.md
@@ -119,3 +119,15 @@ There are many valid ways to set up the DNS. For help, refer to the [Azure DNS d
 Next, install the Rancher Helm chart by following the instructions on [this page.]({{<baseurl>}}/rancher/v2.6/en/installation/install-rancher-on-k8s/#install-the-rancher-helm-chart) The Helm instructions are the same for installing Rancher on any Kubernetes distribution.
 
 Use that DNS name from the previous step as the Rancher server URL when you install Rancher. It can be passed in as a Helm option. For example, if the DNS name is `rancher.my.org`, you could run the Helm installation command with the option `--set hostname=rancher.my.org`.
+<br/>
+<br/>
+
+**_New in v2.6.7_**
+
+When installing Rancher on top of this setup, you will also need to pass the value below into the Rancher helm install command in order to set the name of the ingress controller to be used with Rancher's ingress resource:
+
+```
+--set ingress.ingressClassName=nginx
+```
+
+Refer [here for your cert options]({{<baseurl>}}/rancher/v2.6/en/installation/install-rancher-on-k8s/#5-install-rancher-with-helm-and-your-chosen-certificate-option).

--- a/content/rancher/v2.6/en/installation/resources/k8s-tutorials/amazon-eks/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/k8s-tutorials/amazon-eks/_index.md
@@ -128,7 +128,7 @@ helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --namespace ingress-nginx \
   --set controller.service.type=LoadBalancer \
-  --version 3.12.0 \
+  --version 4.0.18 \
   --create-namespace
 ```
 

--- a/content/rancher/v2.6/en/installation/resources/k8s-tutorials/amazon-eks/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/k8s-tutorials/amazon-eks/_index.md
@@ -119,7 +119,7 @@ rancher-server-cluster		us-west-2	True
 
 The cluster needs an Ingress so that Rancher can be accessed from outside the cluster.
 
-The following command installs an `nginx-ingress-controller` with a LoadBalancer service. This will result in an ELB (Elastic Load Balancer) in front of NGINX:
+The following command installs an `nginx-ingress-controller` with a LoadBalancer service. This will result in an ELB (Elastic Load Balancer) in front of NGINX.
 
 ```
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
@@ -164,3 +164,15 @@ There are many valid ways to set up the DNS. For help, refer to the AWS document
 Next, install the Rancher Helm chart by following the instructions on [this page.]({{<baseurl>}}/rancher/v2.6/en/installation/install-rancher-on-k8s/#install-the-rancher-helm-chart) The Helm instructions are the same for installing Rancher on any Kubernetes distribution.
 
 Use that DNS name from the previous step as the Rancher server URL when you install Rancher. It can be passed in as a Helm option. For example, if the DNS name is `rancher.my.org`, you could run the Helm installation command with the option `--set hostname=rancher.my.org`.
+<br/>
+<br/>
+
+**_New in v2.6.7_**
+
+When installing Rancher on top of this setup, you will also need to pass the value below into the Rancher helm install command in order to set the name of the ingress controller to be used with Rancher's ingress resource:
+
+```
+--set ingress.ingressClassName=nginx
+```
+
+Refer [here for your cert options]({{<baseurl>}}/rancher/v2.6/en/installation/install-rancher-on-k8s/#5-install-rancher-with-helm-and-your-chosen-certificate-option).

--- a/content/rancher/v2.6/en/installation/resources/k8s-tutorials/amazon-eks/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/k8s-tutorials/amazon-eks/_index.md
@@ -119,7 +119,7 @@ rancher-server-cluster		us-west-2	True
 
 The cluster needs an Ingress so that Rancher can be accessed from outside the cluster.
 
-The following command installs an `nginx-ingress-controller` with a LoadBalancer service. This will result in an ELB (Elastic Load Balancer) in front of NGINX.
+The following command installs an `nginx-ingress-controller` with a LoadBalancer service. This will result in an ELB (Elastic Load Balancer) in front of NGINX:
 
 ```
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx

--- a/content/rancher/v2.6/en/installation/resources/k8s-tutorials/amazon-eks/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/k8s-tutorials/amazon-eks/_index.md
@@ -169,10 +169,10 @@ Use that DNS name from the previous step as the Rancher server URL when you inst
 
 **_New in v2.6.7_**
 
-When installing Rancher on top of this setup, you will also need to pass the value below into the Rancher helm install command in order to set the name of the ingress controller to be used with Rancher's ingress resource:
+When installing Rancher on top of this setup, you will also need to pass the value below into the Rancher Helm install command in order to set the name of the ingress controller to be used with Rancher's ingress resource:
 
 ```
 --set ingress.ingressClassName=nginx
 ```
 
-Refer [here for your cert options]({{<baseurl>}}/rancher/v2.6/en/installation/install-rancher-on-k8s/#5-install-rancher-with-helm-and-your-chosen-certificate-option).
+Refer [here for the Helm install command]({{<baseurl>}}/rancher/v2.6/en/installation/install-rancher-on-k8s/#5-install-rancher-with-helm-and-your-chosen-certificate-option) for your chosen certificate option.

--- a/content/rancher/v2.6/en/installation/resources/k8s-tutorials/gke/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/k8s-tutorials/gke/_index.md
@@ -187,10 +187,10 @@ Use the DNS name from the previous step as the Rancher server URL when you insta
 
 **_New in v2.6.7_**
 
-When installing Rancher on top of this setup, you will also need to pass the value below into the Rancher helm install command in order to set the name of the ingress controller to be used with Rancher's ingress resource:
+When installing Rancher on top of this setup, you will also need to pass the value below into the Rancher Helm install command in order to set the name of the ingress controller to be used with Rancher's ingress resource:
 
 ```
 --set ingress.ingressClassName=nginx
 ```
 
-Refer [here for your cert options]({{<baseurl>}}/rancher/v2.6/en/installation/install-rancher-on-k8s/#5-install-rancher-with-helm-and-your-chosen-certificate-option).
+Refer [here for the Helm install command]({{<baseurl>}}/rancher/v2.6/en/installation/install-rancher-on-k8s/#5-install-rancher-with-helm-and-your-chosen-certificate-option) for your chosen certificate option.

--- a/content/rancher/v2.6/en/installation/resources/k8s-tutorials/gke/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/k8s-tutorials/gke/_index.md
@@ -148,7 +148,7 @@ helm upgrade --install \
   ingress-nginx ingress-nginx/ingress-nginx \
   --namespace ingress-nginx \
   --set controller.service.type=LoadBalancer \
-  --version 3.12.0 \
+  --version 4.0.18 \
   --create-namespace
 ```
 

--- a/content/rancher/v2.6/en/installation/resources/k8s-tutorials/gke/_index.md
+++ b/content/rancher/v2.6/en/installation/resources/k8s-tutorials/gke/_index.md
@@ -182,3 +182,15 @@ There are many valid ways to set up the DNS. For help, refer to the Google Cloud
 Next, install the Rancher Helm chart by following the instructions on [this page.]({{<baseurl>}}/rancher/v2.6/en/installation/install-rancher-on-k8s/#install-the-rancher-helm-chart) The Helm instructions are the same for installing Rancher on any Kubernetes distribution.
 
 Use the DNS name from the previous step as the Rancher server URL when you install Rancher. It can be passed in as a Helm option. For example, if the DNS name is `rancher.my.org`, you could run the Helm installation command with the option `--set hostname=rancher.my.org`.
+<br/>
+<br/>
+
+**_New in v2.6.7_**
+
+When installing Rancher on top of this setup, you will also need to pass the value below into the Rancher helm install command in order to set the name of the ingress controller to be used with Rancher's ingress resource:
+
+```
+--set ingress.ingressClassName=nginx
+```
+
+Refer [here for your cert options]({{<baseurl>}}/rancher/v2.6/en/installation/install-rancher-on-k8s/#5-install-rancher-with-helm-and-your-chosen-certificate-option).


### PR DESCRIPTION
Closes #4221 

- Updated nginx versions and added note on new value for GKE, AKS, and Amazon EKS
- For the K8s versions, we updated GKE, AKS, and EKS with a placeholder in this [PR](https://github.com/rancher/docs/pull/4218)