### PR TITLE
Update Azure AD Graph API retirement date

### DIFF
--- a/content/rancher/v2.6/en/admin-settings/authentication/azure-ad/_index.md
+++ b/content/rancher/v2.6/en/admin-settings/authentication/azure-ad/_index.md
@@ -215,7 +215,7 @@ Enter the values that you copied to your [text file](#tip).
 
 ### Migrating from Azure AD Graph API to Microsoft Graph API
 
-Since [Azure AD Graph API](https://docs.microsoft.com/en-us/graph/migrate-azure-ad-graph-overview) was deprecated in June 2022 and will be retired at the end of 2022, users should update their Azure AD App to use the new [Microsoft Graph API](https://docs.microsoft.com/en-us/graph/use-the-api) in Rancher.
+Since [Azure AD Graph API](https://docs.microsoft.com/en-us/graph/migrate-azure-ad-graph-overview) was deprecated in June 2022 and will be retired on June 30, 2023, users should update their Azure AD App to use the new [Microsoft Graph API](https://docs.microsoft.com/en-us/graph/use-the-api) in Rancher.
 
 #### Updating Endpoints in the Rancher UI
 


### PR DESCRIPTION
MS extended the retirement of the Azure AD Graph API from the end of 2022 to June 30, 2023.

https://learn.microsoft.com/en-us/answers/questions/768833/when-is-adal-and-azure-ad-graph-reaching-end-of-li.html
https://learn.microsoft.com/en-us/graph/migrate-azure-ad-graph-overview


