### PR TITLE
Adapter docs upd

### DIFF
--- a/content/rancher/v2.6/en/installation/cloud-marketplace/aws/adapter-install/_index.md
+++ b/content/rancher/v2.6/en/installation/cloud-marketplace/aws/adapter-install/_index.md
@@ -15,11 +15,19 @@ First, click on the local cluster and download a kubeconfig token. You can then 
 export KUBECONFIG=$TOKEN_PATH
 ```
 
-### 2. Create Certificate Secrets 
+### 2. Create the Adapter Namespace
+
+Create the namespace that the adapter will be installed in.
+
+```bash
+kubectl create ns cattle-csp-adapter-system
+```
+
+### 3. Create Certificate Secrets 
 
 The adapter requires access to the root CA that Rancher is using to communicate with the Rancher server. You can read more about which certificate options Rancher supports in the [chart options page]({{<baseurl>}}/rancher/v2.6/en/installation/install-rancher-on-k8s/chart-options).
 
-If your Rancher install uses a certificate signed by a recognized Certificate Authority such as Let's Encrypt, then you can safely skip to [Step 3](#install-the-chart).
+If your Rancher install uses a certificate signed by a recognized Certificate Authority such as Let's Encrypt, then you can safely skip to [Step 4](#4-install-the-chart).
 
 However, if your Rancher install uses a custom certificate such as a Rancher-generated certificate or one signed by a private Certificate Authority, you will need to provide the certificate for this authority in PEM-encoded format so that the adapter can communicate with Rancher.
 
@@ -37,9 +45,7 @@ kubectl -n cattle-csp-adapter-system create secret generic tls-ca-additional --f
 
 > **Important:** Do not change the names of the file or of the created secret. Making changes to these values may result in errors when the adapter runs.
 
-When you install the chart in [Step 3](#install-the-chart), you will also need to specify `additionalTrustedCAs=true`.
-
-### 3. Install the Chart
+### 4. Install the Chart
 
 First, add the `rancher/charts` repo using the following command:
 
@@ -49,17 +55,19 @@ helm repo add rancher-charts https://charts.rancher.io
 
 Next, install the CSP adapter. You must specify several values, including the account number, and the name of the role created in the prerequisites.
 
-> **Note:** If you specified a custom cert, you will also need to specify `additionalTrustedCAs=true`.
-
-You can do this using the Helm CLI using the command below. Replace `$MY_ACC_NUM` with your AWS account number and `$MY_ROLE_NAME` with the name of the role created in the prerequisites:
-
-```bash
-helm install rancher-csp-adapter rancher-charts/rancher-csp-adapter --namespace cattle-csp-adapter-system --set aws.enabled=true --set aws.roleName=$MY_ROLE_NAME --set-string aws.accountNumber=$MY_ACC_NUM --create-namespace
-```
+For the below instructions, replace `$MY_ACC_NUM` with your AWS account number and `$MY_ROLE_NAME` with the name of the role created in the prerequisites.
 
 > **Note:** If you use shell variables, do not specify quotation marks. For example, MY_ACC_NUM=123456789012 will work, but MY_ACC_NUM="123456789012" will fail.
 
-Alternatively, you can use a `values.yaml` and specify options like the below, replacing `$MY_ACC_NUM` with your AWS account number and `$MY_ROLE_NAME` with the name of the role created in the prerequisites: 
+{{% tabs %}}
+{{% tab "Let's Encrypt/ Public Certificate Authority" %}}
+
+```bash
+helm install rancher-csp-adapter rancher-charts/rancher-csp-adapter --namespace cattle-csp-adapter-system --set aws.enabled=true --set aws.roleName=$MY_ROLE_NAME --set-string aws.accountNumber=$MY_ACC_NUM
+```
+
+
+Alternatively, you can use a `values.yaml` and specify options like below:
 
 ```yaml
 aws:
@@ -68,7 +76,7 @@ aws:
   roleName: $MY_ROLE_NAME
 ```
 
-> **Note:** The account number needs to be specified in a string format, exactly like the above, or the installation will fail. 
+> **Note:** The account number needs to be specified in a string format, like the above, or the installation will fail.
 
 You can then install the adapter with the following command:
 
@@ -76,9 +84,37 @@ You can then install the adapter with the following command:
 helm install rancher-csp-adapter rancher-charts/rancher-csp-adapter -f values.yaml
 ```
 
-### 4. Managing Certificate Updates
+{{% /tab %}}
+{{% tab "Private CA Authority / Rancher-generated Certificates" %}}
 
-If you had to create a secret storing a custom cert in [Step 2](#create-certificate-secrets), you will need to update this secret over time as the certificate is rotated. 
+```bash
+helm install rancher-csp-adapter rancher-charts/rancher-csp-adapter --namespace cattle-csp-adapter-system --set aws.enabled=true --set aws.roleName=$MY_ROLE_NAME --set-string aws.accountNumber=$MY_ACC_NUM --set additionalTrustedCAs=true
+```
+
+Alternatively, you can use a `values.yaml` and specify options the below:
+
+```yaml
+aws:
+  enabled: true
+  accountNum: "$MY_ACC_NUM"
+  roleName: $MY_ROLE_NAME
+additionalTrustedCAs: true
+```
+
+> **Note:** The account number needs to be specified in a string format, like the above, or the installation will fail.
+
+You can then install the adapter with the following command:
+
+```bash
+helm install rancher-csp-adapter rancher-charts/rancher-csp-adapter -f values.yaml
+```
+
+{{% /tab %}}
+{{% /tabs %}}
+
+### 5. Managing Certificate Updates
+
+If you had to create a secret storing a custom cert in [Step 3](#3-create-certificate-secrets), you will need to update this secret over time as the certificate is rotated. 
 
 First, delete the original secret in the cattle-csp-adapter-system namespace, using the below command:
 
@@ -86,7 +122,7 @@ First, delete the original secret in the cattle-csp-adapter-system namespace, us
 kubectl delete secret tls-ca-additional -n cattle-csp-adapter-system
 ```
 
-Then, follow the original installation steps to replace the content of the secret with the updated value.
+Then, follow the original installation steps in [Step 3](#3-create-certificate-secrets) to replace the content of the secret with the updated value.
 
 Finally, restart the rancher-csp-adapter deployment to ensure that the updated value is made available to the adapter:
 

--- a/content/rancher/v2.6/en/installation/cloud-marketplace/aws/prerequisites/_index.md
+++ b/content/rancher/v2.6/en/installation/cloud-marketplace/aws/prerequisites/_index.md
@@ -8,7 +8,7 @@ weight: 1
 First, complete the [first step](https://docs.aws.amazon.com/license-manager/latest/userguide/getting-started.html) of the license manager one-time setup.
 Next, go to the AWS Marketplace. Locate the "Rancher Premium Support Billing Container Starter Pack". Purchase at least one entitlement.
 
-If you have installed Rancher using the "Rancher Setup" AWS Marketplace offering, skip to [Step 4](#create-an-oidc-provider).
+If you have installed Rancher using the "Rancher Setup" AWS Marketplace offering, skip to [Step 4](#4-create-an-oidc-provider).
 
 > **Note:** Each entitlement grants access to support for a certain amount of nodes. You can purchase more licenses as necessary later on.
 


### PR DESCRIPTION
Updates the docs for the csp adapter.

Changes:
- Fixes some broken links
- Adds in a table for the adapter's install options so it's easier to figure out how to install the chart for a given certificate option