### PR TITLE
Adding instructions to use v1.0.1 image

### DIFF
--- a/content/rancher/v2.6/en/installation/cloud-marketplace/aws/adapter-install/_index.md
+++ b/content/rancher/v2.6/en/installation/cloud-marketplace/aws/adapter-install/_index.md
@@ -59,22 +59,26 @@ For the below instructions, replace `$MY_ACC_NUM` with your AWS account number a
 
 > **Note:** If you use shell variables, do not specify quotation marks. For example, MY_ACC_NUM=123456789012 will work, but MY_ACC_NUM="123456789012" will fail.
 
-> **Note:** Accounts using the AWS Marketplace listing for Europe, the Middle East, and Africa (EMEA) will need to specify an additional `--set image.repository=rancher/rancher-csp-adapter-eu` option. To see if your account needs this option when installing the adapter, refer to the usage instructions of the marketplace listing.
+> **Note:** Accounts using the AWS Marketplace listing for the EU and the UK will need to specify an additional `--set image.repository=rancher/rancher-csp-adapter-eu` option. To see if your account needs this option when installing the adapter, refer to the usage instructions of the marketplace listing.
+
+> **Note:** It is important that you follow the instructions below exactly. In particular, the command to install version 1.0.1 of the adapter (by using --set image.tag=v1.0.1) is key to ensure that node counts are accurate. 
 
 {{% tabs %}}
 {{% tab "Let's Encrypt/ Public Certificate Authority" %}}
 
 ```bash
-helm install rancher-csp-adapter rancher-charts/rancher-csp-adapter --namespace cattle-csp-adapter-system --set aws.enabled=true --set aws.roleName=$MY_ROLE_NAME --set-string aws.accountNumber=$MY_ACC_NUM
+helm install rancher-csp-adapter rancher-charts/rancher-csp-adapter --namespace cattle-csp-adapter-system --set aws.enabled=true --set aws.roleName=$MY_ROLE_NAME --set-string aws.accountNumber=$MY_ACC_NUM --set image.tag=v1.0.1
 ```
 
 
 Alternatively, you can use a `values.yaml` and specify options like below:
 
 ```yaml
+image:
+  tag: v1.0.1
 aws:
   enabled: true
-  accountNum: "$MY_ACC_NUM"
+  accountNumber: "$MY_ACC_NUM"
   roleName: $MY_ROLE_NAME
 ```
 
@@ -90,15 +94,17 @@ helm install rancher-csp-adapter rancher-charts/rancher-csp-adapter -f values.ya
 {{% tab "Private CA Authority / Rancher-generated Certificates" %}}
 
 ```bash
-helm install rancher-csp-adapter rancher-charts/rancher-csp-adapter --namespace cattle-csp-adapter-system --set aws.enabled=true --set aws.roleName=$MY_ROLE_NAME --set-string aws.accountNumber=$MY_ACC_NUM --set additionalTrustedCAs=true
+helm install rancher-csp-adapter rancher-charts/rancher-csp-adapter --namespace cattle-csp-adapter-system --set aws.enabled=true --set aws.roleName=$MY_ROLE_NAME --set-string aws.accountNumber=$MY_ACC_NUM --set additionalTrustedCAs=true --set image.tag=v1.0.1
 ```
 
 Alternatively, you can use a `values.yaml` and specify options the below:
 
 ```yaml
+image:
+  tag: v1.0.1
 aws:
   enabled: true
-  accountNum: "$MY_ACC_NUM"
+  accountNumber: "$MY_ACC_NUM"
   roleName: $MY_ROLE_NAME
 additionalTrustedCAs: true
 ```

--- a/content/rancher/v2.6/en/installation/cloud-marketplace/aws/common-issues/_index.md
+++ b/content/rancher/v2.6/en/installation/cloud-marketplace/aws/common-issues/_index.md
@@ -22,7 +22,7 @@ This message indicates that you do not have enough entitlements for the amount o
 Keep in mind the following limitations:
 
 - Each entitlement is valid for a certain number of nodes.
-- Every node currently managed by Rancher counts toward your usage total, even nodes in the cluster Rancher is installed on.
+- Every node currently managed by Rancher counts toward your usage total (with exception of nodes in the cluster rancher is installed on).
 - Each entitlement can be used by at most one Rancher instance. For example, if you have two running Rancher instances in your account (each installed on a separate EKS cluster), then you will need at least two entitlements.
 
 You may also have recently uninstalled/re-installed the adapter. If the adapter loses track of the licenses that it is currently managing, it can take up to an hour to resolve the actual state of the licenses.


### PR DESCRIPTION
Related to rancher/rancher#38712. The published, first version of the adapter contains a bug that would cause issues if used. Because of this, customers will need to specify a newer version when installing the adapter. This pr updates the install instructions to make use of this new version.
