### PR TITLE
Document how to change the node CIDR mask

### DIFF
--- a/content/rke/latest/en/example-yamls/_index.md
+++ b/content/rke/latest/en/example-yamls/_index.md
@@ -262,6 +262,8 @@ services:
         # https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster/
         cluster-signing-cert-file: "/etc/kubernetes/ssl/kube-ca.pem"
         cluster-signing-key-file: "/etc/kubernetes/ssl/kube-ca-key.pem"
+        # Change the per-node pod subnet size for more or larger nodes, default is /24
+        node-cidr-mask-size: '24'
     kubelet:
       # Base domain for the cluster
       cluster_domain: cluster.local


### PR DESCRIPTION
[Kubernetes official reference](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/#:~:text=Mask%20size%20for%20node%20cidr,IPv4%20and%2064%20for%20IPv6.&text=Mask%20size%20for%20IPv4%20node,Default%20is%2024.)

Been looking for that in the docs, couldn't find it. It seems very important for people who want larger farms of smaller nodes or the other way around. 256~ish pods is quite a good default, but sometimes not large enough.

Note : I read the PR template, and hope It's what's expected to update the "latest" folder ? (that's what is done by default when clicking "Edit this page" in the docs)
