### PR TITLE
Update steps for accessing Prometheus Rules

### DIFF
--- a/content/rancher/v2.5/en/monitoring-alerting/configuration/advanced/prometheusrules/_index.md
+++ b/content/rancher/v2.5/en/monitoring-alerting/configuration/advanced/prometheusrules/_index.md
@@ -17,7 +17,7 @@ _Available as of v2.5.4_
 
 To create rule groups in the Rancher UI,
 
-1. Click **Cluster Explorer > Monitoring** and click **Prometheus Rules.** 
+1. Click **Cluster Explorer > Monitoring > Advanced** and click **Prometheus Rules.** 
 1. Click **Create.**
 1. Enter a **Group Name.**
 1. Configure the rules. In Rancher's UI, we expect a rule group to contain either alert rules or recording rules, but not both. For help filling out the forms, refer to the configuration options below.

--- a/content/rancher/v2.6/en/monitoring-alerting/configuration/advanced/prometheusrules/_index.md
+++ b/content/rancher/v2.6/en/monitoring-alerting/configuration/advanced/prometheusrules/_index.md
@@ -14,7 +14,7 @@ A PrometheusRule defines a group of Prometheus alerting and/or recording rules.
 
 To create rule groups in the Rancher UI,
 
-1. Go to the cluster where you want to create rule groups. Click **Monitoring** and click **Prometheus Rules**. 
+1. Go to the cluster where you want to create rule groups. Click **Monitoring > Advanced** and click **Prometheus Rules**. 
 1. Click **Create**.
 1. Enter a **Group Name**.
 1. Configure the rules. In Rancher's UI, we expect a rule group to contain either alert rules or recording rules, but not both. For help filling out the forms, refer to the configuration options below.


### PR DESCRIPTION
### For Rancher (product) docs only
When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
