### PR TITLE
Added back Calico CNI for RKE as supported in 2.6

### DIFF
--- a/content/rancher/v2.5/en/faq/networking/cni-providers/_index.md
+++ b/content/rancher/v2.5/en/faq/networking/cni-providers/_index.md
@@ -46,7 +46,7 @@ CNI network providers using this network model include Calico and Romana.
 
 ### What CNI Providers are Provided by Rancher?
 
-Out-of-the-box, Rancher provides the following CNI network providers for Kubernetes clusters: Canal, Flannel, Calico and Weave. You can choose your CNI network provider when you create new Kubernetes clusters from Rancher.
+Out-of-the-box, Rancher provides the following CNI network providers for Kubernetes clusters: Canal, Flannel, Calico, and Weave. You can choose your CNI network provider when you create new Kubernetes clusters from Rancher.
 
 #### Canal
 

--- a/content/rancher/v2.6/en/faq/networking/cni-providers/_index.md
+++ b/content/rancher/v2.6/en/faq/networking/cni-providers/_index.md
@@ -46,7 +46,7 @@ CNI network providers using this network model include Calico and Cilium. Cilium
 
 ### RKE Kubernetes clusters
 
-Out-of-the-box, Rancher provides the following CNI network providers for RKE Kubernetes clusters: Canal, Flannel, and Weave. 
+Out-of-the-box, Rancher provides the following CNI network providers for RKE Kubernetes clusters: Canal, Flannel, Calico, and Weave. 
 
 You can choose your CNI network provider when you create new Kubernetes clusters from Rancher.
 


### PR DESCRIPTION
Closes #3981 

Reference: [CNI providers for RKE](https://rancher.com/docs/rancher/v2.6/en/faq/networking/cni-providers/#what-cni-providers-are-provided-by-rancher)

- Confirmed Calico was accidentally removed in [a previous PR](https://github.com/rancher/docs/pull/3802/files#diff-fd3bfbeee45d2d91035b13631ee7d6fd3ebdc77931a2c4eaa852ef9021bb63b0R49) and should be added back per @manuelbuil via Slack.