### PR TITLE
Var name typo fix for Vagrant setup

### DIFF
--- a/content/rancher/v2.6/en/quick-start-guide/deployment/quickstart-vagrant/_index.md
+++ b/content/rancher/v2.6/en/quick-start-guide/deployment/quickstart-vagrant/_index.md
@@ -28,7 +28,7 @@ The following steps quickly deploy a Rancher Server with a single node cluster a
 3. **Optional:** Edit `config.yaml` to:
 
     - Change the number of nodes and the memory allocations, if required. (`node.count`, `node.cpus`, `node.memory`)
-    - Change the password of the `admin` user for logging into Rancher. (`default_password`)
+    - Change the password of the `admin` user for logging into Rancher. (`admin_password`)
 
 4. To initiate the creation of the environment run, `vagrant up --provider=virtualbox`.
 


### PR DESCRIPTION
The variable is currently named "admin_password" instead of the documented value of "default_password".

### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
