### PR TITLE
Set logo width

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -444,5 +444,6 @@ ctaBanner: true
     .limited-height {
       margin-top: 10px;
       max-height: 65px;
+      width: 100%;
     }
   </style>


### PR DESCRIPTION
Fixes https://github.com/rancher/docs/issues/4329

Neuvector and Kubewarden are PNGs while the other logos are SVGs so these two are behaving differently. This explicitly defines the width.

![landing-page-neuvector](https://user-images.githubusercontent.com/1832069/193368847-ed8f51ac-3972-4f37-9ab5-a7b9b955ea9e.png)

![landing-page-kubewarden](https://user-images.githubusercontent.com/1832069/193368852-71341865-0db1-432b-a15c-49cd2d0f1a04.png)
