### PR TITLE
Updated AWS autoscaler to a placeholder version

### DIFF
--- a/content/rancher/v2.5/en/cluster-admin/cluster-autoscaler/amazon/_index.md
+++ b/content/rancher/v2.5/en/cluster-admin/cluster-autoscaler/amazon/_index.md
@@ -29,7 +29,9 @@ These elements are required to follow this guide:
 
 ### 1. Create a Custom Cluster
 
-On Rancher server, we should create a custom k8s cluster v1.18.x. Be sure that cloud_provider name is set to `amazonec2`. Once cluster is created we need to get:
+On Rancher server, we should create a custom k8s cluster. Refer [here](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/) to check for version compatibility.
+
+Be sure that cloud_provider name is set to `amazonec2`. Once cluster is created we need to get:
 
 * clusterID: `c-xxxxx` will be used on EC2 `kubernetes.io/cluster/<clusterID>` instance tag
 * clusterName: will be used on EC2 `k8s.io/cluster-autoscaler/<clusterName>` instance tag
@@ -483,7 +485,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/controlplane: "true"
       containers:
-        - image: eu.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler:v1.18.1
+        - image: eu.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler:<VERSION>
           name: cluster-autoscaler
           resources:
             limits:

--- a/content/rancher/v2.6/en/cluster-admin/cluster-autoscaler/amazon/_index.md
+++ b/content/rancher/v2.6/en/cluster-admin/cluster-autoscaler/amazon/_index.md
@@ -27,7 +27,9 @@ These elements are required to follow this guide:
 
 ### 1. Create a Custom Cluster
 
-On Rancher server, we should create a custom k8s cluster v1.18.x. Be sure that cloud_provider name is set to `amazonec2`. Once cluster is created we need to get:
+On Rancher server, we should create a custom k8s cluster. Refer [here](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/) to check for version compatibility.
+
+Be sure that cloud_provider name is set to `amazonec2`. Once cluster is created we need to get:
 
 * clusterID: `c-xxxxx` will be used on EC2 `kubernetes.io/cluster/<clusterID>` instance tag
 * clusterName: will be used on EC2 `k8s.io/cluster-autoscaler/<clusterName>` instance tag
@@ -481,7 +483,7 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/controlplane: "true"
       containers:
-        - image: eu.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler:v1.18.1
+        - image: eu.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler:<VERSION>
           name: cluster-autoscaler
           resources:
             limits:


### PR DESCRIPTION
Closes #4234 

- Per QA, Rancher has not tested new autoscaler versions nor is it on the roadmap at this time. Consequently, we have updated the 1.18.x version with a `placeholder`.