### PR TITLE
Added backup_config

### DIFF
--- a/content/rke/latest/en/example-yamls/_index.md
+++ b/content/rke/latest/en/example-yamls/_index.md
@@ -148,6 +148,21 @@ system_images:
 
 services:
     etcd:
+      backup_config:
+        interval_hours: 12
+        retention: 6
+        s3backupconfig:
+          access_key: S3_ACCESS_KEY
+          secret_key: S3_SECRET_KEY
+          bucket_name: s3-bucket-name
+          region: ""
+          folder: "" # Optional - Available as of v0.3.0
+          endpoint: s3.amazonaws.com
+          custom_ca: |-
+            -----BEGIN CERTIFICATE-----
+            $CERTIFICATE
+            -----END CERTIFICATE-----
+          
       # Custom uid/guid for etcd directory and files
       uid: 52034
       gid: 52034


### PR DESCRIPTION
For some reason, this example config does not include the backup configurations.  Added them

### K3s update

The K3s documentation is moving. Please file any issues or pull requests at https://github.com/k3s-io/docs instead.

### For Rancher (product) docs only

When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
