### PR TITLE
Add messaging for move to new RM repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/request-a-k3s-change.md
+++ b/.github/ISSUE_TEMPLATE/request-a-k3s-change.md
@@ -7,4 +7,6 @@ assignees: ''
 
 ---
 
-The K3s documentation is moving. Please file any issues or pull requests at https://github.com/k3s-io/docs instead.
+The K3s* documentation is moving. Please file any issues or pull requests at https://github.com/k3s-io/docs instead.
+
+* = content/k3s

--- a/.github/ISSUE_TEMPLATE/request-a-rancher-2-change.md
+++ b/.github/ISSUE_TEMPLATE/request-a-rancher-2-change.md
@@ -7,8 +7,7 @@ assignees: ''
 
 ---
 
-**Request Summary:**
-<!-- Briefly describe what you would like to change in Rancher 2.x documentation below this line. This can include any type of change such as deleting something from a section, a whole page, or adding a new section or page, or any updates/additions. -->
+The Rancher Manager* documentation is moving. Please file any issues or pull requests at https://github.com/rancher/rancher-docs instead.
 
-**Details:**
-<!-- If you have specific content you want changed, please indicate this below this line. -->
+* = content/rancher
+

--- a/README.md
+++ b/README.md
@@ -3,9 +3,17 @@ Rancher Docs
 
 ## Contributing
 
+### Rancher Manager update
+
+The Rancher Manager* documentation is moving. Please file any issues or pull requests at https://github.com/rancher/rancher-docs instead.
+
+* = content/rancher
+
 ### K3s update
 
-The K3s documentation is moving. Please file any issues or pull requests at https://github.com/k3s-io/docs instead.
+The K3s* documentation is moving. Please file any issues or pull requests at https://github.com/k3s-io/docs instead.
+
+* = content/k3s
 
 ### Rancher documentation
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,9 +1,12 @@
+### Rancher Manager update
+
+The Rancher Manager* documentation is moving. Please file any issues or pull requests at https://github.com/rancher/rancher-docs instead.
+
+* = content/rancher
+
 ### K3s update
 
-The K3s documentation is moving. Please file any issues or pull requests at https://github.com/k3s-io/docs instead.
+The K3s* documentation is moving. Please file any issues or pull requests at https://github.com/k3s-io/docs instead.
 
-### For Rancher (product) docs only
+* = content/k3s
 
-When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.
-
-Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.


### PR DESCRIPTION
### K3s update

The K3s documentation is moving. Please file any issues or pull requests at https://github.com/k3s-io/docs instead.

### For Rancher (product) docs only

When contributing to docs, please update the versioned docs. For example, the docs in the v2.6 folder of the `rancher` folder.

Doc versions older than the latest minor version should only be updated to fix inaccuracies or make minor updates as necessary. The majority of new content should be added to the folder for the latest minor version.
