### PR TITLE
fixed small typo in monitoring-alerting docs

### DIFF
--- a/content/rancher/v2.6/en/monitoring-alerting/configuration/receiver/_index.md
+++ b/content/rancher/v2.6/en/monitoring-alerting/configuration/receiver/_index.md
@@ -36,7 +36,7 @@ To create notification receivers in the Rancher UI,
 {{% tab "Rancher v2.6.5+" %}}
 
 1. Go to the cluster where you want to create receivers. Click **Monitoring -> Alerting -> AlertManagerConfigs**.
-1. Ciick **Create**.
+1. Click **Create**.
 1. Click **Add Receiver**.
 1. Enter a **Name** for the receiver.
 1. Configure one or more providers for the receiver. For help filling out the forms, refer to the configuration options below.


### PR DESCRIPTION
fixed small typo - changed 'Ciick' to 'Click'

### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
