### PR TITLE
Specifying that the options are set in the cluster yaml

### DIFF
--- a/content/rke/latest/en/etcd-snapshots/recurring-snapshots/_index.md
+++ b/content/rke/latest/en/etcd-snapshots/recurring-snapshots/_index.md
@@ -10,7 +10,7 @@ Recurring snapshots are handled differently based on your version of RKE.
 
 To schedule automatic recurring etcd snapshots, you can enable the `etcd-snapshot` service with [extra configuration options](#options-for-the-etcd-snapshot-service). `etcd-snapshot` runs in a service container alongside the `etcd` container. By default, the `etcd-snapshot` service takes a snapshot for every node that has the `etcd` role and stores them to local disk in `/opt/rke/etcd-snapshots`.
 
-If you set up the [options for S3](#options-for-the-etcd-snapshot-service), the snapshot will also be uploaded to the S3 backend.
+If you set up the [options for S3](#options-for-the-etcd-snapshot-service) in your RKE cluster yaml, the snapshot will also be uploaded to the S3 backend.
 
 ### Snapshot Service Logging
 

--- a/content/rke/latest/en/etcd-snapshots/recurring-snapshots/_index.md
+++ b/content/rke/latest/en/etcd-snapshots/recurring-snapshots/_index.md
@@ -8,7 +8,7 @@ Recurring snapshots are handled differently based on your version of RKE.
 {{% tabs %}}
 {{% tab "RKE v0.2.0+"%}}
 
-To schedule automatic recurring etcd snapshots, you can enable the `etcd-snapshot` service with [extra configuration options](#options-for-the-etcd-snapshot-service). `etcd-snapshot` runs in a service container alongside the `etcd` container. By default, the `etcd-snapshot` service takes a snapshot for every node that has the `etcd` role and stores them to local disk in `/opt/rke/etcd-snapshots`.
+To schedule automatic recurring etcd snapshots, you can enable the `etcd-snapshot` service with [extra configuration options](#options-for-the-etcd-snapshot-service) in your cluster yaml. `etcd-snapshot` runs in a service container alongside the `etcd` container. By default, the `etcd-snapshot` service takes a snapshot for every node that has the `etcd` role and stores them to local disk in `/opt/rke/etcd-snapshots`.
 
 If you set up the [options for S3](#options-for-the-etcd-snapshot-service) in your RKE cluster yaml, the snapshot will also be uploaded to the S3 backend.
 
@@ -120,7 +120,7 @@ time="2018-05-04T18:43:16Z" level=info msg="Created backup" name="2018-05-04T18:
 
 |Option|Description|
 |---|---|
-|**Snapshot**|By default, the recurring snapshot service is disabled. To enable the service, you need to define it as part of `etcd` and set it to `true`.|
+|**Snapshot**|By default, the recurring snapshot service is disabled. To enable the service, you need to define it as part of `etcd` in your cluster yaml manifest and set it to `true`.|
 |**Creation**|By default, the snapshot service will take snapshots every 5 minutes (`5m0s`). You can change the time between snapshots as part of the `creation` directive for the `etcd` service.|
 |**Retention**|By default, all snapshots are saved for 24 hours (`24h`) before being deleted and purged. You can change how long to store a snapshot as part of the `retention` directive for the `etcd` service.|
 


### PR DESCRIPTION
No where in the doc does it specify WHERE the configurations are set.  It's not even in the cluster yaml examples or the cluster yaml options...

### K3s update

The K3s documentation is moving. Please file any issues or pull requests at https://github.com/k3s-io/docs instead.

### For Rancher (product) docs only

When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
