### PR TITLE
Fix issue with relative paths on rancher.com

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,5 +1,6 @@
 map_hash_bucket_size 256;
 map $request_uri $redirect_uri {
+  ~^/docs$ /docs/;
   ~^/docs/rancher/v2.0/(.*)$   /docs/rancher/v2.x/$1;
   ~^/docs/rke/v0.1.x(/?.*)$   /docs/rke/latest$1;
   ~^/docs/os/quick-start-guide/?$ /rancher-os;


### PR DESCRIPTION
When you visit rancher.com/docs the base location for relative paths is rancher.com/. When the visited page is rancher.com/docs/ (notice the trailing /) the root location for relative paths is rancher.com/docs/. This difference causes a problem with relative paths

This PR redirects rancher.com/docs to rancher.com/docs/ so that the trailing / is always present. This should enable all relative paths to work in production and the local development environment
