### PR TITLE
Add image property to Twitter card

### DIFF
--- a/layouts/partials/seo.html
+++ b/layouts/partials/seo.html
@@ -69,6 +69,7 @@
   <meta name="twitter:title" content="{{ .Title }}" />
   <meta name="twitter:site" content="{{ .Site.Params.twitter }}" />
   <meta name="twitter:creator" content="{{ .Site.Params.twitter }}" />
+  <meta name="twitter:image" content="https://raw.githubusercontent.com/rancher/docs/master/static/docs/rancher-logo.svg" />
 
   <!-- OG data -->
   <meta property="og:locale" content="en_US" />


### PR DESCRIPTION
Per feedback from the web team, the site's SEO score needs to be improved. This lack of a image in the Twitter card is affecting the score.