### PR TITLE
actualize url of helm3 downloader

### DIFF
--- a/content/rancher/v2.0-v2.4/en/installation/other-installation-methods/behind-proxy/launch-kubernetes/_index.md
+++ b/content/rancher/v2.0-v2.4/en/installation/other-installation-methods/behind-proxy/launch-kubernetes/_index.md
@@ -80,7 +80,7 @@ sudo mv ./kubectl /usr/local/bin/kubectl
 * [helm](https://helm.sh/docs/intro/install/)
 
 ```
-curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
 chmod +x get_helm.sh
 sudo ./get_helm.sh
 ```

--- a/content/rancher/v2.5/en/installation/other-installation-methods/behind-proxy/launch-kubernetes/_index.md
+++ b/content/rancher/v2.5/en/installation/other-installation-methods/behind-proxy/launch-kubernetes/_index.md
@@ -82,7 +82,7 @@ sudo mv ./kubectl /usr/local/bin/kubectl
 * [helm](https://helm.sh/docs/intro/install/)
 
 ```
-curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
 chmod +x get_helm.sh
 sudo ./get_helm.sh
 ```

--- a/content/rancher/v2.6/en/installation/other-installation-methods/behind-proxy/launch-kubernetes/_index.md
+++ b/content/rancher/v2.6/en/installation/other-installation-methods/behind-proxy/launch-kubernetes/_index.md
@@ -98,7 +98,7 @@ sudo mv ./kubectl /usr/local/bin/kubectl
 * [helm](https://helm.sh/docs/intro/install/)
 
 ```
-curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
 chmod +x get_helm.sh
 sudo ./get_helm.sh
 ```


### PR DESCRIPTION
new url from https://helm.sh/docs/intro/install/#from-script

### K3s update

The K3s documentation is moving. Please file any issues or pull requests at https://github.com/k3s-io/docs instead.

### For Rancher (product) docs only

When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
