### PR TITLE
Add notation for `kubectl logs` command

### DIFF
--- a/content/rancher/v2.6/en/troubleshooting/kubernetes-resources/_index.md
+++ b/content/rancher/v2.6/en/troubleshooting/kubernetes-resources/_index.md
@@ -126,8 +126,13 @@ kubectl -n ingress-nginx describe pods -l app=ingress-nginx
 
 ### Pod container logs
 
+This command can show logs of all the pods labeled "app=ingress-nginx", but it shows only 10 lines of log because of restriction of `kubectl logs` command. Refer `--tail` of `kubectl logs -h`.
 ```
 kubectl -n ingress-nginx logs -l app=ingress-nginx
+```
+If full log is needed specify pod name like trailing command.
+```
+kubectl -n ingress-nginx logs <pod name>
 ```
 
 ### Namespace events

--- a/content/rancher/v2.6/en/troubleshooting/kubernetes-resources/_index.md
+++ b/content/rancher/v2.6/en/troubleshooting/kubernetes-resources/_index.md
@@ -126,11 +126,14 @@ kubectl -n ingress-nginx describe pods -l app=ingress-nginx
 
 ### Pod container logs
 
-This command can show logs of all the pods labeled "app=ingress-nginx", but it shows only 10 lines of log because of restriction of `kubectl logs` command. Refer `--tail` of `kubectl logs -h`.
+The below command can show the logs of all the pods labeled "app=ingress-nginx", but it will display only 10 lines of log because of the restrictions of `kubectl logs` command. Refer to `--tail` of `kubectl logs -h` for more information.
+
 ```
 kubectl -n ingress-nginx logs -l app=ingress-nginx
 ```
-If full log is needed specify pod name like trailing command.
+
+If the full log is needed, specify the pod name in the trailing command:
+
 ```
 kubectl -n ingress-nginx logs <pod name>
 ```

--- a/content/rancher/v2.6/en/troubleshooting/kubernetes-resources/_index.md
+++ b/content/rancher/v2.6/en/troubleshooting/kubernetes-resources/_index.md
@@ -126,7 +126,7 @@ kubectl -n ingress-nginx describe pods -l app=ingress-nginx
 
 ### Pod container logs
 
-The below command can show the logs of all the pods labeled "app=ingress-nginx", but it will display only 10 lines of log because of the restrictions of `kubectl logs` command. Refer to `--tail` of `kubectl logs -h` for more information.
+The below command can show the logs of all the pods labeled "app=ingress-nginx", but it will display only 10 lines of log because of the restrictions of the `kubectl logs` command. Refer to `--tail` of `kubectl logs -h` for more information.
 
 ```
 kubectl -n ingress-nginx logs -l app=ingress-nginx


### PR DESCRIPTION
### For Rancher (product) docs only

Add notation for `kubectl logs` command to warn users that the logs will be truncated.

Signed-off-by: Masashi Honma <masashi.honma@gmail.com>
