### PR TITLE
Remove K3s from docs repo

### DIFF
--- a/content/k3s/_index.md
+++ b/content/k3s/_index.md
@@ -1,5 +1,0 @@
----
-title: K3S
-weight: 1
-showBreadcrumb: false
----

--- a/content/k3s/latest/_index.md
+++ b/content/k3s/latest/_index.md
@@ -1,4 +1,0 @@
----
-title: K3S
-showBreadcrumb: false
----

--- a/content/k3s/latest/en/_index.md
+++ b/content/k3s/latest/en/_index.md
@@ -1,7 +1,0 @@
----
-title: "K3s - Lightweight Kubernetes"
-shortTitle: K3s
-name: "menu"
----
-
-K3s documentation has moved to [docs.k3s.io](https://docs.k3s.io).

--- a/content/k3s/latest/en/advanced/_index.md
+++ b/content/k3s/latest/en/advanced/_index.md
@@ -1,9 +1,0 @@
----
-title: "Advanced Options and Configuration"
-weight: 45
-aliases:
-  - /k3s/latest/en/running/
-  - /k3s/latest/en/configuration/
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/advanced).

--- a/content/k3s/latest/en/architecture/_index.md
+++ b/content/k3s/latest/en/architecture/_index.md
@@ -1,6 +1,0 @@
----
-title: Architecture
-weight: 1
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/architecture).

--- a/content/k3s/latest/en/backup-restore/_index.md
+++ b/content/k3s/latest/en/backup-restore/_index.md
@@ -1,6 +1,0 @@
----
-title: Backup and Restore
-weight: 26
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/backup-restore).

--- a/content/k3s/latest/en/cluster-access/_index.md
+++ b/content/k3s/latest/en/cluster-access/_index.md
@@ -1,6 +1,0 @@
----
-title: Cluster Access
-weight: 21
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/cluster-access).

--- a/content/k3s/latest/en/faq/_index.md
+++ b/content/k3s/latest/en/faq/_index.md
@@ -1,6 +1,0 @@
----
-title: FAQ
-weight: 60
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/faq).

--- a/content/k3s/latest/en/helm/_index.md
+++ b/content/k3s/latest/en/helm/_index.md
@@ -1,6 +1,0 @@
----
-title: Helm
-weight: 42
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/helm).

--- a/content/k3s/latest/en/installation/_index.md
+++ b/content/k3s/latest/en/installation/_index.md
@@ -1,6 +1,0 @@
----
-title: "Installation"
-weight: 20
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/installation).

--- a/content/k3s/latest/en/installation/airgap/_index.md
+++ b/content/k3s/latest/en/installation/airgap/_index.md
@@ -1,6 +1,0 @@
----
-title: "Air-Gap Install"
-weight: 60
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/installation/airgap).

--- a/content/k3s/latest/en/installation/datastore/_index.md
+++ b/content/k3s/latest/en/installation/datastore/_index.md
@@ -1,6 +1,0 @@
----
-title: "Cluster Datastore Options"
-weight: 50
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/installation/datastore).

--- a/content/k3s/latest/en/installation/disable-flags/_index.md
+++ b/content/k3s/latest/en/installation/disable-flags/_index.md
@@ -1,6 +1,0 @@
----
-title: "Disable Components Flags"
-weight: 60
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/installation/disable-flags).

--- a/content/k3s/latest/en/installation/ha-embedded/_index.md
+++ b/content/k3s/latest/en/installation/ha-embedded/_index.md
@@ -1,6 +1,0 @@
----
-title: "High Availability with Embedded DB"
-weight: 40
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/installation/ha-embedded).

--- a/content/k3s/latest/en/installation/ha/_index.md
+++ b/content/k3s/latest/en/installation/ha/_index.md
@@ -1,6 +1,0 @@
----
-title: High Availability with an External DB
-weight: 30
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/installation/ha).

--- a/content/k3s/latest/en/installation/install-options/_index.md
+++ b/content/k3s/latest/en/installation/install-options/_index.md
@@ -1,6 +1,0 @@
----
-title: "Installation Options"
-weight: 20
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/installation/configuration).

--- a/content/k3s/latest/en/installation/install-options/agent-config/_index.md
+++ b/content/k3s/latest/en/installation/install-options/agent-config/_index.md
@@ -1,6 +1,0 @@
----
-title: K3s Agent Configuration Reference
-weight: 2
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/reference/agent-config).

--- a/content/k3s/latest/en/installation/install-options/how-to-flags/_index.md
+++ b/content/k3s/latest/en/installation/install-options/how-to-flags/_index.md
@@ -1,6 +1,0 @@
----
-title: How to Use Flags and Environment Variables
-weight: 3
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/installation/configuration).

--- a/content/k3s/latest/en/installation/install-options/server-config/_index.md
+++ b/content/k3s/latest/en/installation/install-options/server-config/_index.md
@@ -1,6 +1,0 @@
----
-title: K3s Server Configuration Reference
-weight: 1
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/reference/server-config).

