### PR TITLE
Fix links with double slashes in path

### DIFF
--- a/content/os/v1.x/en/about/_index.md
+++ b/content/os/v1.x/en/about/_index.md
@@ -59,7 +59,7 @@ All of repositories are located within our main GitHub [page](https://github.com
 
 [RancherOS Repo](https://github.com/rancher/os): This repo contains the bulk of the RancherOS code.
 
-[RancherOS Services Repo](https://github.com/rancher/os-services): This repo is where any [system-services]({{< baseurl >}}/os/v1.x/en//system-services/) can be contributed.
+[RancherOS Services Repo](https://github.com/rancher/os-services): This repo is where any [system-services]({{< baseurl >}}/os/v1.x/en/system-services/) can be contributed.
 
 [RancherOS Images Repo](https://github.com/rancher/os-images): This repo is for the corresponding service images.
 

--- a/content/os/v1.x/en/configuration/switching-consoles/_index.md
+++ b/content/os/v1.x/en/configuration/switching-consoles/_index.md
@@ -5,7 +5,7 @@ aliases:
   - /os/v1.x/en/installation/configuration/switching-consoles
 ---
 
-When [booting from the ISO]({{< baseurl >}}/os/v1.x/en/installation/workstation//boot-from-iso/), RancherOS starts with the default console, which is based on busybox.
+When [booting from the ISO]({{< baseurl >}}/os/v1.x/en/installation/workstation/boot-from-iso/), RancherOS starts with the default console, which is based on busybox.
 
 You can select which console you want RancherOS to start with using the [cloud-config]({{< baseurl >}}/os/v1.x/en/configuration/#cloud-config).
 

--- a/content/os/v1.x/en/installation/custom-builds/custom-console/_index.md
+++ b/content/os/v1.x/en/installation/custom-builds/custom-console/_index.md
@@ -3,7 +3,7 @@ title: Custom Console
 weight: 180
 ---
 
-When [booting from the ISO]({{< baseurl >}}/os/v1.x/en/installation/workstation//boot-from-iso/), RancherOS starts with the default console, which is based on busybox.
+When [booting from the ISO]({{< baseurl >}}/os/v1.x/en/installation/workstation/boot-from-iso/), RancherOS starts with the default console, which is based on busybox.
 
 You can select which console you want RancherOS to start with using the [cloud-config]({{< baseurl >}}/os/v1.x/en/configuration/#cloud-config).
 

--- a/content/os/v1.x/en/installation/custom-builds/custom-rancheros-iso/_index.md
+++ b/content/os/v1.x/en/installation/custom-builds/custom-rancheros-iso/_index.md
@@ -11,8 +11,8 @@ Create a clone of the main [RancherOS repository](https://github.com/rancher/os)
 $ git clone https://github.com/rancher/os.git
 ```
 
-In the root of the repository, the "General Configuration" section of `Dockerfile.dapper` can be updated to use [custom kernels]({{<baseurl>}}/os/v1.x/en/installation/custom-builds/custom-kernels). 
-After you've saved your edits, run `make` in the root directory. After the build has completed, a `./dist/artifacts` directory will be created with the custom built RancherOS release files. 
+In the root of the repository, the "General Configuration" section of `Dockerfile.dapper` can be updated to use [custom kernels]({{<baseurl>}}/os/v1.x/en/installation/custom-builds/custom-kernels).
+After you've saved your edits, run `make` in the root directory. After the build has completed, a `./dist/artifacts` directory will be created with the custom built RancherOS release files.
 Build Requirements: `bash`, `make`, `docker` (Docker version >= 1.10.3)
 
 ```
@@ -29,7 +29,7 @@ If you need a compressed ISO, you can run this command:
 $ make release
 ```
 
-The `rancheros.iso` is ready to be used to [boot RancherOS from ISO]({{< baseurl >}}/os/v1.x/en/installation/workstation//boot-from-iso/) or [launch RancherOS using Docker Machine]({{< baseurl >}}/os/v1.x/en/installation/workstation//docker-machine).
+The `rancheros.iso` is ready to be used to [boot RancherOS from ISO]({{< baseurl >}}/os/v1.x/en/installation/workstation/boot-from-iso/) or [launch RancherOS using Docker Machine]({{< baseurl >}}/os/v1.x/en/installation/workstation//docker-machine).
 
 ## Creating a GCE Image Archive
 
@@ -39,7 +39,7 @@ Create a clone of the main [RancherOS repository](https://github.com/rancher/os)
 $ git clone https://github.com/rancher/os-packer.git
 ```
 
-GCE supports KVM virtualization, and we use `packer` to build KVM images. Before building, you need to verify that the host can support KVM. 
+GCE supports KVM virtualization, and we use `packer` to build KVM images. Before building, you need to verify that the host can support KVM.
 If you want to build GCE image based on RancherOS v1.4.0, you can run this command:
 
 ```
@@ -52,7 +52,7 @@ RANCHEROS_VERSION=v1.4.0 make build-gce
 
 With changes to the kernel and built Docker, RancherOS booting requires more memory. For details, please refer to the [memory requirements]({{<baseurl>}}/os/v1.x/en/#hardware-requirements).
 
-By customizing the ISO, you can reduce the memory usage on boot. The easiest way is to downgrade the built-in Docker version, because Docker takes up a lot of space. 
+By customizing the ISO, you can reduce the memory usage on boot. The easiest way is to downgrade the built-in Docker version, because Docker takes up a lot of space.
 This can effectively reduce the memory required to decompress the `initrd` on boot. Using docker 17.03 is a good choice:
 
 ```
@@ -64,9 +64,9 @@ $ USER_DOCKER_VERSION=17.03.2 make release
 
 _Available as of v1.5.0_
 
-When building RancherOS, you have the ability to automatically start in a supported console instead of booting into the default console and switching to your desired one. 
+When building RancherOS, you have the ability to automatically start in a supported console instead of booting into the default console and switching to your desired one.
 
-Here is an example of building RancherOS and having the `alpine` console enabled: 
+Here is an example of building RancherOS and having the `alpine` console enabled:
 
 ```
 $ OS_CONSOLE=alpine make release

--- a/content/os/v1.x/en/quick-start-guide/_index.md
+++ b/content/os/v1.x/en/quick-start-guide/_index.md
@@ -3,7 +3,7 @@ title: Quick Start
 weight: 1
 ---
 
-If you have a specific RanchersOS machine requirements, please check out our [guides on running RancherOS]({{< baseurl >}}/os/v1.x/en/installation/). With the rest of this guide, we'll start up a RancherOS using [Docker machine]({{< baseurl >}}/os/v1.x/en/installation/workstation//docker-machine/) and show you some of what RancherOS can do.
+If you have a specific RanchersOS machine requirements, please check out our [guides on running RancherOS]({{< baseurl >}}/os/v1.x/en/installation/). With the rest of this guide, we'll start up a RancherOS using [Docker machine]({{< baseurl >}}/os/v1.x/en/installation/workstation/docker-machine/) and show you some of what RancherOS can do.
 
 ### Launching RancherOS using Docker Machine
 

--- a/content/os/v1.x/en/upgrading/_index.md
+++ b/content/os/v1.x/en/upgrading/_index.md
@@ -9,7 +9,7 @@ Since RancherOS is a kernel and initrd, the upgrade process is downloading a new
 
 Before upgrading to any version, please review the release notes on our [releases page](https://github.com/rancher/os/releases) in GitHub to review any updates in the release.
 
-> **Note:** If you are using [`docker-machine`]({{< baseurl >}}/os/v1.x/en/installation/workstation//docker-machine/) then you will not be able to upgrade your RancherOS version. You need to delete and re-create the machine.
+> **Note:** If you are using [`docker-machine`]({{< baseurl >}}/os/v1.x/en/installation/workstation/docker-machine/) then you will not be able to upgrade your RancherOS version. You need to delete and re-create the machine.
 
 
 ### Version Control
@@ -140,7 +140,7 @@ rancher:
 
 If you are upgrading to v1.4.0+, please review these notes that could alter your RancherOS settings.
 
-Due to changes in the location of user-docker's data-root, after upgrading to v1.4.0+, you must move or copy the files of user-docker's data-root. If you do not do this, your data will *NOT* be available. 
+Due to changes in the location of user-docker's data-root, after upgrading to v1.4.0+, you must move or copy the files of user-docker's data-root. If you do not do this, your data will *NOT* be available.
 
 ```
 #!/bin/bash
@@ -153,7 +153,7 @@ cp -a $old_docker_root/* $new_docker_root
 system-docker start docker
 ```
 
-If you had another bridge IP set for system-docker, you may need to explicitly set it again depending on your upgrade path. Before re-setting it, you can confirm if it's set. 
+If you had another bridge IP set for system-docker, you may need to explicitly set it again depending on your upgrade path. Before re-setting it, you can confirm if it's set.
 
 ```
 # Check to see if docker bridge IP is set


### PR DESCRIPTION
ContentKing (SEO tool) crawls links on pages and when these links with double slashes are found they are considered a separate page. As the (correct) page with single slash in its path already exists, this page will cause issues with various metrics (e.g. duplicate title).