--- a/content/k3s/latest/en/installation/installation-requirements/_index.md
+++ b/content/k3s/latest/en/installation/installation-requirements/_index.md
@@ -1,8 +1,0 @@
----
-title: Installation Requirements
-weight: 1
-aliases:
-  - /k3s/latest/en/installation/node-requirements/
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/installation/requirements).

--- a/content/k3s/latest/en/installation/installation-requirements/resource-profiling/_index.md
+++ b/content/k3s/latest/en/installation/installation-requirements/resource-profiling/_index.md
@@ -1,7 +1,0 @@
----
-title: K3s Resource Profiling
-shortTitle: Resource Profiling
-weight: 1
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/reference/resource-profiling).

--- a/content/k3s/latest/en/installation/kube-dashboard/_index.md
+++ b/content/k3s/latest/en/installation/kube-dashboard/_index.md
@@ -1,6 +1,0 @@
----
-title: "Kubernetes Dashboard"
-weight: 60
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/installation/kube-dashboard).

--- a/content/k3s/latest/en/installation/network-options/_index.md
+++ b/content/k3s/latest/en/installation/network-options/_index.md
@@ -1,6 +1,0 @@
----
-title: "Network Options"
-weight: 25
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/installation/network-options).

--- a/content/k3s/latest/en/installation/private-registry/_index.md
+++ b/content/k3s/latest/en/installation/private-registry/_index.md
@@ -1,6 +1,0 @@
----
-title: "Private Registry Configuration"
-weight: 55
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/installation/private-registry).

--- a/content/k3s/latest/en/installation/uninstall/_index.md
+++ b/content/k3s/latest/en/installation/uninstall/_index.md
@@ -1,6 +1,0 @@
----
-title: Uninstalling K3s
-weight: 61
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/installation/uninstall).

--- a/content/k3s/latest/en/known-issues/_index.md
+++ b/content/k3s/latest/en/known-issues/_index.md
@@ -1,6 +1,0 @@
----
-title: Known Issues
-weight: 70
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/known-issues).

--- a/content/k3s/latest/en/networking/_index.md
+++ b/content/k3s/latest/en/networking/_index.md
@@ -1,6 +1,0 @@
----
-title: "Networking"
-weight: 35
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/networking).

--- a/content/k3s/latest/en/quick-start/_index.md
+++ b/content/k3s/latest/en/quick-start/_index.md
@@ -1,6 +1,0 @@
----
-title: "Quick-Start Guide"
-weight: 10
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/quick-start).

--- a/content/k3s/latest/en/security/_index.md
+++ b/content/k3s/latest/en/security/_index.md
@@ -1,6 +1,0 @@
----
-title: "Security"
-weight: 90
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/security).

--- a/content/k3s/latest/en/security/hardening_guide/_index.md
+++ b/content/k3s/latest/en/security/hardening_guide/_index.md
@@ -1,6 +1,0 @@
----
-title: "CIS Hardening Guide"
-weight: 80
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/security/hardening-guide).

--- a/content/k3s/latest/en/security/secrets_encryption/_index.md
+++ b/content/k3s/latest/en/security/secrets_encryption/_index.md
@@ -1,6 +1,0 @@
----
-title: Secrets Encryption
-weight: 26
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/security/secrets-encryption).

--- a/content/k3s/latest/en/security/self_assessment/_index.md
+++ b/content/k3s/latest/en/security/self_assessment/_index.md
@@ -1,6 +1,0 @@
----
-title: CIS Self Assessment Guide
-weight: 90
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/security/self-assessment).

--- a/content/k3s/latest/en/storage/_index.md
+++ b/content/k3s/latest/en/storage/_index.md
@@ -1,6 +1,0 @@
----
-title: "Volumes and Storage"
-weight: 30
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/storage).

--- a/content/k3s/latest/en/upgrades/_index.md
+++ b/content/k3s/latest/en/upgrades/_index.md
@@ -1,6 +1,0 @@
----
-title: "Upgrades"
-weight: 25
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/upgrades).

--- a/content/k3s/latest/en/upgrades/automated/_index.md
+++ b/content/k3s/latest/en/upgrades/automated/_index.md
@@ -1,6 +1,0 @@
----
-title: "Automated Upgrades"
-weight: 20
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/upgrades/automated).

--- a/content/k3s/latest/en/upgrades/basic/_index.md
+++ b/content/k3s/latest/en/upgrades/basic/_index.md
@@ -1,6 +1,0 @@
----
-title: "Upgrade Basics"
-weight: 10
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/upgrades/manual).

--- a/content/k3s/latest/en/upgrades/killall/_index.md
+++ b/content/k3s/latest/en/upgrades/killall/_index.md
@@ -1,6 +1,0 @@
----
-title: The k3s-killall.sh script
-weight: 4
----
-
-This page has moved to [docs.k3s.io](https://docs.k3s.io/upgrades/killall).


### PR DESCRIPTION
Signed-off-by: Derek Nola <derek.nola@suse.com>

### K3s update
Now that K3s docs have been moved, and the redirects are in place, this PR removes the old K3s docs content from this repo.

